### PR TITLE
chore(release): add multi-arch release-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,62 @@ sqlflow-image:
 		--label io.turbolytics.duckdb.version=$(DUCKDB_VERSION) \
 		-t $(SQLFLOW_IMAGE) .
 
+# Publishes the Go engine's image. This is the ONLY target that pushes, and it
+# builds the root Dockerfile, never Dockerfile.python -- a bare version tag on
+# turbolytics/sql-flow means the Go engine as of v1.
+#
+# Multi-arch is the point of the target existing. v1.0.0 was published by hand
+# from a mac with a plain `docker build`, which produces a single-arch image, so
+# it went out arm64-only and could not run on amd64 at all. buildx runs the
+# whole Dockerfile once per platform against a platform-matching golang image;
+# install-libduckdb.sh branches on `uname -m`, so each arch fetches its own
+# libduckdb without any change here. CGO_ENABLED=1 rules out cross-compiling, so
+# the foreign arch builds under emulation -- expect the amd64 `go build` to take
+# several minutes on an arm64 host.
+#
+# Run `make test-image` before releasing; the guards below only cover release
+# integrity, not correctness.
+RELEASE_PLATFORMS ?= linux/amd64,linux/arm64
+BUILDX_BUILDER ?= sqlflow-release
+# Set RELEASE_LATEST=0 when re-publishing an older tag, so it does not claim
+# `latest` from a newer release.
+RELEASE_LATEST ?= 1
+# Override with --output=type=cacheonly for a dry run that builds but publishes
+# nothing.
+RELEASE_OUTPUT ?= --push
+
+.PHONY: release-image
+release-image:
+	@test -z "$$(git status --porcelain)" || { \
+		echo "release-image: working tree is dirty, so $(VERSION) would not be reproducible" >&2; \
+		echo "               commit or stash, then re-run" >&2; exit 1; }
+	@git describe --exact-match --tags HEAD >/dev/null 2>&1 || { \
+		echo "release-image: HEAD is not tagged (VERSION=$(VERSION))" >&2; \
+		echo "               tag the release first: git tag -a vX.Y.Z -m ... && git push origin vX.Y.Z" >&2; \
+		exit 1; }
+	@docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1 || \
+		docker buildx create --name $(BUILDX_BUILDER) --driver docker-container >/dev/null
+	docker buildx build \
+		--builder $(BUILDX_BUILDER) \
+		--platform $(RELEASE_PLATFORMS) \
+		-f Dockerfile \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT=$(GIT_COMMIT) \
+		--label org.opencontainers.image.version=$(VERSION) \
+		--label org.opencontainers.image.revision=$(GIT_COMMIT) \
+		--label io.turbolytics.duckdb.version=$(DUCKDB_VERSION) \
+		-t $(SQLFLOW_IMAGE) \
+		$(if $(filter 1,$(RELEASE_LATEST)),-t turbolytics/sql-flow:latest) \
+		$(RELEASE_OUTPUT) .
+
+# Reads the platforms back off the registry, because a single-arch publish looks
+# identical to a good one locally.
+.PHONY: release-image-verify
+release-image-verify:
+	docker buildx imagetools inspect $(SQLFLOW_IMAGE) | grep -E 'Name:|Platform'
+	@$(if $(filter 1,$(RELEASE_LATEST)), \
+		docker buildx imagetools inspect turbolytics/sql-flow:latest | grep -E 'Name:|Platform')
+
 # Fetches the pinned libduckdb for linux into bin/; only useful for linux hosts
 # and containers, macOS development uses the Homebrew install.
 .PHONY: libduckdb

--- a/README.md
+++ b/README.md
@@ -804,6 +804,47 @@ Windows is not a target.
 The resulting binaries are dynamically linked and dlopen libduckdb; they are not
 standalone. See [Installation](#installation).
 
+# Publishing the release image
+
+`make sqlflow-image` builds for the host architecture only, which is fine for
+local testing and wrong for publishing. Releases go out through
+`make release-image`, which builds `linux/amd64` and `linux/arm64` and pushes
+both under one manifest:
+
+```
+git tag -a v1.0.1 -m "..." && git push origin v1.0.1
+make test-image        # release tests against the image
+make release-image     # multi-arch build + push
+make release-image-verify
+```
+
+Tag first: `VERSION` comes from `git describe`, so an untagged `main` yields
+`v1.0.0-1-gac977e2` rather than a release version. The target refuses to run on
+a dirty tree or an untagged `HEAD` for that reason.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RELEASE_PLATFORMS` | `linux/amd64,linux/arm64` | Architectures to build |
+| `RELEASE_LATEST` | `1` | Also tag `latest`; set `0` when re-publishing an older tag |
+| `RELEASE_OUTPUT` | `--push` | Set `--output=type=cacheonly` for a dry run that publishes nothing |
+| `SQLFLOW_IMAGE` | `turbolytics/sql-flow:$(VERSION)` | Full image reference |
+
+The foreign architecture builds under QEMU emulation, so expect the `amd64`
+`go build` to take several minutes on an arm64 host — `CGO_ENABLED=1` is
+required for the ADBC driver manager, which rules out cross-compiling. Each
+platform fetches its own libduckdb, because `scripts/install-libduckdb.sh`
+branches on `uname -m` and sees the target architecture.
+
+> **Why this target exists:** `v1.0.0` was published by hand from a mac with a
+> plain `docker build`, so it went out **arm64-only** and did not run on amd64
+> at all. `docker tag` + `docker push` has the same failure mode — it flattens a
+> manifest list down to one architecture. To point an existing tag at another
+> release, copy the manifest instead:
+> `docker buildx imagetools create -t turbolytics/sql-flow:latest turbolytics/sql-flow:v1.0.1`.
+
+`make docker-image` builds the legacy Python engine and must not be used to
+publish a bare version tag; see [The Python engine](#the-python-engine).
+
 # The Python engine
 
 The original Python implementation still lives in this repository under


### PR DESCRIPTION
## Why

`v1.0.0` was published by hand from a mac with a plain `docker build`, which produces a **single-arch** image. It went out `linux/arm64` only:

```
$ docker buildx imagetools inspect turbolytics/sql-flow:v1.0.0
  -> linux/arm64      (only)
```

So anyone pulling `v1.0.0` or `latest` on amd64 — most CI, most Linux servers — got `exec format error`. Every published tag before v1 was amd64, so this was a regression introduced by publishing the Go image from a workstation.

The v1.0.1 re-release fixed it, but only because the multi-arch flags were hand-typed. This makes them the default.

## What

`make release-image` — builds the root `Dockerfile` (**the Go engine, never `Dockerfile.python`**) for `linux/amd64,linux/arm64` and pushes both under one manifest, tagging `latest` alongside the version.

`make release-image-verify` — reads the platforms back off the registry, because a single-arch publish looks identical to a good one locally. That asymmetry is the whole reason the bad v1.0.0 shipped unnoticed.

Two release-integrity guards, both verified to fire:

```
$ make release-image        # dirty tree
release-image: working tree is dirty, so v1.0.1-dirty would not be reproducible
               commit or stash, then re-run

$ make release-image        # untagged HEAD
release-image: HEAD is not tagged (VERSION=v1.0.1-1-g60d8aec)
               tag the release first: git tag -a vX.Y.Z -m ... && git push origin vX.Y.Z
```

The second matters because `VERSION` comes from `git describe`: releasing off untagged `main` would publish a tag literally named `v1.0.0-1-gac977e2`.

| Variable | Default | Purpose |
|---|---|---|
| `RELEASE_PLATFORMS` | `linux/amd64,linux/arm64` | Architectures to build |
| `RELEASE_LATEST` | `1` | Also tag `latest`; `0` when re-publishing an older tag |
| `RELEASE_OUTPUT` | `--push` | `--output=type=cacheonly` for a dry run |
| `BUILDX_BUILDER` | `sqlflow-release` | Created on demand if absent |

README gains a "Publishing the release image" section documenting the sequence, including the `docker tag` + `docker push` trap — it flattens a manifest list to one arch, which is the same failure again. `docker buildx imagetools create` is the right way to repoint a tag.

## Testing status — read this

Both guards were verified to fire. **The full build path was not verified end-to-end**, because this machine's Docker VM disk is full (`Docker.raw` at 57G of 60G) and apt inside any container currently fails with "At least one invalid signature was encountered" from truncated downloads. That reproduces on a plain `docker run debian:bookworm-slim apt-get update`, independent of this change, and the host fetches the same signed `InRelease` without issue.

The buildx invocation itself is byte-for-byte the one that successfully published multi-arch `v1.0.1` and `latest` earlier today, so the flags are known good — but the target has not been run to a successful push. Worth one dry run after reclaiming disk:

```
make release-image RELEASE_OUTPUT=--output=type=cacheonly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9aP5r69sEoZAGfEN8CDzt
