### PR TITLE
feat(sinks): support ClickHouse Array(T) columns

### DIFF
--- a/internal/sinks/clickhouse.go
+++ b/internal/sinks/clickhouse.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -251,6 +253,13 @@ func appendTables(batch driver.Batch, tables []arrow.Table) error {
 // appenders accept. A null becomes nil, which the driver stores as NULL in a
 // Nullable column and as the column's zero value otherwise.
 func arrowValue(arr arrow.Array, i int) (any, error) {
+	// Lists are handled ahead of the null check: ClickHouse's Array(T) is not
+	// nullable and defaults to the empty array, so a null list must append an
+	// empty slice rather than nil.
+	if l, ok := arr.(*array.List); ok {
+		return arrowListValue(l, i)
+	}
+
 	if arr.IsNull(i) {
 		return nil, nil
 	}
@@ -294,5 +303,79 @@ func arrowValue(arr arrow.Array, i int) (any, error) {
 		return a.Value(i).ToTime(), nil
 	default:
 		return nil, fmt.Errorf("unsupported arrow type %s", arr.DataType())
+	}
+}
+
+// arrowListValue converts one list cell into a Go slice for an Array(T)
+// column. The slice is typed from the Arrow element type rather than built as
+// []any, because the driver matches an Array column's element type against
+// the slice's own element type; an []any is rejected, and an empty list has
+// no element to infer a type from.
+func arrowListValue(l *array.List, row int) (any, error) {
+	values := l.ListValues()
+
+	var start, end int64
+	if !l.IsNull(row) {
+		start, end = l.ValueOffsets(row)
+	}
+
+	out := reflect.MakeSlice(goSliceType(l.DataType().(*arrow.ListType).Elem()), 0, int(end-start))
+	for i := start; i < end; i++ {
+		v, err := arrowValue(values, int(i))
+		if err != nil {
+			return nil, err
+		}
+		if v == nil {
+			out = reflect.Append(out, reflect.Zero(out.Type().Elem()))
+			continue
+		}
+		rv := reflect.ValueOf(v)
+		if !rv.Type().AssignableTo(out.Type().Elem()) {
+			return nil, fmt.Errorf("list element %s is not assignable to %s", rv.Type(), out.Type().Elem())
+		}
+		out = reflect.Append(out, rv)
+	}
+	return out.Interface(), nil
+}
+
+// goSliceType maps an Arrow element type to the Go slice type the driver
+// expects for Array(T), recursing so a nested list becomes [][]T.
+func goSliceType(elem arrow.DataType) reflect.Type {
+	return reflect.SliceOf(goElemType(elem))
+}
+
+func goElemType(dt arrow.DataType) reflect.Type {
+	switch t := dt.(type) {
+	case *arrow.ListType:
+		return goSliceType(t.Elem())
+	case *arrow.BooleanType:
+		return reflect.TypeOf(false)
+	case *arrow.Int8Type:
+		return reflect.TypeOf(int8(0))
+	case *arrow.Int16Type:
+		return reflect.TypeOf(int16(0))
+	case *arrow.Int32Type:
+		return reflect.TypeOf(int32(0))
+	case *arrow.Int64Type:
+		return reflect.TypeOf(int64(0))
+	case *arrow.Uint8Type:
+		return reflect.TypeOf(uint8(0))
+	case *arrow.Uint16Type:
+		return reflect.TypeOf(uint16(0))
+	case *arrow.Uint32Type:
+		return reflect.TypeOf(uint32(0))
+	case *arrow.Uint64Type:
+		return reflect.TypeOf(uint64(0))
+	case *arrow.Float32Type:
+		return reflect.TypeOf(float32(0))
+	case *arrow.Float64Type:
+		return reflect.TypeOf(float64(0))
+	case *arrow.TimestampType, *arrow.Date32Type, *arrow.Date64Type:
+		return reflect.TypeOf(time.Time{})
+	case *arrow.BinaryType, *arrow.LargeBinaryType:
+		return reflect.TypeOf([]byte(nil))
+	default:
+		// String and anything else the element switch renders as a string.
+		return reflect.TypeOf("")
 	}
 }

--- a/internal/sinks/clickhouse_test.go
+++ b/internal/sinks/clickhouse_test.go
@@ -237,3 +237,119 @@ func clickhouseFixtureTable(t *testing.T) arrow.Table {
 	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
 	return table
 }
+
+// Arrow list columns must reach ClickHouse Array(T) columns. The inferred
+// handler turns any JSON array into a list, so this is reachable from an
+// ordinary config -- a Bluesky pipeline selecting commit.record.langs
+// produces exactly this shape.
+func TestClickhouseSink_InsertsArrays(t *testing.T) {
+	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
+		id UInt64,
+		langs Array(String),
+		counts Array(Int64)
+	) ENGINE = MergeTree() ORDER BY id`)
+
+	alloc := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "langs", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+		{Name: "counts", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)},
+	}, nil)
+
+	b := array.NewRecordBuilder(alloc, schema)
+	defer b.Release()
+
+	b.Field(0).(*array.Int64Builder).AppendValues([]int64{1, 2, 3}, nil)
+
+	lb := b.Field(1).(*array.ListBuilder)
+	sv := lb.ValueBuilder().(*array.StringBuilder)
+	lb.Append(true)
+	sv.AppendValues([]string{"en", "ja"}, nil)
+	lb.Append(true) // an empty array stays empty, not null
+	lb.AppendNull() // a null list becomes ClickHouse's empty-array default
+
+	cb := b.Field(2).(*array.ListBuilder)
+	iv := cb.ValueBuilder().(*array.Int64Builder)
+	cb.Append(true)
+	iv.AppendValues([]int64{7, 8, 9}, nil)
+	cb.Append(true)
+	iv.AppendValues([]int64{42}, nil)
+	cb.Append(true)
+
+	rec := b.NewRecord()
+	defer rec.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
+	defer table.Release()
+
+	assert.NoError(t, s.WriteTable(table))
+	assert.NoError(t, s.Flush())
+	assert.Equal(t, uint64(3), clickhouseRowCount(t, s))
+
+	ctx := context.Background()
+	var langs []string
+	row := s.conn.QueryRow(ctx, "SELECT langs FROM "+s.table+" WHERE id = 1")
+	assert.NoError(t, row.Scan(&langs))
+	assert.Equal(t, 2, len(langs))
+	assert.Equal(t, "en", langs[0])
+	assert.Equal(t, "ja", langs[1])
+
+	var counts []int64
+	row = s.conn.QueryRow(ctx, "SELECT counts FROM "+s.table+" WHERE id = 1")
+	assert.NoError(t, row.Scan(&counts))
+	assert.Equal(t, 3, len(counts))
+	assert.Equal(t, int64(9), counts[2])
+
+	// Empty and null lists both land as empty arrays.
+	var empty []string
+	row = s.conn.QueryRow(ctx, "SELECT langs FROM "+s.table+" WHERE id = 2")
+	assert.NoError(t, row.Scan(&empty))
+	assert.Equal(t, 0, len(empty))
+
+	var nulled []string
+	row = s.conn.QueryRow(ctx, "SELECT langs FROM "+s.table+" WHERE id = 3")
+	assert.NoError(t, row.Scan(&nulled))
+	assert.Equal(t, 0, len(nulled))
+}
+
+// A list of lists must reach Array(Array(T)), since the handler infers
+// nested lists from nested JSON arrays.
+func TestClickhouseSink_InsertsNestedArrays(t *testing.T) {
+	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
+		id UInt64,
+		matrix Array(Array(Int64))
+	) ENGINE = MergeTree() ORDER BY id`)
+
+	alloc := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "matrix", Type: arrow.ListOf(arrow.ListOf(arrow.PrimitiveTypes.Int64))},
+	}, nil)
+
+	b := array.NewRecordBuilder(alloc, schema)
+	defer b.Release()
+
+	b.Field(0).(*array.Int64Builder).Append(1)
+	outer := b.Field(1).(*array.ListBuilder)
+	inner := outer.ValueBuilder().(*array.ListBuilder)
+	iv := inner.ValueBuilder().(*array.Int64Builder)
+	outer.Append(true)
+	inner.Append(true)
+	iv.AppendValues([]int64{1, 2}, nil)
+	inner.Append(true)
+	iv.AppendValues([]int64{3}, nil)
+
+	rec := b.NewRecord()
+	defer rec.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
+	defer table.Release()
+
+	assert.NoError(t, s.WriteTable(table))
+	assert.NoError(t, s.Flush())
+
+	var matrix [][]int64
+	row := s.conn.QueryRow(context.Background(), "SELECT matrix FROM "+s.table+" WHERE id = 1")
+	assert.NoError(t, row.Scan(&matrix))
+	assert.Equal(t, 2, len(matrix))
+	assert.Equal(t, 2, len(matrix[0]))
+	assert.Equal(t, int64(3), matrix[1][0])
+}


### PR DESCRIPTION
## Why

`arrowValue` had no list case, so any Arrow list column failed the flush:

```
clickhouse sink: column "langs": unsupported arrow type list<l: utf8, nullable>
```

That was unreachable before — nothing produced list columns. #147 changed this: the inferred handler now turns any JSON array into an Arrow list, so a Bluesky pipeline selecting `commit.record.langs` hits it immediately. ClickHouse has `Array(T)` natively, so the sink was the only thing missing.

## What

Lists convert to a Go slice typed from the Arrow element type.

It has to be a **typed** slice rather than `[]any` — the driver matches an Array column's element type against the slice's own element type, and `[]any` is rejected. The type comes from the Arrow element type rather than from the first element, because an empty list has no element to infer from. Nested lists recurse, so `Array(Array(T))` works.

**A null list appends an empty slice, not nil.** `Array(T)` is not nullable in ClickHouse and defaults to the empty array, so lists are handled *ahead of* the shared null check rather than inside it.

Element types covered: bool, all int/uint widths, float32/64, string, binary, timestamp, date32/64, and nested lists.

## Verification

Tests are live against the dev-stack ClickHouse (skipping when unreachable, as the existing sink tests do), covering `Array(String)`, `Array(Int64)`, `Array(Array(Int64))`, an empty list, and a null list. Watched fail first:

```
--- FAIL: TestClickhouseSink_InsertsArrays
    unsupported arrow type list<item: utf8, nullable>
--- FAIL: TestClickhouseSink_InsertsNestedArrays
    unsupported arrow type list<item: list<item: int64, nullable>, nullable>
```

Beyond unit tests, end to end against **ClickHouse Cloud 26.2.1** — 180 Bluesky messages through Kafka into an `Array(String)` column, then aggregated natively:

```sql
SELECT lang, count() c FROM (SELECT arrayJoin(langs) AS lang FROM sqlflow_bluesky_arrays)
GROUP BY lang ORDER BY c DESC LIMIT 5
```
```
en  187
ja   30
pt    9
es    9
de    5
```

Also exercised against local ClickHouse **26.8.1**. Full suite green, `go vet` and `gofmt` clean.

## Still unsupported

`Decimal`, `Map` and `Tuple` remain unsupported by `arrowValue` — out of scope here, and neither is currently produced by the handlers.

## Unrelated issue this surfaced

Pointing the same pipeline at the **live firehose** rather than Kafka fails in the *handler*, not the sink:

```
Binder Error: Could not find key "langs" in struct.  Candidate Entries: "createdAt"
```

That is the nested-struct divergence noted in #147: `promoteFields` takes struct children from the first message only, while pyarrow unions them across rows. If message one's `commit.record` happens to carry only `createdAt`, `langs` never becomes a column and the config breaks depending on which message arrives first. Worth its own issue — it makes streaming configs non-deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
