### PR TITLE
feat(Serialization): Hacking on serialization

### DIFF
--- a/benchmark/csv-disk-join.sh
+++ b/benchmark/csv-disk-join.sh
@@ -1,5 +1,7 @@
 NUM_MESSAGES=${NUM_MESSAGES:-1000000}
 
+echo "starting benchmark for csv-disk-join with $NUM_MESSAGES messages"
+
 # delete kafka topic if exists
 docker exec -it kafka1 kafka-topics --bootstrap-server localhost:9092 --delete --topic topic-csv-filesystem-join || true
 

--- a/benchmark/csv-mem-join.sh
+++ b/benchmark/csv-mem-join.sh
@@ -1,5 +1,7 @@
 NUM_MESSAGES=${NUM_MESSAGES:-1000000}
 
+echo "Starting benchmark csv-mem-join with $NUM_MESSAGES messages"
+
 # delete kafka topic if exists
 docker exec -it kafka1 kafka-topics --bootstrap-server localhost:9092 --delete --topic topic-csv-mem-join || true
 

--- a/benchmark/enrichment.sh
+++ b/benchmark/enrichment.sh
@@ -1,5 +1,7 @@
 NUM_MESSAGES=${NUM_MESSAGES:-1000000}
 
+echo "starting benchmark for enrichment with $NUM_MESSAGES messages"
+
 # delete kafka topic if exists
 docker exec -it kafka1 kafka-topics --bootstrap-server localhost:9092 --delete --topic topic-enrich || true
 

--- a/benchmark/run-all.sh
+++ b/benchmark/run-all.sh
@@ -1,0 +1,6 @@
+NUM_MESSAGES=10000 ./benchmark/csv-disk-join.sh
+NUM_MESSAGES=10000 ./benchmark/csv-mem-join.sh
+NUM_MESSAGES=10000 ./benchmark/enrichment.sh
+NUM_MESSAGES=10000 ./benchmark/simple-agg-mem.sh
+NUM_MESSAGES=10000 ./benchmark/simple-agg-disk.sh
+NUM_MESSAGES=10000 ./benchmark/tumbling-window.sh

--- a/benchmark/simple-agg-disk.sh
+++ b/benchmark/simple-agg-disk.sh
@@ -1,5 +1,7 @@
 NUM_MESSAGES=${NUM_MESSAGES:-1000000}
 
+echo "starting benchmark for simple-agg-disk with $NUM_MESSAGES messages"
+
 # delete kafka topic if exists
 docker exec -it kafka1 kafka-topics --bootstrap-server localhost:9092 --delete --topic topic-simple-agg || true
 

--- a/benchmark/simple-agg-mem.sh
+++ b/benchmark/simple-agg-mem.sh
@@ -1,5 +1,7 @@
 NUM_MESSAGES=${NUM_MESSAGES:-1000000}
 
+echo "starting benchmark for simple-agg-mem with $NUM_MESSAGES messages"
+
 # delete kafka topic if exists
 docker exec -it kafka1 kafka-topics --bootstrap-server localhost:9092 --delete --topic topic-simple-agg-mem || true
 

--- a/benchmark/tumbling-window.sh
+++ b/benchmark/tumbling-window.sh
@@ -1,5 +1,7 @@
 NUM_MESSAGES=${NUM_MESSAGES:-1000000}
 
+echo "starting benchmark for tumbling-window with $NUM_MESSAGES messages"
+
 # delete kafka topic if exists
 docker exec -it kafka1 kafka-topics --bootstrap-server localhost:9092 --delete --topic tumbling-window || true
 

--- a/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
@@ -4,26 +4,35 @@ tables:
   sql:
     # Create the table to store the count of each post kind in 5 minute buckets
     # This table is available for reference within the pipeline.
-    - name: agg_post_kind_count_5_minutes
+    - name: agg_post_kind_count_1_minute
       sql: |
-        CREATE TABLE agg_post_kind_count_5_minutes (
+        CREATE TABLE agg_post_kind_count_1_minute (
           bucket TIMESTAMPTZ,
           kind VARCHAR,
           count INT 
         );
-        CREATE UNIQUE INDEX five_minute_post_kind_count_idx ON agg_post_kind_count_5_minutes (bucket, kind);
+        CREATE UNIQUE INDEX five_minute_post_kind_count_idx ON agg_post_kind_count_1_minute (bucket, kind);
 
       manager:
         # The tumbling window manager will identify records with "closed" windows i.e. windows < now - duration_seconds
         tumbling_window:
-          duration_seconds: 60
-          time_field: bucket
+          collect_closed_windows_sql: |
+            SELECT 
+              strftime(bucket, '%Y-%m-%dT%H:%M:%S') AS iso_string,
+              kind,
+              count
+            FROM agg_post_kind_count_1_minute
+            WHERE bucket AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND) 
+
+          delete_closed_windows_sql: |
+            DELETE FROM agg_post_kind_count_1_minute
+            WHERE bucket AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND)
 
         sink:
           type: kafka
           kafka:
             brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('localhost:9092') }}]
-            topic: output-bluesky-post-kind-count-5-minutes
+            topic: output-bluesky-post-kind-count-1-minute
 
 pipeline:
   batch_size: 1
@@ -35,9 +44,9 @@ pipeline:
   handler:
     type: 'handlers.InferredMemBatch'
     sql: |
-      INSERT INTO agg_post_kind_count_5_minutes
+      INSERT INTO agg_post_kind_count_1_minute
       SELECT
-        time_bucket(INTERVAL '5 minutes', to_timestamp(time_us / 1000000)) as bucket,
+        time_bucket(INTERVAL '1 minute', to_timestamp(time_us / 1000000)) as bucket,
         kind,
         count(*) as count
       FROM batch

--- a/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
@@ -16,7 +16,7 @@ tables:
       manager:
         # The tumbling window manager will identify records with "closed" windows i.e. windows < now - duration_seconds
         tumbling_window:
-          duration_seconds: 300
+          duration_seconds: 60
           time_field: bucket
 
         sink:

--- a/dev/config/examples/tumbling.window.yml
+++ b/dev/config/examples/tumbling.window.yml
@@ -18,12 +18,12 @@ tables:
               count
             FROM agg_cities_count
             WHERE timestamp AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND) 
+            ORDER BY city
 
           delete_closed_windows_sql: |
             DELETE FROM agg_cities_count 
             WHERE timestamp AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND)
           
-
         sink:
           type: kafka
           kafka:

--- a/dev/config/examples/tumbling.window.yml
+++ b/dev/config/examples/tumbling.window.yml
@@ -11,8 +11,18 @@ tables:
 
       manager:
         tumbling_window:
-          duration_seconds: 10
-          time_field: timestamp
+          collect_closed_windows_sql: |
+            SELECT 
+              strftime(date_trunc('hour', timestamp), '%Y-%m-%dT%H:%M:%S') AS bucket,
+              city,
+              count
+            FROM agg_cities_count
+            WHERE timestamp AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND) 
+
+          delete_closed_windows_sql: |
+            DELETE FROM agg_cities_count 
+            WHERE timestamp AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND)
+          
 
         sink:
           type: kafka

--- a/dev/config/examples/tumbling.window.yml
+++ b/dev/config/examples/tumbling.window.yml
@@ -3,26 +3,26 @@ tables:
     - name: agg_cities_count
       sql: |
         CREATE TABLE agg_cities_count (
-          timestamp TIMESTAMPTZ,
+          bucket TIMESTAMPTZ,
           city VARCHAR,
           count INT 
         );
-        CREATE UNIQUE INDEX daily_cities_count_idx ON agg_cities_count (timestamp, city);
+        CREATE UNIQUE INDEX daily_cities_count_idx ON agg_cities_count (bucket, city);
 
       manager:
         tumbling_window:
           collect_closed_windows_sql: |
             SELECT 
-              strftime(date_trunc('hour', timestamp), '%Y-%m-%dT%H:%M:%S') AS bucket,
+              strftime(date_trunc('hour', bucket), '%Y-%m-%dT%H:%M:%S') AS bucket,
               city,
               count
             FROM agg_cities_count
-            WHERE timestamp AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND) 
+            WHERE bucket AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND) 
             ORDER BY city
 
           delete_closed_windows_sql: |
             DELETE FROM agg_cities_count 
-            WHERE timestamp AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND)
+            WHERE bucket AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND)
           
         sink:
           type: kafka
@@ -48,13 +48,13 @@ pipeline:
       INSERT INTO agg_cities_count
       BY NAME
       SELECT 
-        timestamp::date as timestamp,
+        date_trunc('hour', CAST(timestamp as TIMESTAMP)) as bucket,
         properties.city as city,
         count(*) as count
       FROM batch
       GROUP BY 
-        timestamp, city
-      ON CONFLICT (timestamp, city) 
+        bucket, city
+      ON CONFLICT (bucket, city) 
       DO UPDATE SET count = count + EXCLUDED.count
 
   sink:

--- a/sqlflow/config.py
+++ b/sqlflow/config.py
@@ -43,8 +43,9 @@ class Sink:
 
 @dataclass
 class TumblingWindow:
-    duration_seconds: int
-    time_field: str
+    collect_closed_windows_sql: str
+    delete_closed_windows_sql: str
+    poll_interval_seconds: int = 10
 
 
 @dataclass

--- a/sqlflow/handlers.py
+++ b/sqlflow/handlers.py
@@ -106,18 +106,10 @@ class InferredMemBatch:
         if not res:
             return
 
-        df = res.df()
+        df = res.to_arrow_table()
 
-        records = json.loads(
-            df.to_json(
-                orient='records',
-                index=False,
-            )
-        )
-
-        for rec in records:
+        for rec in df.to_pylist():
             yield json.dumps(rec)
-
 
 def get_class(s: str):
     if s == 'handlers.InferredDiskBatch':

--- a/sqlflow/managers/window.py
+++ b/sqlflow/managers/window.py
@@ -45,7 +45,7 @@ class Tumbling:
 
     def collect_closed(self) -> [object]:
         # select all data with 'closed' windows.
-        df = self.conn.sql(self.collect_closed_windows_sql).to_arrow_table()
+        df = self.conn.execute(self.collect_closed_windows_sql).fetch_arrow_table()
         return df.to_pylist()
 
     def flush(self, records):

--- a/sqlflow/managers/window.py
+++ b/sqlflow/managers/window.py
@@ -52,17 +52,8 @@ class Tumbling:
             self.size_seconds,
         )
         logger.debug(stmt)
-        self.conn.begin()
-        df = self.conn.execute(stmt).df()
-
-        records = json.loads(
-            df.to_json(
-                orient='records',
-                index=False,
-            )
-        )
-        self.conn.commit()
-        return records
+        df = self.conn.sql(stmt).to_arrow_table()
+        return df.to_pylist()
 
     def flush(self, records):
         """

--- a/sqlflow/managers/window.py
+++ b/sqlflow/managers/window.py
@@ -24,12 +24,18 @@ class Tumbling:
     - Publishing records that have closed.
     - Deleteting closed records from the table.
     """
-    def __init__(self, conn, table: Table, size_seconds, sink: Sink, lock=threading.Lock()):
+    def __init__(self,
+                 conn,
+                 collect_closed_windows_sql,
+                 delete_closed_windows_sql,
+                 poll_interval_seconds,
+                 sink: Sink,
+                 lock=threading.Lock()):
         self.conn = conn
-        self.table = table
-        self.size_seconds = size_seconds
+        self.collect_closed_windows_sql = collect_closed_windows_sql
+        self.delete_closed_windows_sql = delete_closed_windows_sql
+        self.poll_interval_seconds = poll_interval_seconds
         self.sink = sink
-        self._poll_interval_seconds = 10
         self.serde = JSON()
         self._stopped = None
         self._lock = lock
@@ -39,20 +45,7 @@ class Tumbling:
 
     def collect_closed(self) -> [object]:
         # select all data with 'closed' windows.
-        # 'closed' is identified by times earlier than NOW() - size_seconds
-        stmt = '''
-        SELECT 
-            * 
-        FROM {}
-        WHERE 
-            {} AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '{}' SECOND)
-        '''.format(
-            self.table.name,
-            self.table.time_field,
-            self.size_seconds,
-        )
-        logger.debug(stmt)
-        df = self.conn.sql(stmt).to_arrow_table()
+        df = self.conn.sql(self.collect_closed_windows_sql).to_arrow_table()
         return df.to_pylist()
 
     def flush(self, records):
@@ -72,18 +65,7 @@ class Tumbling:
 
         :return: the number of deleted rows
         """
-        stmt = '''
-        DELETE 
-            FROM {} 
-        WHERE
-            {} AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '{}' SECOND)
-        '''.format(
-            self.table.name,
-            self.table.time_field,
-            self.size_seconds,
-        )
-        logger.debug(stmt)
-        res = self.conn.execute(stmt).fetchall()
+        res = self.conn.execute(self.delete_closed_windows_sql).fetchall()
         return res[0][0]
 
     def poll(self):
@@ -108,4 +90,4 @@ class Tumbling:
         logger.info('starting managers thread')
         while not self._stopped:
             self.poll()
-            time.sleep(self._poll_interval_seconds)
+            time.sleep(self.poll_interval_seconds)

--- a/sqlflow/pipeline.py
+++ b/sqlflow/pipeline.py
@@ -136,11 +136,9 @@ def build_managed_tables(conn, table_confs, lock=threading.Lock()):
 
         h = window.Tumbling(
             conn=conn,
-            table=window.Table(
-                name=table.name,
-                time_field=table.manager.tumbling_window.time_field,
-            ),
-            size_seconds=table.manager.tumbling_window.duration_seconds,
+            collect_closed_windows_sql=table.manager.tumbling_window.collect_closed_windows_sql,
+            delete_closed_windows_sql=table.manager.tumbling_window.delete_closed_windows_sql,
+            poll_interval_seconds=table.manager.tumbling_window.poll_interval_seconds,
             sink=sink,
             lock=lock,
         )

--- a/sqlflow/pipeline.py
+++ b/sqlflow/pipeline.py
@@ -116,10 +116,10 @@ def init_tables(conn, tables):
             csv_table.header,
             csv_table.auto_detect
         )
-        conn.sql(stmnt)
+        conn.execute(stmnt)
 
     for sql_table in tables.sql:
-        conn.sql(sql_table.sql)
+        conn.execute(sql_table.sql)
 
 
 def build_managed_tables(conn, table_confs, lock=threading.Lock()):

--- a/sqlflow/serde.py
+++ b/sqlflow/serde.py
@@ -1,6 +1,5 @@
 import json
 from abc import ABC, abstractmethod
-from datetime import datetime
 
 
 class Serializer(ABC):
@@ -15,20 +14,12 @@ class Deserializer(ABC):
         pass
 
 
-class DateTimeEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, (datetime)):
-            # Convert datetime to ISO 8601 string
-            return obj.isoformat()
-        return super().default(obj)
-
-
 class JSON(Serializer, Deserializer):
     def decode(self, bs: bytes) -> object:
         return json.loads(bs)
 
     def encode(self, d: object) -> bytes:
-        return json.dumps(d, cls=DateTimeEncoder)
+        return json.dumps(d)
 
 
 class Noop(Serializer, Deserializer):

--- a/sqlflow/serde.py
+++ b/sqlflow/serde.py
@@ -1,5 +1,6 @@
 import json
 from abc import ABC, abstractmethod
+from datetime import datetime
 
 
 class Serializer(ABC):
@@ -14,12 +15,20 @@ class Deserializer(ABC):
         pass
 
 
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime)):
+            # Convert datetime to ISO 8601 string
+            return obj.isoformat()
+        return super().default(obj)
+
+
 class JSON(Serializer, Deserializer):
     def decode(self, bs: bytes) -> object:
         return json.loads(bs)
 
     def encode(self, d: object) -> bytes:
-        return json.dumps(d)
+        return json.dumps(d, cls=DateTimeEncoder)
 
 
 class Noop(Serializer, Deserializer):

--- a/tests/managers/test_tumbling_window.py
+++ b/tests/managers/test_tumbling_window.py
@@ -33,11 +33,9 @@ class TumblingWindowTestCase(unittest.TestCase):
 
         tw = Tumbling(
             conn=conn,
-            table=Table(
-                name='test_table',
-                time_field='timestamp',
-            ),
-            size_seconds=600,
+            collect_closed_windows_sql='SELECT * FROM test_table WHERE timestamp < NOW() - INTERVAL 10 MINUTE',
+            delete_closed_windows_sql=None,
+            poll_interval_seconds=10,
             sink=ConsoleSink(),
         )
         rows = tw.collect_closed()
@@ -70,17 +68,21 @@ class TumblingWindowTestCase(unittest.TestCase):
 
         tw = Tumbling(
             conn=conn,
-            table=Table(
-                name='test_table',
-                time_field='timestamp',
-            ),
-            size_seconds=600,
+            collect_closed_windows_sql='''
+SELECT 
+    strftime(timestamp, '%Y-%m-%dT%H:%M:%S') as timestamp, 
+    id 
+FROM test_table
+            ''',
+            delete_closed_windows_sql=None,
+            poll_interval_seconds=10,
             sink=ConsoleSink(),
         )
+
         rows = tw.collect_closed()
         self.assertEqual(
             [
-                {'timestamp': 1704067200000, 'id': 'test_1'}
+                {'timestamp': '2024-01-01T00:00:00', 'id': 'test_1'}
             ],
             rows,
         )
@@ -90,11 +92,9 @@ class TumblingWindowTestCase(unittest.TestCase):
 
         tw = Tumbling(
             conn=None,
-            table=Table(
-                name='test_table',
-                time_field='timestamp',
-            ),
-            size_seconds=600,
+            collect_closed_windows_sql=None,
+            delete_closed_windows_sql=None,
+            poll_interval_seconds=10,
             sink=writer,
         )
         records = [
@@ -136,11 +136,9 @@ class TumblingWindowTestCase(unittest.TestCase):
 
         tw = Tumbling(
             conn=conn,
-            table=Table(
-                name='test_table',
-                time_field='timestamp',
-            ),
-            size_seconds=600,
+            collect_closed_windows_sql=None,
+            delete_closed_windows_sql='DELETE FROM test_table WHERE timestamp <= NOW()',
+            poll_interval_seconds=10,
             sink=ConsoleSink(),
         )
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -96,8 +96,8 @@ class InvokeExamplesTestCase(unittest.TestCase):
         )
         self.assertEqual(
             [
-                {'timestamp': 1449878400000, 'city': 'New York', 'count': 2},
-                {'timestamp': 1449878400000, 'city': 'Baltimore', 'count': 2},
+                {'bucket': '2015-12-11T19:00:00', 'city': 'New York', 'count': 2},
+                {'bucket': '2015-12-11T19:00:00', 'city': 'Baltimore', 'count': 2}
             ],
             out,
         )
@@ -125,12 +125,11 @@ class InvokeExamplesTestCase(unittest.TestCase):
             # Read the Parquet file and verify the content
             parquet_file_path = os.path.join(temp_dir, parquet_files[0])
             table = pq.read_table(parquet_file_path)
-            df = table.to_pandas()
 
             expected_data = [
                 {'num_records': 4}
             ]
-            self.assertEqual(df.to_dict(orient='records'), expected_data)
+            self.assertEqual(table.to_pylist(), expected_data)
 
 
 class TablesTestCase(unittest.TestCase):
@@ -143,8 +142,8 @@ class TablesTestCase(unittest.TestCase):
                         'sql': 'SELECT 1',
                         'manager': {
                             'tumbling_window': {
-                                'duration_seconds': 600,
-                                'time_field': 'time',
+                                'collect_closed_windows_sql': 'SELECT 1',
+                                'delete_closed_windows_sql': 'SELECT 1',
                             },
                             'sink': {
                                 'type': 'console',
@@ -177,8 +176,8 @@ class TablesTestCase(unittest.TestCase):
         self.assertEqual(
             TableManager(
                 tumbling_window=TumblingWindow(
-                    duration_seconds=600,
-                    time_field='time',
+                    collect_closed_windows_sql='SELECT 1',
+                    delete_closed_windows_sql='SELECT 1',
                 ),
                 sink=Sink(
                     type='console',

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -96,8 +96,8 @@ class InvokeExamplesTestCase(unittest.TestCase):
         )
         self.assertEqual(
             [
-                {'bucket': '2015-12-11T19:00:00', 'city': 'New York', 'count': 2},
-                {'bucket': '2015-12-11T19:00:00', 'city': 'Baltimore', 'count': 2}
+                {'bucket': '2015-12-11T19:00:00', 'city': 'Baltimore', 'count': 2},
+                {'bucket': '2015-12-11T19:00:00', 'city': 'New York', 'count': 2}
             ],
             out,
         )

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -94,10 +94,11 @@ class InvokeExamplesTestCase(unittest.TestCase):
             fixture=os.path.join(fixtures_dir, 'window.jsonl'),
             flush_window=True,
         )
+
         self.assertEqual(
             [
-                {'bucket': '2015-12-11T19:00:00', 'city': 'Baltimore', 'count': 2},
-                {'bucket': '2015-12-11T19:00:00', 'city': 'New York', 'count': 2}
+                {'bucket': '2015-12-12T19:00:00', 'city': 'Baltimore', 'count': 2},
+                {'bucket': '2015-12-12T19:00:00', 'city': 'New York', 'count': 2}
             ],
             out,
         )

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -43,10 +43,10 @@ class InferredMemBatchTestCase(unittest.TestCase):
                     handler=Handler(
                         type=None,
                         sql="""
-                        SELECT
-                            {'something': city} as s1,
-                            row(city, 1, 2) as nested_json
-                        FROM batch 
+SELECT
+    *,
+    {'nested_city': city} AS enriched
+FROM batch
                     """,
                     ),
                     sink=None,
@@ -62,9 +62,9 @@ class InferredMemBatchTestCase(unittest.TestCase):
         res = list(p.invoke())
 
         self.assertEqual([
-            '{"s1": {"something": "New York"}, "nested_json": {"": 2}}',
-            '{"s1": {"something": "New York"}, "nested_json": {"": 2}}',
-            '{"s1": {"something": "Baltimore"}, "nested_json": {"": 2}}',
+            '{"event": "search", "city": "New York", "user_id": "123412ds", "enriched": {"nested_city": "New York"}}',
+            '{"event": "search", "city": "New York", "user_id": "123412ds", "enriched": {"nested_city": "New York"}}',
+            '{"event": "search", "city": "Baltimore", "user_id": "123412ds", "enriched": {"nested_city": "Baltimore"}}'
         ],
             res,
         )

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -39,10 +39,9 @@ class TestLocalParquetSink(unittest.TestCase):
         # Read the Parquet file and verify the content
         parquet_file_path = os.path.join(self.base_path, parquet_files[0])
         table = pq.read_table(parquet_file_path)
-        df = table.to_pandas()
 
         expected_data = [
             {'id': 1, 'name': 'Alice'},
             {'id': 2, 'name': 'Bob'}
         ]
-        self.assertEqual(df.to_dict(orient='records'), expected_data)
+        self.assertEqual(table.to_pylist(), expected_data)


### PR DESCRIPTION
Paving the way for using arrow exclusively for all in-memory buffering. 

- Paves way for serialization framework (refs #35)
- Window manager requires collection and deletion sql (closes #60).
- Removes pandas
- Removes duplicate serialization (closes #48)
- Uses pyarrow as in memory data structure (refs #51)