### PR TITLE
benchmark(Motherduck): Benchmarks motherduck ingestion

### DIFF
--- a/benchmark/kafka-motherduck.sh
+++ b/benchmark/kafka-motherduck.sh
@@ -1,0 +1,12 @@
+NUM_MESSAGES=${NUM_MESSAGES:-1000000}
+
+echo "starting benchmark for kafka.motherduck.yml with $NUM_MESSAGES messages"
+
+# delete kafka topic if exists
+docker exec -it kafka1 kafka-topics --bootstrap-server localhost:9092 --delete --topic input-user-clicks-motherduck || true
+
+# Publish benchmark data set
+python3 cmd/publish-test-data.py --num-messages=$NUM_MESSAGES --topic="input-user-clicks-motherduck"
+
+# consume until complete
+/usr/bin/time -l python3 cmd/sql-flow.py run $(PWD)/dev/config/examples/kafka.motherduck.yml --max-msgs-to-process=$NUM_MESSAGES

--- a/dev/config/examples/kafka.motherduck.yml
+++ b/dev/config/examples/kafka.motherduck.yml
@@ -1,0 +1,37 @@
+commands:
+  - name: attach to motherduck
+    sql: |
+      ATTACH 'md:my_db'
+
+pipeline:
+  name: kafka-motherduck-sink
+  description: "Sinks data from kafka to motherduck"
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default(1000) }}
+
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('localhost:9092') }}]
+      group_id: motherduck-sink-1
+      auto_offset_reset: earliest
+      topics:
+        - "input-user-clicks-motherduck"
+
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: |
+      INSERT INTO my_db.events
+      SELECT
+        ip,
+        event,
+        properties ->> 'city' AS properties_city,
+        properties ->> 'country' AS properties_country,
+        CAST(timestamp AS TIMESTAMP) AS timestamp,
+        type,
+        userId
+      FROM batch;
+
+
+
+  sink:
+    type: noop


### PR DESCRIPTION
refs #128


<img width="316" alt="Screenshot 2025-06-16 at 11 16 50 AM" src="https://github.com/user-attachments/assets/62c92a26-10fe-4562-8cf6-444ca38f8689" />

```
% duckdb 'md:my_db'
v1.1.3 19864453f7
Enter ".help" for usage hints.
D CREATE TABLE events (
      ip TEXT,
      event TEXT,
      properties_city TEXT,
      properties_country TEXT,
      timestamp TIMESTAMP,
      type TEXT,
      userId TEXT
  );
```

Publish 100k messages and time how long it takes to insert them all successfully into motherduck:

```
      INSERT INTO my_db.events
      SELECT
        ip,
        event,
        properties ->> 'city' AS properties_city,
        properties ->> 'country' AS properties_country,
        CAST(timestamp AS TIMESTAMP) AS timestamp,
        type,
        userId
      FROM batch;
```

| Batch Size | Throughput Rate (rows/sec) | Total Duration (sec) | Memory Usage RSS (MB) | 
|------------|-----------------------------|------------------------|--------------------|
| 1                 | 9                       |                    |                | 
| 10               | 98                       |  17minutes                   |  267MB              | 
| 100             | 856                      |115 seconds                    |  264MB              | 
| 500            | 3500                      | 29 seconds                   | 265MB               | 
| 1000          |  6160                     | 17 seconds                   |   264MB             | 

