### PR TITLE
fix(handlers): decode JSON string escape sequences

### DIFF
--- a/internal/handlers/inferred_test.go
+++ b/internal/handlers/inferred_test.go
@@ -439,6 +439,60 @@ func TestInferredMemBatchHandler_ConflictingListElementTypesError(t *testing.T) 
 	assert.That(t, strings.Contains(err.Error(), "cannot convert"))
 }
 
+// jsonparser hands back the raw bytes between a string's quotes, so escape
+// sequences arrive undecoded: "a\nb" is a backslash and an n, not a newline.
+// The Python engine decodes with json.loads, and a sink that stores the raw
+// bytes silently corrupts the value rather than failing.
+func TestInferredMemBatchHandler_DecodesJSONStringEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{"newline", `{"v": "line one\nline two"}`, "line one\nline two"},
+		{"tab", `{"v": "a\tb"}`, "a\tb"},
+		{"quote", `{"v": "say \"hi\""}`, `say "hi"`},
+		{"backslash", `{"v": "back\\slash"}`, `back\slash`},
+		{"unicode escape", `{"v": "less \u003c than"}`, "less < than"},
+		{"surrogate pair", `{"v": "emoji \ud83d\ude00"}`, "emoji 😀"},
+		// Raw UTF-8 is not escaped and must survive the fast path untouched.
+		{"raw utf8", `{"v": "L'Œil 👁 café"}`, "L'Œil 👁 café"},
+		{"plain ascii", `{"v": "nothing to decode"}`, "nothing to decode"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, cleanup := newTestADBCConn(t)
+			defer cleanup()
+
+			h, err := NewInferredMemBatchHandler(conn, "SELECT v FROM batch")
+			assert.NoError(t, err)
+
+			res := invokeRows(t, h, []string{tc.msg})
+			defer res.Release()
+
+			got := res.Column(0).Data().Chunk(0).(*array.String).Value(0)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The same decoding must apply wherever a string is built, not just at the top
+// level -- appendJSONValue is shared by struct fields and list elements.
+func TestInferredMemBatchHandler_DecodesEscapesInNestedValues(t *testing.T) {
+	conn, cleanup := newTestADBCConn(t)
+	defer cleanup()
+
+	h, err := NewInferredMemBatchHandler(conn, "SELECT o.s AS nested, l[1] AS elem FROM batch")
+	assert.NoError(t, err)
+
+	res := invokeRows(t, h, []string{`{"o": {"s": "a\nb"}, "l": ["c\td"]}`})
+	defer res.Release()
+
+	assert.Equal(t, "a\nb", res.Column(0).Data().Chunk(0).(*array.String).Value(0))
+	assert.Equal(t, "c\td", res.Column(1).Data().Chunk(0).(*array.String).Value(0))
+}
+
 // The batch that follows an empty one must still work.
 func TestInferredMemBatchHandler_BatchAfterEmptyBatch(t *testing.T) {
 	conn, cleanup := newTestADBCConn(t)

--- a/internal/handlers/structured.go
+++ b/internal/handlers/structured.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/apache/arrow-adbc/go/adbc"
@@ -50,6 +51,26 @@ func unsafeString(b []byte) string {
 	return unsafe.String(unsafe.SliceData(b), len(b))
 }
 
+// jsonString decodes a JSON string value. jsonparser returns the raw bytes
+// between the quotes with escape sequences intact, so "a\nb" arrives as a
+// backslash and an n; storing that verbatim silently corrupts the value
+// rather than failing. The Python engine decodes with json.loads.
+//
+// A string containing no backslash -- the overwhelming majority -- needs no
+// decoding and keeps the zero-copy path.
+func jsonString(b []byte) string {
+	if bytes.IndexByte(b, '\\') < 0 {
+		return unsafeString(b)
+	}
+	s, err := jsonparser.ParseString(b)
+	if err != nil {
+		// Malformed escapes are not worth failing the batch over; the raw
+		// bytes are still closer to the source than an empty string.
+		return unsafeString(b)
+	}
+	return s
+}
+
 // appendJSONValue extracts a JSON value and appends it to the corresponding Arrow builder.
 func appendJSONValue(builder array.Builder, fieldType arrow.DataType, data []byte, key string) error {
 	val, dataType, _, err := jsonparser.Get(data, key)
@@ -65,7 +86,7 @@ func appendJSONValue(builder array.Builder, fieldType arrow.DataType, data []byt
 func appendValue(builder array.Builder, fieldType arrow.DataType, val []byte, dataType jsonparser.ValueType) error {
 	switch fieldType.(type) {
 	case *arrow.StringType:
-		builder.(*array.StringBuilder).Append(unsafeString(val))
+		builder.(*array.StringBuilder).Append(jsonString(val))
 
 	case *arrow.BooleanType:
 		b, err := strconv.ParseBool(unsafeString(val))


### PR DESCRIPTION
## The bug

`jsonparser` returns the raw bytes between a JSON string's quotes, escape sequences **not** decoded. `appendJSONValue` appended them verbatim through `unsafeString` (`internal/handlers/structured.go:68`), so:

| JSON input | stored before | stored after |
|---|---|---|
| `"a\nb"` | `a\nb` (backslash, n) | `a` ⏎ `b` |
| `"say \"hi\""` | `say \"hi\"` | `say "hi"` |
| `"less < than"` | `less < than` | `less < than` |
| `"back\\slash"` | `back\\slash` | `back\slash` |

This **corrupted data silently** — no error, no log line, the rows just arrive wrong. It hit every string column on both handlers, since `appendJSONValue` is shared by `InferredMemBatch` and `StructuredBatch`.

It is also a parity gap: the Python engine decodes with `json.loads` (`sqlflow/serde.py:19`), so the two engines disagree on the contents of any string containing an escape.

Raw UTF-8 was never affected — `L'Œil 👁`, `café`, Japanese and Korean all round-tripped fine. Only backslash escapes.

## How it was found

Streaming the live Bluesky firehose into a ClickHouse Cloud table and reading the rows back:

```
rows with literal backslash-n : 56 / 600
rows with a real newline      : 0
rows with literal \u00        : 6
```

After the fix, over an equivalent 400-row run against the same table:

```
rows with literal backslash-n : 0
rows with a real newline      : 91
rows with literal \u00        : 0
```

A multi-line post now stores as an actual multi-line string rather than one line full of backslashes.

## The fix

```go
func jsonString(b []byte) string {
	if bytes.IndexByte(b, '\\') < 0 {
		return unsafeString(b)
	}
	s, err := jsonparser.ParseString(b)
	if err != nil {
		return unsafeString(b)
	}
	return s
}
```

A string with no backslash — the overwhelming majority — skips decoding and keeps the existing zero-copy path. Malformed escapes fall back to the raw bytes rather than failing the batch, consistent with how the other `appendJSONValue` cases treat unparseable values.

## Performance

Same machine, `-benchtime=2s`, with and without the change:

| benchmark | before | after | delta |
|---|---|---|---|
| InferredMemBatch batch=500 | 305,204 msgs/sec | 303,332 | −0.6% |
| InferredMemBatch batch=5000 | 483,995 | 476,442 | −1.6% |
| StructuredBatch batch=500 | 478,003 | 473,318 | −1.0% |
| StructuredBatch batch=5000 | 1,610,033 | 1,621,594 | +0.7% |

All within run-to-run noise, and **allocations per op are identical** (970 / 5493 / 804 / 5310 before and after) — the fast path provably does not copy.

## Tests

8 table-driven cases (newline, tab, quote, backslash, `\uXXXX`, surrogate pair, plus raw-UTF-8 and plain-ASCII fast-path regressions) and one covering nested values, since struct fields and list elements go through the same shared function. Watched fail first — the six escape cases failed, the two fast-path cases passed, confirming they were not false positives:

```
--- FAIL: .../newline          "line one\nline two" != "line one\\nline two"
--- FAIL: .../unicode_escape   "less < than" != "less \\u003c than"
--- FAIL: .../surrogate_pair   "emoji 😀" != "emoji \\ud83d\\ude00"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
