### PR TITLE
feat(liveness): Adds a liveness check for kafka.

### DIFF
--- a/dev/config/examples/enrich.yml
+++ b/dev/config/examples/enrich.yml
@@ -1,5 +1,6 @@
 pipeline:
   batch_size: 1000
+  flush_interval_seconds: 30
 
   source:
     type: kafka

--- a/sqlflow/config.py
+++ b/sqlflow/config.py
@@ -125,6 +125,7 @@ class Pipeline:
     handler: Handler
     sink: Sink
     batch_size: int | None = None
+    flush_interval_seconds: int = 30
 
 
 @dataclass
@@ -260,7 +261,8 @@ def new_from_dict(conf):
         tables=tables,
         udfs=udfs,
         pipeline=Pipeline(
-            batch_size=conf['pipeline'].get('batch_size'),
+            batch_size=conf['pipeline'].get('batch_size', 1),
+            flush_interval_seconds=conf['pipeline'].get('flush_interval_seconds', 30),
             source=source,
             handler=Handler(
                 type=conf['pipeline']['handler']['type'],

--- a/sqlflow/sources.py
+++ b/sqlflow/sources.py
@@ -50,7 +50,7 @@ class KafkaSource(Source):
                  consumer,
                  topics,
                  async_commit=False,
-                 read_timeout=1.0):
+                 read_timeout=5.0):
         self._consumer = consumer
         self._async_commit = async_commit
         self._read_timeout = read_timeout


### PR DESCRIPTION
The liveness check will flush after an interval of inactivity (default 30sec) passes.

This handles a case of slow moving streams or a stream that stops, ensuring that buffered messages are flushed.

refs #89.