### PR TITLE
fix(kafka): commit only the offsets the pipeline has processed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/twmb/franz-go v1.20.7
+	github.com/twmb/franz-go/pkg/kmsg v1.12.0
 	github.com/zeebo/assert v1.3.0
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.68.0
@@ -85,7 +86,6 @@ require (
 	github.com/substrait-io/substrait-protobuf/go v0.85.0 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/twmb/avro v1.7.2 // indirect
-	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/uptrace/bun v1.2.18 // indirect
 	github.com/uptrace/bun/dialect/mssqldialect v1.2.18 // indirect

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -24,6 +24,27 @@ type Message struct {
 	Topic     string
 	Partition int32
 	Offset    int64
+	// LeaderEpoch is the Kafka leader epoch the record was read under. It is
+	// carried through so a commit can name it, which lets the broker detect
+	// log truncation. Only meaningful when HasMetadata is true; a source with
+	// no positions leaves it zero along with the rest.
+	LeaderEpoch int32
+}
+
+// Mark is the position of the last message the pipeline has finished with in
+// one partition: written to the handler, or dropped by an error policy.
+type Mark struct {
+	Offset      int64
+	LeaderEpoch int32
+}
+
+// MarkCommitter is implemented by sources that can commit an explicit
+// position. The pipeline prefers it to Commit, because a source that reads
+// ahead of the pipeline -- the Kafka source polls into a buffer -- has fetched
+// messages the pipeline has not processed, and committing "everything fetched"
+// commits those too. Marks are keyed by topic then partition.
+type MarkCommitter interface {
+	CommitMarks(marks map[string]map[int32]Mark) error
 }
 
 // HasMetadata reports whether the source supplied provenance for this message.
@@ -124,10 +145,14 @@ type Turbine struct {
 	handler       Handler
 	batchSize     int
 	flushInterval time.Duration
-	lock          *sync.Mutex
-	running       bool
-	stats         *Stats
-	errorPolicy   PipelineErrorPolicies
+
+	// marks is the last position finished with, per topic and partition; what
+	// commitSource hands a MarkCommitter.
+	marks       map[string]map[int32]Mark
+	lock        *sync.Mutex
+	running     bool
+	stats       *Stats
+	errorPolicy PipelineErrorPolicies
 
 	logger  *zap.Logger
 	metrics *Metrics
@@ -162,6 +187,7 @@ func NewTurbine(
 ) *Turbine {
 	t := &Turbine{
 		source:        source,
+		marks:         map[string]map[int32]Mark{},
 		sink:          sink,
 		handler:       handler,
 		batchSize:     batchSize,
@@ -289,7 +315,9 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 				}
 				// The message is dropped from the batch, but it was still
 				// consumed from the source: it counts toward the reported
-				// total and toward --max-msgs, as in the Python engine.
+				// total and toward --max-msgs, as in the Python engine -- and
+				// its position is finished with, so it is safe to commit past.
+				t.mark(raw)
 				totalConsumed++
 				t.stats.SetNumMessagesConsumed(totalConsumed)
 				if maxMsgs > 0 && totalConsumed >= int64(maxMsgs) {
@@ -300,6 +328,7 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 				continue
 			}
 
+			t.mark(raw)
 			numBatchMessages++
 			totalConsumed++
 			t.stats.SetNumMessagesConsumed(totalConsumed)
@@ -406,6 +435,45 @@ func (t *Turbine) writeDLQ(cause error, phase, message string) error {
 	return t.errorPolicy.DLQSink.Flush()
 }
 
+// mark records that the pipeline has finished with a message -- written to
+// the handler or dropped by policy -- so a commit can name that position.
+// Messages without source metadata have no position to record.
+func (t *Turbine) mark(m Message) {
+	if !m.HasMetadata() {
+		return
+	}
+	parts, ok := t.marks[m.Topic]
+	if !ok {
+		parts = map[int32]Mark{}
+		t.marks[m.Topic] = parts
+	}
+	// Offsets arrive in order within a partition; the guard only matters if
+	// a source ever redelivers.
+	if cur, ok := parts[m.Partition]; ok && cur.Offset >= m.Offset {
+		return
+	}
+	parts[m.Partition] = Mark{Offset: m.Offset, LeaderEpoch: m.LeaderEpoch}
+}
+
+// commitSource commits what the pipeline has processed. A source that can
+// take explicit marks gets exactly the positions this pipeline has finished
+// with; anything else gets the plain Commit it always did.
+//
+// The distinction is not academic. The Kafka source reads ahead of the
+// pipeline into a buffer, and its plain Commit commits everything it has
+// fetched: after one 20,000-message batch it had committed offset 70,086.
+// Whatever sat in that buffer when the process died was gone for good, with
+// the consumer group showing no lag.
+func (t *Turbine) commitSource() error {
+	if mc, ok := t.source.(MarkCommitter); ok {
+		if len(t.marks) == 0 {
+			return nil
+		}
+		return mc.CommitMarks(t.marks)
+	}
+	return t.source.Commit()
+}
+
 // processBatch invokes the handler on the buffered messages, writes the
 // result to the sink, commits the source, and resets the handler for the
 // next batch.
@@ -459,7 +527,7 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 
 	// Committed only after the sink has flushed, so a crash replays the
 	// batch rather than losing it.
-	if err := t.source.Commit(); err != nil {
+	if err := t.commitSource(); err != nil {
 		t.logger.Error("error committing source", zap.Error(err))
 		if batch != nil {
 			batch.Release()

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -34,6 +34,38 @@ func (f *fakeSource) Stream() <-chan []Message {
 func (f *fakeSource) Commit() error { f.commits++; return nil }
 func (f *fakeSource) Close() error  { return nil }
 
+// markingSource is a fakeSource that can commit explicit positions, recording
+// the marks it was handed at each commit.
+type markingSource struct {
+	fakeSource
+	marks []map[string]map[int32]Mark
+}
+
+func (m *markingSource) CommitMarks(marks map[string]map[int32]Mark) error {
+	copied := map[string]map[int32]Mark{}
+	for topic, parts := range marks {
+		copied[topic] = map[int32]Mark{}
+		for p, mk := range parts {
+			copied[topic][p] = mk
+		}
+	}
+	m.marks = append(m.marks, copied)
+	return nil
+}
+
+// kafkaMessages fabricates n messages from one partition with consecutive
+// offsets, the way the Kafka source delivers them.
+func kafkaMessages(topic string, partition int32, from, n int) []Message {
+	out := make([]Message, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, Message{
+			Value: []byte(`{"a":1}`), Topic: topic, Partition: partition,
+			Offset: int64(from + i), LeaderEpoch: 7,
+		})
+	}
+	return out
+}
+
 // fakeHandler emits a table with one row per buffered message, so the sink
 // can be checked against the number of messages the source produced.
 type fakeHandler struct {
@@ -381,4 +413,43 @@ func TestConsumeLoop_BatchOfOnlyBadMessagesIsNotAHandlerError(t *testing.T) {
 	assert.Equal(t, int64(0), sink.rows)
 	// Two rejected messages, and no extra error from invoking an empty batch.
 	assert.Equal(t, 2, stats.NumErrors)
+}
+
+// The Kafka source polls ahead of the pipeline into a buffer, so "commit
+// everything fetched" commits messages the pipeline has not processed: after
+// one 20,000-message batch it had committed offset 70,086. A crash then loses
+// the difference with the consumer group showing no lag. The pipeline must
+// instead hand the source the exact position it has finished with.
+func TestConsumeLoop_CommitsOnlyProcessedMarks(t *testing.T) {
+	src := &markingSource{fakeSource: fakeSource{
+		// One fetch delivers 30 messages; batch_size is 20, so the first
+		// commit must name offset 19 and the final one 29 -- never 29 twice.
+		batches: [][]Message{kafkaMessages("events", 0, 0, 30)},
+	}}
+	tb := newTestTurbine(src, &fakeHandler{}, &fakeSink{}, 20)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(src.marks))
+	assert.Equal(t, Mark{Offset: 19, LeaderEpoch: 7}, src.marks[0]["events"][0])
+	assert.Equal(t, Mark{Offset: 29, LeaderEpoch: 7}, src.marks[1]["events"][0])
+	// A source that can take marks must not also get the blanket commit.
+	assert.Equal(t, 0, src.commits)
+}
+
+func TestConsumeLoop_MarksTrackEachPartition(t *testing.T) {
+	p0 := kafkaMessages("events", 0, 100, 3)
+	p1 := kafkaMessages("events", 1, 500, 2)
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{{p0[0], p1[0], p0[1], p1[1], p0[2]}},
+	}}
+	tb := newTestTurbine(src, &fakeHandler{}, &fakeSink{}, 10)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(src.marks))
+	assert.Equal(t, int64(102), src.marks[0]["events"][0].Offset)
+	assert.Equal(t, int64(501), src.marks[0]["events"][1].Offset)
 }

--- a/internal/kafka/source.go
+++ b/internal/kafka/source.go
@@ -2,8 +2,11 @@ package kafka
 
 import (
 	"context"
+	"fmt"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/zap"
 	"sync"
 	"time"
@@ -82,6 +85,50 @@ func (k *Source) Commit() error {
 	return nil
 }
 
+// CommitMarks commits exactly the positions the pipeline has finished with.
+//
+// Commit above commits everything this source has fetched, and the poll
+// goroutine fetches well ahead of the pipeline: after one 20,000-message
+// batch it had committed offset 70,086. A crash then lost the difference
+// with the consumer group showing no lag. Kafka commits the next offset to
+// read, so a mark at offset N commits N+1.
+func (k *Source) CommitMarks(marks map[string]map[int32]core.Mark) error {
+	offsets := make(map[string]map[int32]kgo.EpochOffset, len(marks))
+	for topic, parts := range marks {
+		offsets[topic] = make(map[int32]kgo.EpochOffset, len(parts))
+		for p, m := range parts {
+			offsets[topic][p] = kgo.EpochOffset{Epoch: m.LeaderEpoch, Offset: m.Offset + 1}
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), commitTimeout)
+	defer cancel()
+
+	var commitErr error
+	k.client.CommitOffsetsSync(ctx, offsets, func(_ *kgo.Client, _ *kmsg.OffsetCommitRequest, resp *kmsg.OffsetCommitResponse, err error) {
+		if err != nil {
+			commitErr = err
+			return
+		}
+		// The request can succeed while a partition inside it is refused.
+		for _, t := range resp.Topics {
+			for _, p := range t.Partitions {
+				if err := kerr.ErrorForCode(p.ErrorCode); err != nil {
+					commitErr = fmt.Errorf("commit %s[%d]: %w", t.Topic, p.Partition, err)
+					return
+				}
+			}
+		}
+	})
+	if commitErr != nil {
+		k.logger.Error("failed to commit offsets", zap.Error(commitErr))
+	}
+	return commitErr
+}
+
+// commitTimeout bounds a synchronous commit; the pipeline blocks on it.
+const commitTimeout = 30 * time.Second
+
 func (k *Source) Stream() <-chan []core.Message {
 	k.logger.Info("starting stream",
 		zap.Int("channel_buffer", k.channelBuffer),
@@ -127,10 +174,11 @@ func (k *Source) Stream() <-chan []core.Message {
 			batch := make([]core.Message, 0, fetches.NumRecords())
 			fetches.EachRecord(func(r *kgo.Record) {
 				batch = append(batch, core.Message{
-					Value:     r.Value,
-					Topic:     r.Topic,
-					Partition: r.Partition,
-					Offset:    r.Offset,
+					Value:       r.Value,
+					Topic:       r.Topic,
+					Partition:   r.Partition,
+					Offset:      r.Offset,
+					LeaderEpoch: r.LeaderEpoch,
 				})
 			})
 

--- a/internal/kafka/source_test.go
+++ b/internal/kafka/source_test.go
@@ -1,0 +1,104 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/zeebo/assert"
+)
+
+// brokerOrSkip returns the dev-stack broker, skipping the test when none is
+// reachable rather than failing a local `go test`. Kafka-backed tests are
+// deliberately not part of CI's unit run.
+func brokerOrSkip(t *testing.T) string {
+	t.Helper()
+	broker := os.Getenv("SQLFLOW_KAFKA_BROKERS")
+	if broker == "" {
+		broker = "localhost:9092"
+	}
+	conn, err := net.DialTimeout("tcp", broker, time.Second)
+	if err != nil {
+		t.Skipf("kafka unavailable at %s: %v", broker, err)
+	}
+	conn.Close()
+	return broker
+}
+
+func newTestClient(t *testing.T, broker, topic, group string) *kgo.Client {
+	t.Helper()
+	// Mirrors sources/init.go: a consumer group with autocommit off, so the
+	// only commits are the ones the source makes.
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(broker),
+		kgo.ConsumerGroup(group),
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.DisableAutoCommit(),
+		kgo.AllowAutoTopicCreation(),
+	)
+	assert.NoError(t, err)
+	return client
+}
+
+func produce(t *testing.T, client *kgo.Client, topic string, n int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for i := 0; i < n; i++ {
+		res := client.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte(`{"i":1}`)})
+		assert.NoError(t, res.FirstErr())
+	}
+}
+
+// The source fetches ahead of whoever reads its stream. Committing must name
+// the position the reader has reached, not the position the source has
+// fetched to -- the latter is how 20,000 processed messages came to commit
+// offset 70,086 and how a batch that never reached ClickHouse had already been
+// committed.
+func TestSource_CommitMarksCommitsOnlyTheProcessedPosition(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-commit-marks-%d", time.Now().UnixNano())
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	produce(t, client, topic, 200)
+
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	// Take 50 messages off the stream. The source will have fetched all 200
+	// by now; the reader has only reached the 50th.
+	stream := src.Stream()
+	var got []core.Message
+	for len(got) < 50 {
+		select {
+		case batch, ok := <-stream:
+			assert.That(t, ok)
+			got = append(got, batch...)
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timed out with %d messages", len(got))
+		}
+	}
+	last := got[49]
+
+	assert.NoError(t, src.CommitMarks(map[string]map[int32]core.Mark{
+		topic: {last.Partition: {Offset: last.Offset, LeaderEpoch: last.LeaderEpoch}},
+	}))
+
+	// Kafka commits the *next* offset to read, so processing offset 49
+	// commits 50. Anything larger is a fetched-but-unprocessed message
+	// committed away.
+	committed := client.CommittedOffsets()[topic][last.Partition]
+	assert.Equal(t, last.Offset+1, committed.Offset)
+	assert.Equal(t, int64(50), committed.Offset)
+	// The commit names the record's leader epoch, so the broker can detect
+	// truncation, rather than the "unknown" sentinel.
+	assert.Equal(t, last.LeaderEpoch, committed.Epoch)
+}


### PR DESCRIPTION
## The bug

The Kafka source committed with `CommitUncommittedOffsets`, which commits **every record the client has fetched**. The poll goroutine fetches far ahead of the pipeline into a buffered channel, so each commit also covered messages the pipeline had never seen. Deterministically, with `--max-msgs=20000`:

```
processed=20000   committed-offset=70086
```

After that point a crash, a failed sink flush, or a `kill` loses up to ~50,000 messages permanently — and the consumer group shows **lag 0**, so nothing downstream notices. The `processBatch` comment ("committed only after the sink has flushed, so a crash replays the batch rather than losing it") described the intent, not the behaviour.

**How it surfaced:** a 1,000,000-row run into ClickHouse Cloud finished with exit 0 and 981,230 rows. The missing 18,770 were one contiguous block at the tail of the stream, and the group's committed offset was already `1000660` — the end of the topic. Whatever happened to that final batch, its offsets had been committed before it was inserted. (A re-run landed all 1,000,000; the loss is timing-dependent, the over-commit is not.)

## The fix

The pipeline now tracks the last position it has *finished with* per topic and partition — a message written to the handler, or dropped by an error policy — and hands exactly those marks to a source that implements the new `core.MarkCommitter`:

```go
type Mark struct { Offset int64; LeaderEpoch int32 }
type MarkCommitter interface { CommitMarks(marks map[string]map[int32]Mark) error }
```

The Kafka source implements it with `CommitOffsetsSync`, committing `offset+1` (Kafka commits the next offset to read) and the record's leader epoch so the broker can detect truncation. Per-partition error codes in an otherwise-successful response are surfaced. Sources without positions (WebSocket, webhook) keep the plain `Commit`. `core.Message` gains `LeaderEpoch`, filled by the Kafka source.

`kmsg` moves from indirect to direct in `go.mod` (`go mod tidy`), since the commit callback names its types.

## Verification

Three levels, each watched fail first:

- **Pipeline** (`internal/core`): a 30-message fetch at `batch_size: 20` hands over marks `19` then `29` — never 29 twice — and the blanket `Commit` is not called. A second test covers interleaved partitions.
- **Kafka source** (`internal/kafka`, live broker, skips when none is reachable): after the reader takes 50 of 200 fetched records and commits the 50th, the committed offset is `50` with the record's epoch. Before the fix the stub committed nothing; with the old `Commit` it would have been 200.
- **End to end** through the built binary against the dev broker:

```
processed=20000   committed-offset=20000    (before: 70086)
```

Full suite green, `go vet` and `gofmt` clean.

## What this changes for operators

At-least-once now holds: a failed final flush leaves its offsets uncommitted and a restart replays it. That is the guarantee the ClickHouse integration docs state, and it was not true until this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

