### PR TITLE
poc(asyncio): Evaluates asyncio for consume loop

### DIFF
--- a/cmd/sql-flow.py
+++ b/cmd/sql-flow.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import threading
 
@@ -68,12 +69,12 @@ def run(config, max_msgs_to_process, with_http_debug, metrics):
         flask_thread = threading.Thread(target=lambda: app.run(debug=True, use_reloader=False))
         flask_thread.start()
 
-    start(
+    asyncio.run(start(
         conf,
         conn=conn,
         lock=lock,
         max_msgs=max_msgs_to_process,
-    )
+    ))
 
 
 @click.group()

--- a/sqlflow/lifecycle.py
+++ b/sqlflow/lifecycle.py
@@ -59,7 +59,7 @@ def invoke(conn, config, fixture, setting_overrides={}, flush_window=False, invo
     print(res.to_pylist())
     return res
 
-def start(conf, conn=None, lock=None, max_msgs=None):
+async def start(conf, conn=None, lock=None, max_msgs=None):
     if conn is None:
         conn = duckdb.connect()
 
@@ -89,7 +89,7 @@ def start(conf, conn=None, lock=None, max_msgs=None):
         handler=h,
         lock=lock,
     )
-    stats = sflow.consume_loop(max_msgs)
+    stats = await sflow.consume_loop(max_msgs)
 
     # flush and stop all managed tables
     for table in managed_tables:


### PR DESCRIPTION
refs #92

performance is a huge dropoff when compared to threaded consumer.

### Asyncio using librdkafka (confluent client)
```
2025-02-01 14:16:32,461 [INFO] max messages reached
2025-02-01 14:16:32,464 [INFO] consumer loop ending: total messages / sec = 11014.0
       91.26 real        46.21 user        22.82 sys
           307593216  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               21556  page reclaims
                1108  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
             2011546  messages sent
             2028119  messages received
                   3  signals received
                 273  voluntary context switches
             9327723  involuntary context switches
        587099349110  instructions retired
        207016390948  cycles elapsed
           176884992  peak memory footprint
```