### PR TITLE
fix(sinks): store zone-less string timestamps as UTC in ClickHouse

### DIFF
--- a/internal/sinks/clickhouse.go
+++ b/internal/sinks/clickhouse.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -179,7 +180,14 @@ func (s *ClickhouseSink) Flush() error {
 		return fmt.Errorf("clickhouse sink: prepare batch: %w", err)
 	}
 
-	if err := appendTables(batch, tables); err != nil {
+	// The prepared batch knows the target column types, which the Arrow
+	// schema does not; appendTables needs them to spot temporal columns.
+	types := make([]column.Type, len(batch.Columns()))
+	for i, c := range batch.Columns() {
+		types[i] = c.Type()
+	}
+
+	if err := appendTables(batch, types, tables); err != nil {
 		batch.Abort()
 		return err
 	}
@@ -216,7 +224,7 @@ func withRows(tables []arrow.Table) []arrow.Table {
 	return kept
 }
 
-func appendTables(batch driver.Batch, tables []arrow.Table) error {
+func appendTables(batch driver.Batch, types []column.Type, tables []arrow.Table) error {
 	for _, table := range tables {
 		reader := array.NewTableReader(table, 0)
 
@@ -230,6 +238,11 @@ func appendTables(batch driver.Batch, tables []arrow.Table) error {
 					if err != nil {
 						reader.Release()
 						return fmt.Errorf("clickhouse sink: column %q: %w", rec.ColumnName(c), err)
+					}
+					if s, ok := v.(string); ok && c < len(types) {
+						if t, ok := temporalFromString(types[c], s); ok {
+							v = t
+						}
 					}
 					row[c] = v
 				}
@@ -247,6 +260,57 @@ func appendTables(batch driver.Batch, tables []arrow.Table) error {
 		}
 	}
 	return nil
+}
+
+// temporalFromString parses a string bound for a Date/DateTime column, with a
+// zone-less value read as UTC.
+//
+// Left to the driver, a zone-less string is parsed in time.Local
+// (lib/column/datetime.go, date.go), so a JSON timestamp the handler passed
+// through without a CAST was stored shifted by the SQLFlow host's UTC offset --
+// "12:00:00" from a UTC-4 laptop landed as 16:00:00. The Python engine sends
+// the string to the server, which parses it as UTC; this matches that. A
+// string carrying an explicit offset is honoured as written.
+//
+// The layouts are the driver's own, so anything it accepted before is still
+// accepted; a string that matches none is handed to the driver unchanged to
+// report as it always has.
+func temporalFromString(colType column.Type, s string) (time.Time, bool) {
+	var withZone, noZone string
+	switch base := baseColumnType(colType); {
+	case strings.HasPrefix(base, "DateTime64"):
+		withZone, noZone = "2006-01-02 15:04:05.999999999 -07:00", "2006-01-02 15:04:05.999999999"
+	case strings.HasPrefix(base, "DateTime"):
+		withZone, noZone = "2006-01-02 15:04:05 -07:00", "2006-01-02 15:04:05"
+	case base == "Date" || base == "Date32":
+		withZone, noZone = "2006-01-02 -07:00", "2006-01-02"
+	default:
+		return time.Time{}, false
+	}
+
+	if t, err := time.Parse(withZone, s); err == nil {
+		return t, true
+	}
+	if t, err := time.ParseInLocation(noZone, s, time.UTC); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// baseColumnType strips the Nullable(...) and LowCardinality(...) wrappers so
+// the underlying type can be matched.
+func baseColumnType(t column.Type) string {
+	s := string(t)
+	for {
+		switch {
+		case strings.HasPrefix(s, "Nullable(") && strings.HasSuffix(s, ")"):
+			s = s[len("Nullable(") : len(s)-1]
+		case strings.HasPrefix(s, "LowCardinality(") && strings.HasSuffix(s, ")"):
+			s = s[len("LowCardinality(") : len(s)-1]
+		default:
+			return s
+		}
+	}
 }
 
 // arrowValue converts one Arrow cell to the Go value the driver's column

--- a/internal/sinks/clickhouse_test.go
+++ b/internal/sinks/clickhouse_test.go
@@ -353,3 +353,54 @@ func TestClickhouseSink_InsertsNestedArrays(t *testing.T) {
 	assert.Equal(t, 2, len(matrix[0]))
 	assert.Equal(t, int64(3), matrix[1][0])
 }
+
+// A timestamp that arrives as a string -- a JSON field the handler passed
+// through without a CAST -- must be stored as the wall-clock value written,
+// not shifted by whatever zone the SQLFlow host happens to run in. The zone is
+// pinned to one far from UTC so the test means the same thing on a UTC CI
+// runner as on a laptop.
+func TestClickhouseSink_StringTemporalsAreNotShiftedByHostZone(t *testing.T) {
+	tokyo, err := time.LoadLocation("Asia/Tokyo") // UTC+9, no DST
+	assert.NoError(t, err)
+	prev := time.Local
+	time.Local = tokyo
+	t.Cleanup(func() { time.Local = prev })
+
+	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
+		id UInt64,
+		ts DateTime,
+		ts64 DateTime64(3),
+		d Date
+	) ENGINE = MergeTree() ORDER BY id`)
+
+	alloc := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "ts", Type: arrow.BinaryTypes.String},
+		{Name: "ts64", Type: arrow.BinaryTypes.String},
+		{Name: "d", Type: arrow.BinaryTypes.String},
+	}, nil)
+	b := array.NewRecordBuilder(alloc, schema)
+	defer b.Release()
+	b.Field(0).(*array.Int64Builder).Append(1)
+	b.Field(1).(*array.StringBuilder).Append("2026-09-01 12:00:00")
+	b.Field(2).(*array.StringBuilder).Append("2026-09-01 12:00:00.123")
+	b.Field(3).(*array.StringBuilder).Append("2026-09-01")
+	rec := b.NewRecord()
+	defer rec.Release()
+	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
+	defer table.Release()
+
+	assert.NoError(t, s.WriteTable(table))
+	assert.NoError(t, s.Flush())
+
+	// Rendered by the server in its own zone (UTC in the dev stack), so a
+	// value parsed as Tokyo time would read 03:00, and the date 2026-08-31.
+	var ts, ts64, d string
+	row := s.conn.QueryRow(context.Background(),
+		"SELECT toString(ts), toString(ts64), toString(d) FROM "+s.table+" WHERE id = 1")
+	assert.NoError(t, row.Scan(&ts, &ts64, &d))
+	assert.Equal(t, "2026-09-01 12:00:00", ts)
+	assert.Equal(t, "2026-09-01 12:00:00.123", ts64)
+	assert.Equal(t, "2026-09-01", d)
+}


### PR DESCRIPTION
## The bug

A timestamp that reached the ClickHouse sink as a **string** — a JSON field the handler passed through without a `CAST` — was stored shifted by the SQLFlow host's UTC offset:

| handler emits | host zone | stored (server renders UTC) |
|---|---|---|
| `'2026-09-01 12:00:00.123'` as `VARCHAR` | UTC−4 (laptop) | `2026-09-01 16:00:00.123` |
| `'2026-09-01 12:00:00'` as `VARCHAR` | UTC+9 (test) | `2026-09-01 03:00:00` |
| `'2026-09-01'` as `VARCHAR` into `Date` | UTC+9 (test) | `2026-08-31` |

Silent, and the offset depends on wherever the process happens to run. Found while measuring type mappings for the ClickHouse integration docs: `CAST(ts AS TIMESTAMP)` stored 12:00, the same value as a string stored 16:00.

**Cause:** clickhouse-go parses a zone-less string in `time.Local` (`lib/column/datetime.go:293`, `date.go:230`) and has no option to change it. The Python engine sends the string to the server, which parses it as UTC — so this was also a parity gap.

## The fix

The prepared batch knows each target column's ClickHouse type (`Batch.Columns()[i].Type()`), which the Arrow schema does not. For `Date`, `Date32`, `DateTime`, `DateTime64` — through `Nullable(...)` / `LowCardinality(...)` — a string is now parsed by the sink using the driver's own layouts:

- explicit offset (`... -07:00`) → honoured as written
- zone-less → UTC
- matches neither → handed to the driver unchanged, so error reporting is as before

Nothing changes for values that arrive as Arrow timestamps; those were already correct.

## Verification

The test pins `time.Local` to `Asia/Tokyo`, so it is **not vacuous on a UTC CI runner** — without the fix it fails there exactly as on a laptop:

```
--- FAIL: TestClickhouseSink_StringTemporalsAreNotShiftedByHostZone
    clickhouse_test.go:403: "2026-09-01 12:00:00" != "2026-09-01 03:00:00"
```

End to end through the built binary on a UTC−4 host, one Kafka message → sink → read back with the server rendering in UTC:

```
dt64  2026-09-01 12:00:00.123   (was 16:00:00.123)
dt    2026-09-01 12:00:00
d     2026-09-01
dz    2026-09-01 03:00:00       (input carried +09:00 — correct)
```

Full suite green, `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9aP5r69sEoZAGfEN8CDzt
