### PR TITLE
Durable state and DuckDB-managed offsets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,65 +1,31 @@
 # Writing style
 
-Write prose in the style of [Google Technical Writing One](https://developers.google.com/tech-writing/one). This applies to commit messages, pull request descriptions, code comments, documentation, and replies in the terminal.
+All prose — commit messages, PR descriptions, code comments, docs, README,
+terminal replies — follows Google's Technical Writing One style:
+https://developers.google.com/tech-writing/one
 
-## Words
+- Active voice over passive.
+- One idea per sentence. One idea per paragraph.
+- Short sentences — split compound ones.
+- Cut unnecessary words. No adverbs or adjectives that don't carry information.
+- No hedging, no throat-clearing lead-ins.
+- Strong, specific lead sentence per paragraph/section.
+- Most important information first.
+- Consistent terminology — don't vary a term for style.
+- Bulleted lists for unordered items, numbered for sequences.
+- Introduce a list or table with a sentence ending in a colon.
+- `that` for essential clauses, no comma. `which` for nonessential, with comma.
 
-Use one term for one thing. Do not alternate between synonyms for the same concept.
+Draft short the first time. Don't draft long and plan to trim later.
 
-Spell out an acronym on first use, then use the acronym. Skip the acronym entirely when a term appears fewer than about four times.
+Replace wordy phrases: `in order to` → `to`, `is able to` → `can`, `at this
+point in time` → `now`, `due to the fact that` → `because`.
 
-Define a term the reader may not know, or link to a definition.
+## Code comments
 
-## Sentences
+Explain why, not what. The code shows what.
 
-Follow these rules:
+## Commit messages
 
-- Focus each sentence on a single idea.
-- Use active voice. Reserve passive voice for the rare sentence whose actor genuinely does not matter.
-- Pick a specific verb over a vague one. `The pipeline commits the offset` beats `The offset is handled by the pipeline`.
-- Split a subordinate clause into its own sentence when it carries a separate idea.
-- Use `that` for an essential clause and take no comma. Use `which` for a nonessential clause and take a comma.
-
-Cut filler words. Replace these phrases:
-
-| Wordy | Concise |
-|---|---|
-| at this point in time | now |
-| in order to | to |
-| is able to | can |
-| determine the location of | find |
-| provides a detailed description of | describes |
-| due to the fact that | because |
-
-## Lists and tables
-
-Introduce every list and table with a sentence that ends in a colon.
-
-Use a bulleted list for unordered items. Use a numbered list for ordered items, and start each item with an imperative verb.
-
-Keep list items parallel. The first item sets a pattern of grammar, category, capitalization, and punctuation that every later item must match.
-
-Capitalize the first word of each list item. Punctuate an item that is a full sentence as a sentence.
-
-## Paragraphs
-
-State the paragraph's point in its first sentence.
-
-Give each paragraph one topic. Move a second topic into its own paragraph.
-
-State the key point at the start of a document, not at the end.
-
-## Comments and commit messages
-
-Explain why the code does something. The code already shows what it does.
-
-Write a commit message that names the defect, the fix, and the evidence. State what a reader loses if the change is wrong.
-
-## What this style rejects
-
-Avoid these habits:
-
-- Hedging that carries no information, such as `it seems that` or `arguably`.
-- Marketing adjectives, such as `powerful`, `seamless`, or `robust`.
-- A closing sentence that repeats the opening sentence.
-- Em dashes and parenthetical asides where a second sentence is clearer.
+Name the defect, the fix, and the evidence. State what breaks if the change is
+wrong.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# Writing style
+
+Write prose in the style of [Google Technical Writing One](https://developers.google.com/tech-writing/one). This applies to commit messages, pull request descriptions, code comments, documentation, and replies in the terminal.
+
+## Words
+
+Use one term for one thing. Do not alternate between synonyms for the same concept.
+
+Spell out an acronym on first use, then use the acronym. Skip the acronym entirely when a term appears fewer than about four times.
+
+Define a term the reader may not know, or link to a definition.
+
+## Sentences
+
+Follow these rules:
+
+- Focus each sentence on a single idea.
+- Use active voice. Reserve passive voice for the rare sentence whose actor genuinely does not matter.
+- Pick a specific verb over a vague one. `The pipeline commits the offset` beats `The offset is handled by the pipeline`.
+- Split a subordinate clause into its own sentence when it carries a separate idea.
+- Use `that` for an essential clause and take no comma. Use `which` for a nonessential clause and take a comma.
+
+Cut filler words. Replace these phrases:
+
+| Wordy | Concise |
+|---|---|
+| at this point in time | now |
+| in order to | to |
+| is able to | can |
+| determine the location of | find |
+| provides a detailed description of | describes |
+| due to the fact that | because |
+
+## Lists and tables
+
+Introduce every list and table with a sentence that ends in a colon.
+
+Use a bulleted list for unordered items. Use a numbered list for ordered items, and start each item with an imperative verb.
+
+Keep list items parallel. The first item sets a pattern of grammar, category, capitalization, and punctuation that every later item must match.
+
+Capitalize the first word of each list item. Punctuate an item that is a full sentence as a sentence.
+
+## Paragraphs
+
+State the paragraph's point in its first sentence.
+
+Give each paragraph one topic. Move a second topic into its own paragraph.
+
+State the key point at the start of a document, not at the end.
+
+## Comments and commit messages
+
+Explain why the code does something. The code already shows what it does.
+
+Write a commit message that names the defect, the fix, and the evidence. State what a reader loses if the change is wrong.
+
+## What this style rejects
+
+Avoid these habits:
+
+- Hedging that carries no information, such as `it seems that` or `arguably`.
+- Marketing adjectives, such as `powerful`, `seamless`, or `robust`.
+- A closing sentence that repeats the opening sentence.
+- Em dashes and parenthetical asides where a second sentence is clearer.

--- a/README.md
+++ b/README.md
@@ -621,6 +621,43 @@ set** is anonymous memory, comparable to RSS — what the engine actually holds.
 Memory is flat across handlers and batch sizes at roughly a quarter GiB, so
 throughput scales with batch size without buying it with memory.
 
+## What durable state costs
+
+Setting `pipeline.state.path` puts every batch in a DuckDB transaction. That
+transaction is one fsync per batch, so its cost per message falls as batches
+grow. Same pipeline, same 300,000 messages, state in memory against state on
+disk:
+
+| `batch_size` | State in memory | Durable state | Cost |
+|---|---|---|---|
+| 500 | ~95,600 msgs/sec | ~51,100 msgs/sec | 47% |
+| 2000 | ~184,600 msgs/sec | ~130,600 msgs/sec | 29% |
+| 5000 | ~201,600 msgs/sec | ~171,500 msgs/sec | 15% |
+
+Use a batch of at least 5000 for a stateful pipeline. Below 2000 the commit
+dominates and you pay for durability on every message instead of amortising it
+across a batch.
+
+Memory is unchanged: peak working set stayed within 191-218 MiB across every
+run above, with and without state. Durability costs throughput, not memory.
+
+`state_commit_latency` reports the per-batch commit time on the metrics
+endpoint, so you can see this cost on your own hardware rather than inferring
+it from the table.
+
+Reproduce both arms:
+
+```
+make benchmark-container NUM_MESSAGES=300000 BATCH_SIZE=5000 \
+    CONFIG=dev/config/examples/benchmark.stateful.mem.yml
+STATE_PATH=/tmp/bench-state.db make benchmark-container NUM_MESSAGES=300000 BATCH_SIZE=5000 \
+    CONFIG=dev/config/examples/benchmark.stateful.mem.yml
+```
+
+Delete the state file between runs. A second run resumes from the first run's
+offsets and consumes nothing, which reports a meaningless number rather than
+failing.
+
 To reproduce:
 
 ```

--- a/README.md
+++ b/README.md
@@ -538,7 +538,13 @@ pipeline with a `tables` block.
 Two consequences worth knowing:
 
 - The state file is the source of truth. When it disagrees with the consumer
-  group, the pipeline commits the file's offsets to Kafka on startup.
+  group, the pipeline resumes from the file's offsets. It applies them while
+  joining the group, so a restart works even while the previous process is
+  still a member, which it is for the session timeout after a crash.
+- Window close predicates are evaluated at most one `flush_interval_seconds`
+  behind the wall clock. A stateful pipeline holds one transaction open per
+  batch and DuckDB's `now()` is the transaction's start time, so the pipeline
+  commits on the flush tick even when idle to keep that clock moving.
 - DuckDB locks the file exclusively. One state file belongs to one running
   pipeline, and no other process can read it, not even read-only. Use the
   `/stats` endpoint to inspect a running pipeline.
@@ -607,7 +613,9 @@ tables:
 Collect, write and flush happen before the delete, so a sink failure retries
 rather than dropping a window. A retry re-sends rows the sink already received,
 so give a window sink a key it can deduplicate on. One final poll runs on
-shutdown, so a window that closes during shutdown is not stranded.
+shutdown, against a current clock and with its delete committed, so a window
+that closes during shutdown is published once and not republished on the next
+start.
 
 Windows close on wall-clock time, as written in your
 `collect_closed_windows_sql`. There is no event-time watermarking and no
@@ -623,7 +631,7 @@ State in a managed table is lost on a crash unless the pipeline sets
 
 ## Metrics
 
-`--metrics prometheus` serves `/metrics` on `:8000`. Seven instruments are
+`--metrics prometheus` serves `/metrics` on `:8000`. Twelve instruments are
 exported under the meter name `sqlflow`:
 
 | Instrument | Type | Unit |
@@ -635,12 +643,41 @@ exported under the meter name `sqlflow`:
 | `sink_flush_latency` | histogram | seconds |
 | `sink_flush_count` | counter | flushes |
 | `sink_flush_num_rows` | gauge | rows |
+| `consumer_lag` | gauge (attrs: `topic`, `partition`) | messages |
+| `state_commit_count` | counter | commits |
+| `state_commit_latency` | histogram | seconds |
+| `state_db_size_bytes` | gauge | bytes |
+| `state_table_rows` | gauge (attr: `table`) | rows |
+
+The last four appear only when the pipeline declares a state path. An absent
+series and an empty state are different facts, so a pipeline with state in
+memory reports nothing rather than zero.
 
 ```
 $ sqlflow run -c <config> --metrics=prometheus &
 $ curl -s localhost:8000/metrics | grep message_count
 message_count_messages_total{otel_scope_name="sqlflow",...} 154635
 ```
+
+`consumer_lag` is the one to alert on. It is the broker's high watermark minus
+the offset the pipeline has finished with, so it measures the work the
+pipeline still owes rather than what its consumer group has been told.
+
+### Inspecting durable state
+
+`--metrics prometheus` also serves `/stats` on `:8000`, which reports what is
+on disk right now:
+
+```
+$ curl -s localhost:8000/stats
+{"state":{"path":"/var/lib/sqlflow/state.db","size_bytes":2109440,
+          "tables":[{"table":"agg_city_count","rows":1440}],
+          "offsets":[{"topic":"events","partition":0,"offset":98213}]}}
+```
+
+Reads come from a second connection, so a scrape never blocks a batch and
+never reports rows a rollback then erased. A pipeline with no state path
+serves no `/stats`.
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ pipeline:   # required
   description:
   batch_size:              # required, >= 1
   flush_interval_seconds:  # optional; unset means only batch_size triggers a batch
+  state:                   # optional; makes state durable, see Durable state
   on_error:                # optional
   source:                  # required
   handler:                 # required
@@ -294,10 +295,9 @@ source:
 ```
 
 Offsets are committed after the batch has been handled and the sink has
-flushed, and only up to the last message the pipeline actually processed — not
-to wherever the consumer has read ahead to. Delivery is therefore
-**at-least-once**: a crash between a sink flush and its commit replays that
-batch on restart.
+flushed, and only up to the last message the pipeline actually processed, not
+to wherever the consumer has read ahead to. See
+[Delivery guarantees](#delivery-guarantees).
 
 **SASL / TLS.** Set `security_protocol` to one of `PLAINTEXT`, `SSL`,
 `SASL_PLAINTEXT`, `SASL_SSL`:
@@ -515,6 +515,64 @@ columns: `error`, `message`, `phase` (`handler.write` or `handler.invoke`) and
 `timestamp`. See [`kafka.dlq.yml`](dev/config/examples/kafka.dlq.yml).
 `source.error.policy` is parsed but unused; use `pipeline.on_error`.
 
+## Durable state
+
+A pipeline that aggregates needs its state to survive a restart. Give it a file:
+
+```yaml
+pipeline:
+  state:
+    path: /var/lib/sqlflow/state.db
+```
+
+DuckDB then runs on that file instead of in memory, and a `sqlflow_offsets`
+table lives there beside the tables your handler writes. Every batch commits
+the handler's writes and the Kafka offsets that produced them in one
+transaction. On startup the pipeline reads those offsets and resumes from them.
+
+Without a state path, DuckDB runs in memory. A crash mid-window loses that
+window's aggregate while its offsets are already committed, so the consumer
+group reports no lag and a restart replays nothing. Set a state path for any
+pipeline with a `tables` block.
+
+Two consequences worth knowing:
+
+- The state file is the source of truth. When it disagrees with the consumer
+  group, the pipeline commits the file's offsets to Kafka on startup.
+- DuckDB locks the file exclusively. One state file belongs to one running
+  pipeline, and no other process can read it, not even read-only. Use the
+  `/stats` endpoint to inspect a running pipeline.
+
+Durable state costs throughput. See
+[What durable state costs](#what-durable-state-costs) for the numbers and the
+batch size to use.
+
+## Delivery guarantees
+
+SQLFlow gives two guarantees. Which one applies depends on where the data
+lands.
+
+**Pipeline state is exactly-once relative to offsets.** With a state path set,
+the tables your handler writes and the offsets that produced them commit in a
+single transaction. A crash replays exactly the batches whose state did not
+commit, so a windowed aggregate is neither short nor double-counted across a
+restart.
+
+**External sinks are at-least-once.** Kafka, ClickHouse, Iceberg and
+`sqlcommand` are flushed before that transaction commits. A crash in between
+replays the batch and the sink sees those rows twice. Committing first would
+move offsets past rows the sink never received, which loses them silently, so
+the duplicate is the deliberate choice. Use a sink that absorbs it:
+`ReplacingMergeTree` in ClickHouse, an upsert in `sqlcommand`, or a downstream
+dedupe on a key.
+
+**Window sinks are at-least-once for the same reason.** A tumbling window is
+published before its rows are deleted, and that delete commits with the
+pipeline's next batch. A crash in between republishes the window.
+
+Without a state path there is no state guarantee at all: handler state does not
+survive the process.
+
 ## Tumbling windows
 
 A table declared under `tables.sql` can carry a `manager`, which polls the table
@@ -547,11 +605,21 @@ tables:
 ```
 
 Collect, write and flush happen before the delete, so a sink failure retries
-rather than dropping a window. One final poll runs on shutdown, so a window that
-closes during shutdown is not stranded. Windows close on wall-clock time as
-written in your `collect_closed_windows_sql`; there is no event-time
-watermarking. `tumbling_window` is currently the only manager type. See
-[`tumbling.window.yml`](dev/config/examples/tumbling.window.yml).
+rather than dropping a window. A retry re-sends rows the sink already received,
+so give a window sink a key it can deduplicate on. One final poll runs on
+shutdown, so a window that closes during shutdown is not stranded.
+
+Windows close on wall-clock time, as written in your
+`collect_closed_windows_sql`. There is no event-time watermarking and no
+late-arrival policy: a message that arrives after its window closed lands in
+whichever window its own SQL puts it in.
+
+State in a managed table is lost on a crash unless the pipeline sets
+[`state.path`](#durable-state).
+
+`tumbling_window` is currently the only manager type. See
+[`tumbling.window.yml`](dev/config/examples/tumbling.window.yml) and
+[`kafka.stateful.window.yml`](dev/config/examples/kafka.stateful.window.yml).
 
 ## Metrics
 

--- a/dev/config/examples/benchmark.stateful.mem.yml
+++ b/dev/config/examples/benchmark.stateful.mem.yml
@@ -1,0 +1,58 @@
+# Measures what durable state costs.
+#
+# Identical to benchmark.inferred.mem.yml except the handler writes to a
+# managed table instead of returning rows. Set SQLFLOW_STATE_PATH to make
+# DuckDB file-backed and put every batch in a transaction. Leave it unset to
+# measure the same pipeline with state in memory. The difference is the cost
+# of the durability guarantee.
+tables:
+  sql:
+    - name: agg_city_count
+      sql: |
+        CREATE TABLE IF NOT EXISTS agg_city_count (
+          city VARCHAR,
+          count INT
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS agg_city_count_idx
+          ON agg_city_count (city);
+
+      manager:
+        tumbling_window:
+          poll_interval_seconds: 3600
+          collect_closed_windows_sql: "SELECT city, count FROM agg_city_count WHERE false"
+          delete_closed_windows_sql: "DELETE FROM agg_city_count WHERE false"
+        sink:
+          type: noop
+
+pipeline:
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default(500) }}
+
+{% if SQLFLOW_STATE_PATH %}
+  state:
+    path: {{ SQLFLOW_STATE_PATH }}
+{% endif %}
+
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('localhost:9092') }}]
+      group_id: {{ SQLFLOW_GROUP_ID|default('benchmark-stateful') }}
+      auto_offset_reset: earliest
+      topics:
+        - "{{ SQLFLOW_TOPIC|default('benchmark-input') }}"
+
+  handler:
+    type: "handlers.InferredMemBatch"
+    sql: |
+      INSERT INTO agg_city_count
+      BY NAME
+      SELECT
+        properties.city as city,
+        COUNT(*) as count
+      FROM batch
+      GROUP BY properties.city
+      ON CONFLICT (city)
+      DO UPDATE SET count = count + EXCLUDED.count;
+
+  sink:
+    type: noop

--- a/dev/config/examples/kafka.stateful.window.yml
+++ b/dev/config/examples/kafka.stateful.window.yml
@@ -1,0 +1,72 @@
+# A windowed aggregation with durable state.
+#
+# pipeline.state.path makes DuckDB file-backed, so the window table and the
+# Kafka offsets that produced it are committed together in one transaction.
+# Without it, state lives in memory: a crash mid-window loses that window's
+# aggregate while its offsets are already committed, silently, with the
+# consumer group reporting no lag.
+#
+# The close predicate here is deliberately an hour, so the window stays open
+# for the length of a test run and recovery can be observed on a partial
+# aggregate rather than one that has already been published and deleted.
+tables:
+  sql:
+    - name: agg_city_count
+      sql: |
+        CREATE TABLE IF NOT EXISTS agg_city_count (
+          bucket TIMESTAMPTZ,
+          city VARCHAR,
+          count INT
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS agg_city_count_idx
+          ON agg_city_count (bucket, city);
+
+      manager:
+        tumbling_window:
+          poll_interval_seconds: 3600
+          collect_closed_windows_sql: |
+            SELECT
+              strftime(bucket, '%Y-%m-%dT%H:%M:%S') AS bucket,
+              city,
+              count
+            FROM agg_city_count
+            WHERE bucket < (now()::timestamptz - INTERVAL '3600' SECOND)
+          delete_closed_windows_sql: |
+            DELETE FROM agg_city_count
+            WHERE bucket < (now()::timestamptz - INTERVAL '3600' SECOND)
+
+        sink:
+          type: console
+
+pipeline:
+  name: stateful-window
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default('250') }}
+
+  state:
+    path: {{ SQLFLOW_STATE_PATH|default('/tmp/sqlflow/state.db') }}
+
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('localhost:9092') }}]
+      group_id: {{ SQLFLOW_GROUP_ID|default('stateful-window') }}
+      auto_offset_reset: earliest
+      topics:
+        - "{{ SQLFLOW_TOPIC|default('input-stateful-window') }}"
+
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: |
+      INSERT INTO agg_city_count
+      BY NAME
+      SELECT
+        date_trunc('hour', CAST(timestamp AS TIMESTAMPTZ)) AS bucket,
+        properties.city AS city,
+        count(*) AS count
+      FROM batch
+      GROUP BY bucket, city
+      ON CONFLICT (bucket, city)
+      DO UPDATE SET count = count + EXCLUDED.count
+
+  sink:
+    type: noop

--- a/docs/superpowers/plans/2026-09-02-durable-state-and-offsets.md
+++ b/docs/superpowers/plans/2026-09-02-durable-state-and-offsets.md
@@ -507,6 +507,102 @@ git commit -m "feat(config): add pipeline.state.path"
 
 ---
 
+## Task 2b: Teach the JSON Schema about `pipeline.state`
+
+**Files:**
+- Modify: `internal/cli/schemas/config.json`
+- Test: `internal/cli/config_test.go`
+
+**Interfaces:** none; this is the validation surface for Task 2's config field.
+
+Found by Task 2's review, not by the original plan. `sqlflow config validate`
+renders the config and checks it against this schema, and the `pipeline`
+object sets `additionalProperties: false` while listing only `batch_size`,
+`description`, `flush_interval_seconds`, `handler`, `name`, `on_error`,
+`sink`, `source`. A config using `pipeline.state.path` therefore **runs but
+fails validation** -- the same trap the README documents for webhook sources,
+where the schema rejects what the engine accepts.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/cli/config_test.go`, following the existing validate tests
+in that file:
+
+```go
+// A config that `run` accepts must also pass `config validate`. The schema
+// sets additionalProperties: false on pipeline, so a new field is invisible
+// to validation until it is declared here too.
+func TestConfigValidate_AcceptsStatePath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.yml")
+	body := `
+pipeline:
+  batch_size: 10
+  state:
+    path: /var/lib/sqlflow/state.db
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      topics: [t]
+  handler:
+    type: handlers.InferredMemBatch
+    sql: SELECT 1
+  sink:
+    type: noop
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	assert.NoError(t, validateConfig(path, &out))
+}
+```
+
+Match the helper name and signature the neighbouring validate tests already
+use; read them first rather than assuming `validateConfig`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/cli/ -run TestConfigValidate_AcceptsStatePath -v`
+Expected: FAIL, with a schema error naming `state` as an unexpected property.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the `pipeline` object's `properties` in `internal/cli/schemas/config.json`:
+
+```json
+"state": {
+  "type": "object",
+  "description": "Where the pipeline keeps its DuckDB state. Absent means in-memory, and state is lost on a crash.",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "File backing the pipeline's DuckDB database. Window state and Kafka offsets are stored here and committed together."
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/cli/ -v`
+Expected: PASS, and every pre-existing validate test still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/ && go vet ./...
+git add internal/cli/schemas/config.json internal/cli/config_test.go
+git commit -m "fix(schema): accept pipeline.state so validate matches run"
+```
+
+---
+
 ## Task 3: The offset store
 
 **Files:**

--- a/docs/superpowers/plans/2026-09-02-durable-state-and-offsets.md
+++ b/docs/superpowers/plans/2026-09-02-durable-state-and-offsets.md
@@ -1,0 +1,1695 @@
+# Durable State and DuckDB-Managed Offsets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make SQLFlow a stateful stream processor: window state survives a crash, the Kafka offsets that produced that state are committed atomically with it inside DuckDB, and both are observable at runtime.
+
+**Architecture:** DuckDB becomes the single source of truth. A pipeline may declare `pipeline.state.path`; the engine opens DuckDB on that file instead of in memory, and keeps a `sqlflow_offsets` table there alongside the user's tables. Each batch runs with ADBC autocommit disabled: the handler's writes to state and the offset upsert land in one transaction, committed after the external sink has flushed. On startup the engine reads offsets out of DuckDB and seeks Kafka to them, so Kafka's committed offsets become advisory (useful for lag dashboards, no longer authoritative).
+
+**Observability is part of the deliverable, not a follow-up.** State you cannot see is worse than no state: an operator has no way to tell a healthy pipeline from one that is falling behind or growing without bound. Every state feature here lands with the instrument that makes it observable — on-disk size, rows per managed table, consumer lag, and the latency of the commit this design introduces. Because DuckDB takes an exclusive file lock, a *running* pipeline must serve its own stats over HTTP; a *stopped* one is read from the file by a CLI. Both are built here.
+
+### The Prometheus surface after this work
+
+Exported under the meter name `sqlflow`, served on the existing `/metrics` endpoint (`--metrics prometheus`, `:8000`). The exporter, registry and mux already exist in `internal/cli/run/metrics.go`; this adds instruments to them rather than building anything new. `Int64Gauge` is already in use by `sink_flush_num_rows`, so gauges are known to export correctly through the OTel Prometheus bridge.
+
+| Instrument | Type | Attributes | Task | Answers |
+|---|---|---|---|---|
+| `message_count` | counter | — | exists | Throughput |
+| `error_count` | counter | `phase` | exists | Failure rate, by stage |
+| `source_read_latency` | histogram | — | exists | Is the source starving the pipeline |
+| `batch_processing_latency` | histogram | — | exists | Handler cost per batch |
+| `sink_flush_latency` | histogram | — | exists | Sink cost per batch |
+| `sink_flush_count` | counter | — | exists | Batches completed |
+| `sink_flush_num_rows` | gauge | — | exists | Rows per batch |
+| **`consumer_lag`** | gauge | `topic`, `partition` | 5b | Am I falling behind |
+| **`state_db_size_bytes`** | gauge | — | 5c | Is state growing without bound |
+| **`state_table_rows`** | gauge | `table` | 5c | Which table is growing |
+| **`state_commit_latency`** | histogram | — | 4 | What the durability guarantee costs per batch |
+| **`state_commit_count`** | counter | — | 4 | Commits completed, to pair with the sink count |
+
+`state_*` instruments record nothing when the pipeline has no `state.path`, rather than reporting zero — an absent series and a genuinely empty state are different facts, and a dashboard should be able to tell them apart.
+
+**Tech Stack:** Go 1.25, DuckDB via Arrow ADBC driver manager (`drivermgr`), franz-go for Kafka, zap, `github.com/zeebo/assert` for tests.
+
+**Spec:** This document. The design was settled in conversation on 2026-09-02; the findings it rests on are recorded under "Established facts" below.
+
+## Established facts
+
+Each was verified by execution on 2026-09-02, not read from source. Do not re-litigate these; do re-verify if behaviour surprises you.
+
+1. **DuckDB is opened in memory today.** `internal/duckdb/open.go` passes no path. All window state is process-local.
+2. **A crash mid-window loses the aggregate silently.** 2,000 events were folded into an open window, the process was `kill -9`ed, and afterwards the consumer group read `committed=2000, log-end=2000, LAG=0`. A restart consumed 0 messages. The aggregate is permanently short and every signal reports healthy.
+3. **DuckDB ADBC accepts a `path` option.** `drivermgr.Driver.NewDatabase({"driver": …, "entrypoint": "duckdb_adbc_init", "path": "/tmp/x.db"})` creates and uses the file. The keys `uri`, `database` and `filename` were not needed.
+4. **ADBC transactions work; raw `BEGIN` does not.** `conn.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled)` returns nil and the connection implements `Commit(ctx)`/`Rollback(ctx)`. Issuing `BEGIN TRANSACTION` afterwards fails with `cannot start a transaction within a transaction`, because disabling autocommit already opened one. **Use the ADBC methods, never SQL transaction statements.**
+5. **Offsets already commit only what was processed.** As of #154 the pipeline hands the Kafka source explicit marks. This plan moves the authority for those marks into DuckDB; it does not revisit the mark-tracking logic.
+6. **DuckDB holds an exclusive file lock.** While one process has the state file open, a second process cannot open it *even read-only*: `IO Error: Could not set lock on file … Conflicting lock is held`. After the writer exits, the file opens normally read-only and read-write. This is why stats are served over HTTP by the running process and read from the file only when it is stopped.
+7. **Consumer lag needs no new dependency.** `kgo.FetchPartition` carries `HighWatermark` (and `LogStartOffset`) on every fetch, so lag is `HighWatermark - lastProcessedOffset`, computed in the poll loop. Do not add `kadm` for this.
+8. **A second connection to the same database gets snapshot isolation.** `db.Open(ctx)` called twice on one `adbc.Database` yields two connections. With the writer inside an open transaction (autocommit disabled) and an uncommitted row pending, the reader reported the old count; after `Commit` it reported the new one. This is what lets `/stats` read without dirty reads and without taking the pipeline's lock. **Stats therefore report the last committed state — exactly what would survive a crash at that moment**, which is the number an operator wants from a durability feature.
+
+## Global Constraints
+
+- **No new external dependencies.** DuckDB and franz-go are already present; nothing else may be added. `go.mod` must not gain a direct requirement.
+- **Backward compatible.** A config without `pipeline.state.path` behaves exactly as today: in-memory DuckDB, autocommit on, Kafka-authoritative offsets. Every existing test must pass unchanged.
+- **Go 1.25**, `CGO_ENABLED=1`. `go vet ./...` and `gofmt -l internal/ cmd/` must be clean before every commit.
+- **TDD.** Every task writes a failing test first and watches it fail for the expected reason. A test that passes on first run is a plan failure — fix the test, not the claim.
+- **Kafka-backed tests skip when no broker is reachable**, matching `internal/kafka/source_test.go`'s `brokerOrSkip`. They must not run in CI's unit job.
+- **Delivery-guarantee vocabulary is fixed.** "Exactly-once" describes *state relative to offsets* only. External sinks remain at-least-once. Never write "exactly-once" unqualified.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/duckdb/open.go` (modify) | Gains `OpenPath(ctx, path)`; existing `Open` delegates to it with an empty path |
+| `internal/config/config.go` (modify) | New `State` struct on `Pipeline`; `path` field |
+| `internal/core/offsets.go` (create) | `OffsetStore`: schema creation, `Load`, `Save`. Owns the `sqlflow_offsets` table and nothing else |
+| `internal/core/offsets_test.go` (create) | Round-trip and schema tests against a real DuckDB |
+| `internal/core/marks.go` (create) | `Marks`: per-partition positions, forward-only `Advance`, sorted `Each`. Replaces `map[string]map[int32]Mark` everywhere |
+| `internal/core/turbine.go` (modify) | Transactional batch: autocommit off, sink flush, offset save, `Commit`; rollback on failure |
+| `internal/core/turbine_test.go` (modify) | Fakes for the transactional path; ordering assertions |
+| `internal/core/metrics.go` (modify) | Four new instruments: state size, rows per table, consumer lag, commit latency/count |
+| `internal/core/stats.go` (create) | `StateStats`: the JSON-shaped snapshot both the HTTP endpoint and the CLI render. Reads a DuckDB connection, knows nothing about HTTP |
+| `internal/core/stats_test.go` (create) | Snapshot tests against a real state file |
+| `internal/kafka/source.go` (modify) | `SeekTo(marks)`; records `HighWatermark` per partition for lag |
+| `internal/kafka/source_test.go` (modify) | Live-broker seek and high-watermark tests |
+| `internal/cli/run/metrics.go` (modify) | Already owns the Prometheus exporter, registry and mux; `/stats` is registered on the same mux |
+| `internal/cli/stats/root.go` (create) | `sqlflow stats -c <config>`: opens the state file read-only, renders `StateStats`, explains the lock error when the pipeline is running |
+| `internal/cli/stats/root_test.go` (create) | Offline read, and the locked-file message |
+| `internal/cli/run/root.go` (modify) | Wires `state.path` → `OpenPath`, builds the `OffsetStore`, seeks before consuming, starts the HTTP server |
+| `tests/release/test_image.py` (modify) | Crash-recovery acceptance test, plus a `/stats` assertion through the image |
+| `README.md` (modify) | Guarantee statement, `pipeline.state`, the new metrics, and `sqlflow stats` |
+
+---
+
+## Task 0: A `Marks` type
+
+**Files:**
+- Modify: `internal/core/turbine.go`, `internal/core/turbine_test.go`, `internal/kafka/source.go`, `internal/kafka/source_test.go`
+- Test: `internal/core/marks_test.go` (create), `internal/core/marks.go` (create)
+
+**Interfaces:**
+- Consumes: `Mark`.
+- Produces:
+
+```go
+type Marks struct { /* unexported nested map */ }
+
+func NewMarks() *Marks
+func (m *Marks) Advance(topic string, partition int32, mark Mark)
+func (m *Marks) Get(topic string, partition int32) (Mark, bool)
+func (m *Marks) Len() int
+func (m *Marks) Empty() bool
+func (m *Marks) Each(fn func(topic string, partition int32, mark Mark))
+```
+
+Every later task uses `*Marks` where it would otherwise say `map[string]map[int32]Mark`: `MarkCommitter.CommitMarks(*Marks)`, `Source.SeekTo(*Marks)`, `OffsetStore.Save(ctx, *Marks)`, `OffsetStore.Load(ctx) (*Marks, error)`. Do this task first — retrofitting it later means editing six files twice.
+
+Two behaviours move into the type rather than being repeated by callers:
+
+- **`Advance` only moves forward.** The rule currently sits inline in `turbine.mark()`; a partition never goes backwards, so a redelivery cannot rewind a committed position.
+- **`Each` iterates in sorted order**, topic then partition. Map iteration is random, and unsorted output makes `/stats` JSON and `sqlflow stats` diffs unreadable between runs.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zeebo/assert"
+)
+
+// Advance carries the invariant that a partition only moves forward, so a
+// redelivered message cannot rewind a position that has already been
+// committed.
+func TestMarks_AdvanceNeverGoesBackwards(t *testing.T) {
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 1})
+	m.Advance("events", 0, Mark{Offset: 4, LeaderEpoch: 1})
+
+	got, ok := m.Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(10), got.Offset)
+}
+
+func TestMarks_AdvanceMovesForward(t *testing.T) {
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 4, LeaderEpoch: 1})
+	m.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 2})
+
+	got, _ := m.Get("events", 0)
+	assert.Equal(t, int64(10), got.Offset)
+	assert.Equal(t, int32(2), got.LeaderEpoch)
+}
+
+func TestMarks_TracksPartitionsIndependently(t *testing.T) {
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 5})
+	m.Advance("events", 1, Mark{Offset: 99})
+	m.Advance("other", 0, Mark{Offset: 1})
+
+	assert.Equal(t, 3, m.Len())
+	p0, _ := m.Get("events", 0)
+	p1, _ := m.Get("events", 1)
+	assert.Equal(t, int64(5), p0.Offset)
+	assert.Equal(t, int64(99), p1.Offset)
+}
+
+func TestMarks_EmptyAndMissing(t *testing.T) {
+	m := NewMarks()
+	assert.That(t, m.Empty())
+	assert.Equal(t, 0, m.Len())
+
+	_, ok := m.Get("nope", 0)
+	assert.That(t, !ok)
+
+	m.Advance("events", 0, Mark{Offset: 1})
+	assert.That(t, !m.Empty())
+}
+
+// Sorted iteration keeps /stats output and CLI diffs stable between runs;
+// map order would shuffle them.
+func TestMarks_EachIteratesInSortedOrder(t *testing.T) {
+	m := NewMarks()
+	m.Advance("zeta", 0, Mark{Offset: 1})
+	m.Advance("alpha", 2, Mark{Offset: 2})
+	m.Advance("alpha", 0, Mark{Offset: 3})
+
+	var order []string
+	m.Each(func(topic string, partition int32, mark Mark) {
+		order = append(order, fmt.Sprintf("%s/%d", topic, partition))
+	})
+	assert.Equal(t, []string{"alpha/0", "alpha/2", "zeta/0"}, order)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestMarks -v`
+Expected: FAIL — `undefined: NewMarks`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/core/marks.go`. `Advance` creates the inner map on first use and compares against any existing mark. `Each` collects topics, `sort.Strings` them, then collects and sorts each topic's partitions before calling `fn`. Keep the map unexported so the invariant cannot be bypassed.
+
+Then replace the nested map at all nine sites. `Turbine.marks` becomes `*Marks`, initialised in `NewTurbine`; `turbine.mark()` becomes a call to `t.marks.Advance(...)` and loses its inline comparison; `commitSource` checks `t.marks.Empty()`. In `kafka.Source.CommitMarks`, build the `kgo` offsets inside `marks.Each(...)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/... && go test ./internal/kafka/ -count=1`
+Expected: PASS. `TestConsumeLoop_CommitsOnlyProcessedMarks` and `TestConsumeLoop_MarksTrackEachPartition` must still pass — they are the regression gate for #154 and this refactor must not weaken them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/ && go vet ./...
+git add internal/core/marks.go internal/core/marks_test.go internal/core/turbine.go internal/core/turbine_test.go internal/kafka/source.go internal/kafka/source_test.go
+git commit -m "refactor(core): introduce a Marks type for per-partition positions"
+```
+
+---
+
+## Task 1: Open DuckDB on a path
+
+**Files:**
+- Modify: `internal/duckdb/open.go`
+- Test: `internal/duckdb/open_test.go` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+
+```go
+// DB owns the ADBC database handle so more than one connection can be opened
+// against the same file. Today's Open discards that handle, which makes a
+// second connection impossible -- and a second connection is what lets stats
+// be read without disturbing the writer (fact 8).
+type DB struct { /* adbc.Database, path */ }
+
+func OpenPath(ctx context.Context, path string) (*DB, error)
+func (d *DB) Connect(ctx context.Context) (adbc.Connection, error)
+func (d *DB) Path() string
+func (d *DB) Close() error
+```
+
+An empty `path` is in-memory. `func Open(ctx context.Context) (adbc.Connection, error)` is retained for callers that want one connection and no handle: it calls `OpenPath(ctx, "")` then `Connect`. Every existing caller keeps compiling.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package duckdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zeebo/assert"
+)
+
+func exec(t *testing.T, conn interface {
+	NewStatement() (interface {
+		SetSqlQuery(string) error
+		ExecuteUpdate(context.Context) (int64, error)
+		Close() error
+	}, error)
+}, sql string) {
+	t.Helper()
+}
+
+// A pipeline that declares a state path must get a DuckDB backed by that file,
+// so window state survives the process. In-memory state is lost on a crash
+// while its offsets are already committed.
+func TestOpenPath_PersistsAcrossConnections(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.db")
+
+	db, err := OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+
+	stmt, err := conn.NewStatement()
+	assert.NoError(t, err)
+	assert.NoError(t, stmt.SetSqlQuery("CREATE TABLE agg (city VARCHAR, n INTEGER); INSERT INTO agg VALUES ('NYC', 7)"))
+	_, err = stmt.ExecuteUpdate(context.Background())
+	assert.NoError(t, err)
+	stmt.Close()
+	conn.Close()
+
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr)
+
+	// A second process opening the same file sees the committed row.
+	db2, err := OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	defer db2.Close()
+	conn2, err := db2.Connect(context.Background())
+	assert.NoError(t, err)
+	defer conn2.Close()
+
+	stmt2, err := conn2.NewStatement()
+	assert.NoError(t, err)
+	defer stmt2.Close()
+	assert.NoError(t, stmt2.SetSqlQuery("SELECT n FROM agg WHERE city = 'NYC'"))
+	reader, _, err := stmt2.ExecuteQuery(context.Background())
+	assert.NoError(t, err)
+	defer reader.Release()
+
+	got := int64(-1)
+	for reader.Next() {
+		rec := reader.Record()
+		if rec.NumRows() > 0 {
+			got = rec.Column(0).(interface{ Value(int) int32 }).Value(0) != 0 &&
+				true == true // replaced below
+		}
+	}
+	_ = got
+}
+
+// An empty path keeps today's in-memory behaviour, so existing configs are
+// unaffected.
+func TestOpenPath_EmptyPathIsInMemory(t *testing.T) {
+	db, err := OpenPath(context.Background(), "")
+	assert.NoError(t, err)
+	defer db.Close()
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	stmt, err := conn.NewStatement()
+	assert.NoError(t, err)
+	defer stmt.Close()
+	assert.NoError(t, stmt.SetSqlQuery("CREATE TABLE t (i INTEGER)"))
+	_, err = stmt.ExecuteUpdate(context.Background())
+	assert.NoError(t, err)
+}
+```
+
+Replace the awkward scan in the first test with the helper style already used in `internal/managers/tumbling_test.go:58` (`countRows`), which reads an `*array.Int64` column directly. Copy that helper into this file rather than exporting it; it is four lines and cross-package test helpers are not worth the coupling. The assertion is `assert.Equal(t, int64(7), got)`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/duckdb/ -run TestOpenPath -v`
+Expected: FAIL — `undefined: OpenPath`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// OpenPath returns a DuckDB connection over ADBC. A non-empty path opens that
+// file, so tables created on the connection outlive the process; an empty path
+// is in-memory, which is the historical behaviour.
+// DB owns the ADBC database handle. Holding it is what allows a second
+// connection against the same file, which is how stats are read without
+// disturbing the writer: connections see snapshot-isolated committed state.
+type DB struct {
+	db   adbc.Database
+	path string
+}
+
+// OpenPath opens a DuckDB database. A non-empty path is a file, so tables
+// outlive the process; an empty path is in-memory, the historical behaviour.
+func OpenPath(ctx context.Context, path string) (*DB, error) {
+	opts := map[string]string{
+		"driver":     LibPath(),
+		"entrypoint": "duckdb_adbc_init",
+	}
+	if path != "" {
+		opts["path"] = path
+	}
+
+	var drv drivermgr.Driver
+	database, err := drv.NewDatabase(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize DuckDB driver: %w", err)
+	}
+	return &DB{db: database, path: path}, nil
+}
+
+// Connect opens one connection. Each connection has its own transaction
+// state, so a reader never sees a writer's uncommitted batch.
+func (d *DB) Connect(ctx context.Context) (adbc.Connection, error) {
+	conn, err := d.db.Open(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open DuckDB connection: %w", err)
+	}
+	return conn, nil
+}
+
+func (d *DB) Path() string { return d.path }
+
+func (d *DB) Close() error { return d.db.Close() }
+
+// Open returns a single in-memory DuckDB connection, for callers that want no
+// handle of their own.
+func Open(ctx context.Context) (adbc.Connection, error) {
+	db, err := OpenPath(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	return db.Connect(ctx)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/duckdb/ -v`
+Expected: PASS, both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/duckdb/ && go vet ./internal/duckdb/
+git add internal/duckdb/open.go internal/duckdb/open_test.go
+git commit -m "feat(duckdb): open on a file path for durable state"
+```
+
+---
+
+## Task 2: Config gains `pipeline.state.path`
+
+**Files:**
+- Modify: `internal/config/config.go` (the `Pipeline` struct, near `FlushIntervalSeconds` at line 177)
+- Test: `internal/config/load_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Pipeline.State *StateConf` where `type StateConf struct { Path string \`yaml:"path"\` }`. Nil when the block is absent.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// A pipeline may name a file for its DuckDB state. Absent, state stays in
+// memory and is lost on a crash.
+func TestLoad_StatePath(t *testing.T) {
+	conf := loadString(t, `
+pipeline:
+  batch_size: 10
+  state:
+    path: /var/lib/sqlflow/state.db
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      topics: [t]
+  handler:
+    type: handlers.InferredMemBatch
+    sql: SELECT 1
+  sink:
+    type: noop
+`)
+	assert.That(t, conf.Pipeline.State != nil)
+	assert.Equal(t, "/var/lib/sqlflow/state.db", conf.Pipeline.State.Path)
+}
+
+func TestLoad_StateAbsentIsNil(t *testing.T) {
+	conf := loadString(t, `
+pipeline:
+  batch_size: 10
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      topics: [t]
+  handler:
+    type: handlers.InferredMemBatch
+    sql: SELECT 1
+  sink:
+    type: noop
+`)
+	assert.That(t, conf.Pipeline.State == nil)
+}
+```
+
+`loadString` may not exist. If not, write it beside these tests: it writes the YAML to `t.TempDir()` and calls `Load(path, nil)`, mirroring `renderString` at `internal/config/load_test.go:12`. Parsing is strict, so an unknown key is an error — that is what makes the second test meaningful.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestLoad_State -v`
+Expected: FAIL — strict parsing rejects the unknown `state` key.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// StateConf points the pipeline's DuckDB at a file, so tables the handler
+// writes -- window state above all -- survive a restart. Offsets are stored in
+// the same database, which is what makes state and offsets recoverable
+// together.
+type StateConf struct {
+	Path string `yaml:"path"`
+}
+```
+
+and on `Pipeline`, beside `FlushIntervalSeconds`:
+
+```go
+	State *StateConf `yaml:"state,omitempty"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -v`
+Expected: PASS. `TestLoad_AllExampleConfigs` must still pass — it walks every shipped config.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/config/ && go vet ./internal/config/
+git add internal/config/config.go internal/config/load_test.go
+git commit -m "feat(config): add pipeline.state.path"
+```
+
+---
+
+## Task 3: The offset store
+
+**Files:**
+- Create: `internal/core/offsets.go`
+- Test: `internal/core/offsets_test.go`
+
+**Interfaces:**
+- Consumes: `core.Mark` (`internal/core/turbine.go`), an `adbc.Connection`.
+- Produces:
+
+```go
+type OffsetStore struct { /* conn */ }
+func NewOffsetStore(conn adbc.Connection) *OffsetStore
+func (s *OffsetStore) Init(ctx context.Context) error
+func (s *OffsetStore) Save(ctx context.Context, marks *Marks) error
+func (s *OffsetStore) Load(ctx context.Context) (*Marks, error)
+```
+
+`Init` is idempotent (`CREATE TABLE IF NOT EXISTS`). `Save` upserts one row per topic/partition. `Save` must **not** commit — the caller owns the transaction. Table:
+
+```sql
+CREATE TABLE IF NOT EXISTS sqlflow_offsets (
+    topic        VARCHAR NOT NULL,
+    partition    INTEGER NOT NULL,
+    offset       BIGINT  NOT NULL,
+    leader_epoch INTEGER NOT NULL,
+    PRIMARY KEY (topic, partition)
+)
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/duckdb"
+	"github.com/zeebo/assert"
+)
+
+func newStateConn(t *testing.T, path string) adbc.Connection {
+	t.Helper()
+	if os.Getenv("SQLFLOW_DUCKDB_LIB") == "" {
+		os.Setenv("SQLFLOW_DUCKDB_LIB", "/opt/homebrew/lib/libduckdb.dylib")
+	}
+	db, err := duckdb.OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	t.Cleanup(func() { conn.Close(); db.Close() })
+	return conn
+}
+
+// Offsets round-trip through DuckDB, which is what lets a restart resume from
+// the position that produced the state currently in the database.
+func TestOffsetStore_RoundTrip(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+
+	in := NewMarks()
+	in.Advance("events", 0, Mark{Offset: 41, LeaderEpoch: 7})
+	in.Advance("events", 1, Mark{Offset: 8, LeaderEpoch: 7})
+	assert.NoError(t, s.Save(context.Background(), in))
+
+	out, err := s.Load(context.Background())
+	assert.NoError(t, err)
+	p0, ok := out.Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(41), p0.Offset)
+	assert.Equal(t, int32(7), p0.LeaderEpoch)
+	p1, _ := out.Get("events", 1)
+	assert.Equal(t, int64(8), p1.Offset)
+}
+
+// Saving the same partition again advances it rather than duplicating it.
+func TestOffsetStore_SaveIsAnUpsert(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+
+	first := NewMarks(); first.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 1})
+	assert.NoError(t, s.Save(context.Background(), first))
+	second := NewMarks(); second.Advance("events", 0, Mark{Offset: 99, LeaderEpoch: 2})
+	assert.NoError(t, s.Save(context.Background(), second))
+
+	out, err := s.Load(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, out.Len())
+	got, _ := out.Get("events", 0)
+	assert.Equal(t, int64(99), got.Offset)
+	assert.Equal(t, int32(2), got.LeaderEpoch)
+}
+
+// A fresh state file has no offsets; the caller must treat that as "start
+// where auto_offset_reset says", not as offset zero.
+func TestOffsetStore_LoadEmptyIsEmptyNotZero(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+
+	out, err := s.Load(context.Background())
+	assert.NoError(t, err)
+	assert.That(t, out.Empty())
+}
+
+// Init runs on every start, including against an existing state file.
+func TestOffsetStore_InitIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+	assert.NoError(t, s.Init(context.Background()))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/core/ -run TestOffsetStore -v`
+Expected: FAIL — `undefined: NewOffsetStore`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/core/offsets.go`. Notes that will otherwise cost time:
+
+- `offset` and `partition` are not reserved in DuckDB, but quote the column names anyway (`"offset"`) — it reads as a keyword to anyone scanning the SQL.
+- Execute writes with `stmt.ExecuteUpdate`; read with `stmt.ExecuteQuery` and iterate the `array.RecordReader` exactly as `internal/managers/tumbling.go:132` does.
+- Columns come back as `*array.String`, `*array.Int32`, `*array.Int64`, `*array.Int32`. Assert those types; a wrong cast panics at runtime rather than failing to compile.
+- Use `INSERT INTO … ON CONFLICT (topic, partition) DO UPDATE SET "offset" = EXCLUDED."offset", leader_epoch = EXCLUDED.leader_epoch`, which the tumbling window example already relies on.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/core/ -run TestOffsetStore -v`
+Expected: PASS, all four.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/core/ && go vet ./internal/core/
+git add internal/core/offsets.go internal/core/offsets_test.go
+git commit -m "feat(core): store Kafka offsets in DuckDB"
+```
+
+---
+
+## Task 4: Transactional batch
+
+**Files:**
+- Modify: `internal/core/turbine.go` (`processBatch`, and the `Turbine` struct)
+- Test: `internal/core/turbine_test.go`
+
+**Interfaces:**
+- Consumes: `OffsetStore` from Task 3.
+- Produces: `NewTurbine` gains a `WithStateStore(store *OffsetStore, conn adbc.Connection)` option. When set, `processBatch` runs transactionally.
+
+**Ordering — get this right, it is the whole point.** Within one batch:
+
+1. `handler.Invoke` — user SQL runs, mutating state inside the open transaction.
+2. `sink.WriteTable` + `sink.Flush` — the external sink is flushed **before** the transaction commits, so a crash here replays the batch. External sinks stay at-least-once and may duplicate.
+3. `offsets.Save` — the marks go into `sqlflow_offsets`, still inside the transaction.
+4. `conn.Commit(ctx)` — state and offsets become durable together.
+5. `source.CommitMarks` — Kafka commit, now advisory, for lag dashboards.
+
+Any failure before step 4 calls `conn.Rollback(ctx)` and returns the error; the batch is replayed on restart. A failure at step 5 is logged, not fatal: the authoritative offsets are already durable.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// txConn records the transaction calls the pipeline makes, so the ordering
+// that makes state and offsets atomic can be asserted.
+type txConn struct {
+	adbc.Connection
+	events *[]string
+}
+
+func (c *txConn) Commit(ctx context.Context) error {
+	*c.events = append(*c.events, "commit")
+	return nil
+}
+
+func (c *txConn) Rollback(ctx context.Context) error {
+	*c.events = append(*c.events, "rollback")
+	return nil
+}
+
+// The external sink must flush before the transaction commits: a crash
+// between them replays the batch (a duplicate, which is at-least-once) rather
+// than committing offsets for rows the sink never received.
+func TestProcessBatch_FlushesSinkBeforeCommittingState(t *testing.T) {
+	var events []string
+	sink := &orderingSink{events: &events}
+	store := &fakeOffsetStore{events: &events}
+	conn := &txConn{events: &events}
+
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	tb := NewTurbine(src, &fakeHandler{}, sink, 4, time.Second, &sync.Mutex{},
+		PipelineErrorPolicies{}, WithStateStore(store, conn))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"flush", "save-offsets", "commit"}, events)
+}
+
+// A sink failure must roll the transaction back, leaving the offsets on disk
+// where they were so the batch is replayed.
+func TestProcessBatch_RollsBackWhenSinkFails(t *testing.T) {
+	var events []string
+	sink := &failingSink{events: &events}
+	store := &fakeOffsetStore{events: &events}
+	conn := &txConn{events: &events}
+
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	tb := NewTurbine(src, &fakeHandler{}, sink, 4, time.Second, &sync.Mutex{},
+		PipelineErrorPolicies{}, WithStateStore(store, conn))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.Error(t, err)
+	assert.Equal(t, []string{"flush-failed", "rollback"}, events)
+}
+
+// Without a state store the pipeline behaves exactly as before: no
+// transaction calls at all.
+func TestProcessBatch_NoStateStoreIsUnchanged(t *testing.T) {
+	var events []string
+	sink := &orderingSink{events: &events}
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	tb := newTestTurbine(src, &fakeHandler{}, sink, 4)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"flush"}, events)
+	assert.Equal(t, 1, len(src.marks))
+}
+```
+
+Write `orderingSink`, `failingSink` and `fakeOffsetStore` beside these — each appends its label to the shared slice. `fakeOffsetStore` needs the same method set the real store exposes to the pipeline; extract a small `offsetSaver` interface (`Save(ctx, marks) error`) in `turbine.go` so the fake does not need a real DuckDB connection.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/core/ -run TestProcessBatch -v`
+Expected: FAIL — `undefined: WithStateStore`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `Turbine`: `offsets offsetSaver`, `stateConn interface{ Commit(context.Context) error; Rollback(context.Context) error }`. Add the option. In `processBatch`, wrap the existing body: after the flush succeeds, call `t.offsets.Save(ctx, t.marks)`, then `t.stateConn.Commit(ctx)`; on any error before that, `t.stateConn.Rollback(ctx)`. Leave every path unchanged when `t.offsets == nil`.
+
+Autocommit is disabled once, at startup, in Task 6 — not per batch. `Commit(ctx)` on an ADBC connection with autocommit disabled begins the next transaction implicitly (fact 4).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/core/ -v`
+Expected: PASS, including every pre-existing test in the package.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/core/ && go vet ./internal/core/
+git add internal/core/turbine.go internal/core/turbine_test.go
+git commit -m "feat(core): commit state and offsets in one transaction"
+```
+
+---
+
+## Task 5: Seek Kafka to stored offsets
+
+**Files:**
+- Modify: `internal/kafka/source.go`
+- Test: `internal/kafka/source_test.go`
+
+**Interfaces:**
+- Consumes: `core.Mark`.
+- Produces: `func (k *Source) SeekTo(marks *core.Marks) error`. Called before `Start`. Empty marks is a no-op, leaving `auto_offset_reset` to decide.
+
+Use `kgo.Client.SetOffsets(map[string]map[int32]kgo.EpochOffset)` with `Offset: mark.Offset + 1` and `Epoch: mark.LeaderEpoch` — the same `+1` convention as `CommitMarks`, since a mark names the last *processed* offset.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// A restart must resume from the offsets in DuckDB, not from wherever the
+// consumer group happens to be, because the state file is the source of truth.
+func TestSource_SeekToResumesFromStoredOffsets(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-seek-%d", time.Now().UnixNano())
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	produce(t, client, topic, 100)
+
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	// Resume as though offset 49 had been processed: the next record read
+	// must be 50.
+	resume := core.NewMarks()
+	resume.Advance(topic, 0, core.Mark{Offset: 49, LeaderEpoch: 0})
+	assert.NoError(t, src.SeekTo(resume))
+
+	select {
+	case batch := <-src.Stream():
+		assert.That(t, len(batch) >= 1)
+		assert.Equal(t, int64(50), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for a message")
+	}
+}
+
+// No stored offsets means no seek, so auto_offset_reset still governs a first
+// run against a fresh state file.
+func TestSource_SeekToEmptyIsANoop(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-seek-empty-%d", time.Now().UnixNano())
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	produce(t, client, topic, 3)
+
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	assert.NoError(t, src.SeekTo(nil))
+
+	select {
+	case batch := <-src.Stream():
+		assert.Equal(t, int64(0), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for a message")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/kafka/ -run TestSource_SeekTo -v`
+Expected: FAIL — `undefined: SeekTo`. If no broker is reachable the test skips; start one with `make start-backing-services` before claiming a result.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// SeekTo resumes consumption from positions recorded in the state database.
+// The stored mark is the last offset processed, so consumption resumes at the
+// next one, exactly as CommitMarks commits it.
+func (k *Source) SeekTo(marks *core.Marks) error {
+	if marks == nil || marks.Empty() {
+		return nil
+	}
+	offsets := make(map[string]map[int32]kgo.EpochOffset, marks.Len())
+	marks.Each(func(topic string, partition int32, m core.Mark) {
+		if offsets[topic] == nil {
+			offsets[topic] = map[int32]kgo.EpochOffset{}
+		}
+		offsets[topic][partition] = kgo.EpochOffset{Epoch: m.LeaderEpoch, Offset: m.Offset + 1}
+	})
+	k.client.SetOffsets(offsets)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/kafka/ -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/kafka/ && go vet ./internal/kafka/
+git add internal/kafka/source.go internal/kafka/source_test.go
+git commit -m "feat(kafka): seek to offsets stored in DuckDB"
+```
+
+---
+
+## Task 5b: Consumer lag
+
+**Files:**
+- Modify: `internal/kafka/source.go` (the `EachRecord` loop, ~line 130), `internal/core/metrics.go`, `internal/core/turbine.go`
+- Test: `internal/kafka/source_test.go`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `core.Message` gains `HighWatermark int64`. `Metrics` gains `ConsumerLag metric.Int64Gauge`, recorded per topic/partition with those attributes.
+
+Lag is `HighWatermark - Offset` for the last record the pipeline processed. Fact 7: the watermark is on the fetch, so this costs nothing. Record it in `mark()`, where the last processed offset is already known.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// Lag is only meaningful against the broker's high watermark, which arrives
+// on the fetch itself. Without it, an operator cannot tell a healthy pipeline
+// from one falling behind.
+func TestSource_MessagesCarryHighWatermark(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-hwm-%d", time.Now().UnixNano())
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	produce(t, client, topic, 10)
+
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	select {
+	case batch := <-src.Stream():
+		assert.That(t, len(batch) >= 1)
+		// Ten records were produced, so the high watermark is 10 and the
+		// first record sits 9 behind it.
+		assert.Equal(t, int64(10), batch[0].HighWatermark)
+		assert.Equal(t, int64(0), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for a message")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/kafka/ -run TestSource_MessagesCarryHighWatermark -v`
+Expected: FAIL — `batch[0].HighWatermark undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `core.Message` add `HighWatermark int64` with a comment that it is the partition's high watermark at fetch time, zero for sources without one. In the source, the record loop is inside `fetches.EachRecord`, which does not expose the partition — switch to `fetches.EachPartition(func(p kgo.FetchTopicPartition) { ... })` so `p.HighWatermark` is in scope, and append records from `p.Records`. Keep the resulting `[]core.Message` ordering identical.
+
+In `metrics.go`, add:
+
+```go
+	m.ConsumerLag, err = meter.Int64Gauge(
+		"consumer_lag",
+		metric.WithDescription("Messages between the last one processed and the partition's high watermark"),
+		metric.WithUnit("messages"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("consumer_lag: %w", err)
+	}
+```
+
+In `turbine.mark()`, after recording the mark:
+
+```go
+	if m.HighWatermark > 0 {
+		t.metrics.ConsumerLag.Record(context.Background(), m.HighWatermark-m.Offset-1,
+			metric.WithAttributes(
+				attribute.String("topic", m.Topic),
+				attribute.Int("partition", int(m.Partition)),
+			))
+	}
+```
+
+`-1` because a mark names the last *processed* offset: having processed offset 9 with a watermark of 10 is lag zero.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/kafka/ -count=1 -v && SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/core/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/ && go vet ./...
+git add internal/kafka/source.go internal/kafka/source_test.go internal/core/metrics.go internal/core/turbine.go
+git commit -m "feat(metrics): report consumer lag from the fetch high watermark"
+```
+
+---
+
+## Task 5c: State stats — the snapshot both consumers render
+
+**Files:**
+- Create: `internal/core/stats.go`, `internal/core/stats_test.go`
+- Modify: `internal/core/metrics.go`
+
+**Interfaces:**
+- Consumes: `OffsetStore`, an `adbc.Connection`.
+- Produces:
+
+```go
+type TableStat struct {
+	Name string `json:"name"`
+	Rows int64  `json:"rows"`
+}
+
+type OffsetStat struct {
+	Topic       string `json:"topic"`
+	Partition   int32  `json:"partition"`
+	Offset      int64  `json:"offset"`
+	LeaderEpoch int32  `json:"leader_epoch"`
+}
+
+type StateStats struct {
+	Path      string       `json:"path"`
+	SizeBytes int64        `json:"size_bytes"`
+	Tables    []TableStat  `json:"tables"`
+	Offsets   []OffsetStat `json:"offsets"`
+}
+
+func CollectStateStats(ctx context.Context, conn adbc.Connection, path string) (*StateStats, error)
+```
+
+`Tables` excludes `sqlflow_offsets` and the transient `batch` table — those are engine bookkeeping, not user state. Row counts come from `duckdb_tables()`; sizes from `os.Stat(path)`. `Metrics` gains `StateSizeBytes` and `StateTableRows` gauges recorded from the same struct, so the Prometheus numbers and the JSON can never disagree.
+
+**The connection passed here is a dedicated reader**, obtained from `DB.Connect` and never the one the pipeline writes on. Per fact 8 it sees only committed state, so `count(*)` here cannot read a half-written batch and cannot block the writer. Do not take the pipeline's DuckDB mutex in this function; it is the wrong lock and holding it would let a scraper stall throughput.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// The stats snapshot is what an operator reads to answer "is my state growing
+// without bound, and how far behind am I?" It must report the user's tables
+// and the stored offsets, and must not leak engine bookkeeping tables.
+func TestCollectStateStats(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.db")
+	conn := newStateConn(t, path)
+
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+	saved := NewMarks()
+	saved.Advance("events", 0, Mark{Offset: 41, LeaderEpoch: 7})
+	assert.NoError(t, s.Save(context.Background(), saved))
+
+	exec(t, conn, "CREATE TABLE agg (city VARCHAR, n INTEGER)")
+	exec(t, conn, "INSERT INTO agg VALUES ('NYC', 1), ('SF', 2), ('LA', 3)")
+
+	stats, err := CollectStateStats(context.Background(), conn, path)
+	assert.NoError(t, err)
+
+	assert.Equal(t, path, stats.Path)
+	assert.That(t, stats.SizeBytes > 0)
+
+	assert.Equal(t, 1, len(stats.Tables))
+	assert.Equal(t, "agg", stats.Tables[0].Name)
+	assert.Equal(t, int64(3), stats.Tables[0].Rows)
+
+	assert.Equal(t, 1, len(stats.Offsets))
+	assert.Equal(t, "events", stats.Offsets[0].Topic)
+	assert.Equal(t, int64(41), stats.Offsets[0].Offset)
+}
+
+// Stats read a dedicated connection, so an in-flight batch is invisible until
+// it commits. Without this the endpoint would report rows that a rollback
+// then erased, and a durability feature would be reporting numbers that never
+// survived anything.
+func TestCollectStateStats_DoesNotSeeUncommittedWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := duckdb.OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	writer, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer writer.Close()
+	reader, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer reader.Close()
+
+	assert.NoError(t, NewOffsetStore(writer).Init(context.Background()))
+	exec(t, writer, "CREATE TABLE agg (city VARCHAR)")
+	exec(t, writer, "INSERT INTO agg VALUES ('NYC')")
+
+	// The writer goes transactional and adds a row it has not committed.
+	po, ok := writer.(adbc.PostInitOptions)
+	assert.That(t, ok)
+	assert.NoError(t, po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+	exec(t, writer, "INSERT INTO agg VALUES ('SF')")
+
+	stats, err := CollectStateStats(context.Background(), reader, path)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Tables[0].Rows)
+
+	// After the commit the reader sees it.
+	assert.NoError(t, writer.(interface {
+		Commit(context.Context) error
+	}).Commit(context.Background()))
+
+	stats, err = CollectStateStats(context.Background(), reader, path)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), stats.Tables[0].Rows)
+}
+
+// An empty state file reports zero tables rather than failing, so `stats` is
+// useful on a pipeline that has not processed anything yet.
+func TestCollectStateStats_EmptyState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
+
+	stats, err := CollectStateStats(context.Background(), conn, path)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(stats.Tables))
+	assert.Equal(t, 0, len(stats.Offsets))
+}
+```
+
+`exec` is the helper at `internal/managers/tumbling_test.go:41`; copy it into `internal/core` rather than exporting it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/core/ -run TestCollectStateStats -v`
+Expected: FAIL — `undefined: CollectStateStats`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+List tables with `SELECT table_name FROM duckdb_tables() WHERE schema_name = 'main' ORDER BY table_name`, skipping `sqlflow_offsets` and `batch`. Count each with `SELECT count(*) FROM "<name>"` — quote the identifier, a user table may be named anything. Read offsets through `OffsetStore.Load` rather than a second query, so there is one definition of that schema.
+
+Sort `Offsets` by topic then partition; map iteration order is random and unsorted JSON makes diffs unreadable.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/core/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/core/ && go vet ./internal/core/
+git add internal/core/stats.go internal/core/stats_test.go internal/core/metrics.go
+git commit -m "feat(core): collect state stats for metrics and the stats endpoint"
+```
+
+---
+
+## Task 5d: Serve `/stats`, and record state gauges
+
+**Files:**
+- Modify: `internal/cli/run/metrics.go` (it already builds the OTel Prometheus exporter, owns the registry and the mux, and registers `/metrics` at line 35 — `/stats` joins it there), `internal/core/turbine.go` (`StatusLoop`)
+
+**Interfaces:**
+- Consumes: `CollectStateStats`.
+- Produces: the existing metrics-server constructor gains a `stats func() (*core.StateStats, error)` parameter and registers `/stats` on the same mux. Do **not** create a second server or a second port.
+
+`/stats` returns the `StateStats` JSON plus the counters the pipeline already tracks:
+
+```json
+{
+  "pipeline": "nyc-taxi-clickhouse",
+  "messages_consumed": 1000,
+  "num_errors": 0,
+  "state": {"path": "/state/state.db", "size_bytes": 274432,
+            "tables": [{"name": "agg", "rows": 24}],
+            "offsets": [{"topic": "events", "partition": 0, "offset": 999, "leader_epoch": 7}]}
+}
+```
+
+A pipeline with no `state.path` returns `"state": null` rather than erroring — the endpoint is still useful for counters.
+
+`StatusLoop` already ticks every five seconds (`turbine.go:215`). Reuse it: collect stats on that tick and record `StateSizeBytes` and `StateTableRows`. Do not add a second ticker.
+
+**Concurrency.** Collection runs on the dedicated reader connection from Task 5c, so it needs neither the pipeline's mutex nor any coordination with the writer. It does need its own mutex: `StatusLoop` and any number of concurrent `/stats` requests share that one reader connection, and a single ADBC connection is not safe for concurrent use. Guard the reader, not the pipeline.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package run
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/zeebo/assert"
+)
+
+// An operator cannot read the state file while the pipeline holds it -- DuckDB
+// takes an exclusive lock -- so the running process has to serve its own
+// stats.
+func TestServeHTTP_StatsEndpoint(t *testing.T) {
+	want := &core.StateStats{
+		Path: "/state/state.db", SizeBytes: 4096,
+		Tables:  []core.TableStat{{Name: "agg", Rows: 24}},
+		Offsets: []core.OffsetStat{{Topic: "events", Partition: 0, Offset: 999, LeaderEpoch: 7}},
+	}
+	srv := serveHTTP("127.0.0.1:0", nil, func() (*core.StateStats, error) { return want, nil })
+	defer srv.Close()
+
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	state := got["state"].(map[string]any)
+	assert.Equal(t, "/state/state.db", state["path"])
+	assert.Equal(t, float64(24), state["tables"].([]any)[0].(map[string]any)["rows"])
+}
+
+// A pipeline without a state path still answers, with a null state block.
+func TestServeHTTP_StatsWithoutState(t *testing.T) {
+	srv := serveHTTP("127.0.0.1:0", nil, func() (*core.StateStats, error) { return nil, nil })
+	defer srv.Close()
+
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.That(t, got["state"] == nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cli/run/ -run TestServeHTTP -v`
+Expected: FAIL — `undefined: serveHTTP`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Build an `http.ServeMux`, register the Prometheus handler at `/metrics` when `reg != nil`, and `/stats` always. Return the `*http.Server` without calling `ListenAndServe` — the test drives `Handler` directly and the caller starts it in a goroutine.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cli/run/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/cli/ && go vet ./...
+git add internal/cli/run/metrics.go internal/cli/run/root.go internal/core/turbine.go
+git commit -m "feat(run): serve /stats and record state gauges"
+```
+
+---
+
+## Task 5e: `sqlflow stats` for a stopped pipeline
+
+> **Scope note.** This is the weakest task in the plan: it only works when the
+> pipeline is *not* running, which is when you are least likely to be
+> debugging. `/metrics` and `/stats` cover the live case, and a stopped
+> pipeline's state file can be read with the `duckdb` CLI directly. Cut this
+> first if scope needs cutting; the README line pointing at `duckdb` costs
+> nothing.
+
+**Files:**
+- Create: `internal/cli/stats/root.go`, `internal/cli/stats/root_test.go`
+- Modify: `internal/cli/root.go` (register the command)
+
+**Interfaces:**
+- Consumes: `config.Load`, `duckdb.OpenPath`, `CollectStateStats`.
+- Produces: `sqlflow stats -c <config> [--json]`.
+
+Reads `pipeline.state.path` from the config and opens that file. **The lock is the interesting case:** if the pipeline is running, the open fails with `Could not set lock on file`. Detect that substring and replace it with something actionable rather than passing DuckDB's error through.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// Reading a stopped pipeline's state is the offline half of observability.
+func TestStats_ReadsAStoppedPipelinesState(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.db")
+
+	db, err := duckdb.OpenPath(context.Background(), statePath)
+	assert.NoError(t, err)
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	store := core.NewOffsetStore(conn)
+	assert.NoError(t, store.Init(context.Background()))
+	saved := core.NewMarks()
+	saved.Advance("events", 0, core.Mark{Offset: 41, LeaderEpoch: 7})
+	assert.NoError(t, store.Save(context.Background(), saved))
+	execSQL(t, conn, "CREATE TABLE agg (city VARCHAR)")
+	execSQL(t, conn, "INSERT INTO agg VALUES ('NYC')")
+	conn.Close()
+	db.Close()
+
+	cfg := writeConfig(t, dir, statePath)
+
+	var out bytes.Buffer
+	assert.NoError(t, runStats(context.Background(), cfg, true, &out))
+
+	var got core.StateStats
+	assert.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, int64(1), got.Tables[0].Rows)
+	assert.Equal(t, int64(41), got.Offsets[0].Offset)
+}
+
+// A running pipeline holds an exclusive lock, so this must say what to do
+// instead of surfacing DuckDB's IO error.
+func TestStats_ExplainsTheLockWhenPipelineIsRunning(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.db")
+
+	holderDB, err := duckdb.OpenPath(context.Background(), statePath)
+	assert.NoError(t, err)
+	defer holderDB.Close()
+	holder, err := holderDB.Connect(context.Background())
+	assert.NoError(t, err)
+	defer holder.Close()
+
+	cfg := writeConfig(t, dir, statePath)
+
+	var out bytes.Buffer
+	err = runStats(context.Background(), cfg, true, &out)
+	assert.Error(t, err)
+	assert.That(t, strings.Contains(err.Error(), "appears to be running"))
+	assert.That(t, strings.Contains(err.Error(), "/stats"))
+}
+
+// A config with no state path is an error naming the missing setting, not a
+// crash on an empty path.
+func TestStats_RequiresAStatePath(t *testing.T) {
+	dir := t.TempDir()
+	cfg := writeConfig(t, dir, "")
+
+	var out bytes.Buffer
+	err := runStats(context.Background(), cfg, true, &out)
+	assert.Error(t, err)
+	assert.That(t, strings.Contains(err.Error(), "pipeline.state.path"))
+}
+```
+
+`writeConfig` writes a minimal valid pipeline YAML into `dir`, with `pipeline.state.path` set to the argument and omitted entirely when it is empty. `execSQL` is the same four-line helper as elsewhere.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/cli/stats/ -v`
+Expected: FAIL — package does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+	db, err := duckdb.OpenPath(ctx, conf.Pipeline.State.Path)
+	if err == nil {
+		defer db.Close()
+		_, err = db.Connect(ctx)
+	}
+	if err != nil {
+		if strings.Contains(err.Error(), "Could not set lock on file") {
+			return fmt.Errorf(
+				"the pipeline using %s appears to be running: DuckDB holds an "+
+					"exclusive lock on its state, so it cannot be read from here. "+
+					"Read its /stats endpoint instead (served on the metrics "+
+					"address, :8000 by default), or stop the pipeline",
+				conf.Pipeline.State.Path)
+		}
+		return err
+	}
+```
+
+Default output is a short human-readable summary; `--json` emits `StateStats` verbatim so it can be piped to `jq`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib go test ./internal/cli/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/cli/ && go vet ./...
+git add internal/cli/stats/ internal/cli/root.go
+git commit -m "feat(cli): add sqlflow stats for a stopped pipeline"
+```
+
+---
+
+## Task 6: Wire it together in `run`
+
+**Files:**
+- Modify: `internal/cli/run/root.go` (DuckDB open near the top of the command; `NewTurbine` call around line 191)
+
+**Interfaces:**
+- Consumes: Tasks 1–5.
+- Produces: nothing new; this is the composition root.
+
+Startup order, when `conf.Pipeline.State != nil`:
+
+1. `db, err := duckdb.OpenPath(ctx, conf.Pipeline.State.Path)` instead of `duckdb.Open(ctx)`, then `conn, err := db.Connect(ctx)` for the pipeline's writer. Keep `db` alive for the process lifetime; the stats reader comes from the same handle.
+2. `conn.(adbc.PostInitOptions).SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled)` — **once**, here.
+3. Run `commands` and `tables` DDL as today, then `offsets.Init(ctx)`, then `conn.Commit(ctx)` so setup is durable before consumption starts.
+4. `marks, err := offsets.Load(ctx)`; if the source is Kafka, `src.SeekTo(marks)`.
+5. `NewTurbine(..., WithStateStore(offsets, conn))`.
+
+When `State` is nil, none of this happens and the code path is byte-for-byte today's.
+
+- [ ] **Step 1: Write the failing test**
+
+This is the composition root, so the test is the acceptance test in Task 7. Do not invent a unit test for wiring; skip to Step 3 and let Task 7 gate it.
+
+- [ ] **Step 2: (not applicable)**
+
+- [ ] **Step 3: Write the implementation**
+
+As described above. Two failure modes to handle explicitly rather than discover:
+
+- The state file's directory may not exist. Create it with `os.MkdirAll(filepath.Dir(path), 0o755)` before opening, and fail with a message naming the path.
+- A stored offset may be **before the topic's log start** (retention deleted it) or **past its log end** (topic recreated). `SetOffsets` will not fix this. Log a warning naming the topic, partition and stored offset, and let franz-go's `ConsumeResetOffset` handle it — the behaviour then matches `auto_offset_reset`. Document this in Task 8.
+
+- [ ] **Step 4: Verify by hand before moving on**
+
+```bash
+make sqlflow
+SQLFLOW_DUCKDB_LIB=/opt/homebrew/lib/libduckdb.dylib ./bin/sqlflow run -c <a windowed config with state.path> --max-msgs=100
+duckdb /tmp/sqlflow/state.db -c "SELECT * FROM sqlflow_offsets"
+```
+
+Expected: one row per partition, offsets matching what was consumed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/cli/ && go vet ./...
+git add internal/cli/run/root.go
+git commit -m "feat(run): open state on disk and resume from stored offsets"
+```
+
+---
+
+## Task 7: Crash-recovery acceptance test
+
+**Files:**
+- Modify: `tests/release/test_image.py`
+- Create: `dev/config/examples/kafka.stateful.window.yml`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the test that proves the bug this plan exists to fix is gone.
+
+This is the inverse of the failure recorded in "Established facts" #2.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_window_state_survives_a_crash(image):
+    """A kill mid-window must not lose the aggregate.
+
+    Before durable state, 2,000 events folded into an open window were lost by
+    a SIGKILL while their offsets were already committed: the consumer group
+    showed lag 0 and a restart replayed nothing, so the aggregate was silently
+    short. State and offsets now commit together, so a restart rebuilds it.
+    """
+    topic = f"crash-recovery-{int(time.time())}"
+    network = Network().create()
+
+    kafka_ctr = KafkaContainer()
+    kafka_ctr.with_network(network)
+    kafka_ctr.with_network_aliases("kafka")
+    kafka_ctr.start()
+
+    producer = Producer({"bootstrap.servers": kafka_ctr.get_bootstrap_server()})
+    ts = "2026-09-02T12:00:00.000Z"
+    for i in range(2000):
+        producer.produce(topic, json.dumps(
+            {"timestamp": ts, "properties": {"city": "NYC"}, "user": {"id": str(i)}}))
+    producer.flush()
+
+    with tempfile.TemporaryDirectory() as state_dir:
+        os.chmod(state_dir, 0o777)
+
+        def run_until(n_messages):
+            c = DockerContainer(image) \
+                .with_volume_mapping(settings.DEV_DIR, "/tmp/conf") \
+                .with_volume_mapping(state_dir, "/state") \
+                .with_env("SQLFLOW_KAFKA_BROKERS", "kafka:9092") \
+                .with_network(network) \
+                .with_command(
+                    "run /tmp/conf/config/examples/kafka.stateful.window.yml "
+                    f"--max-msgs={n_messages}")
+            c.start()
+            wait_for_logs(c, "consumer loop ending|max messages consumed", timeout=120)
+            return c
+
+        # First half, then stop -- the window is still open, nothing published.
+        run_until(1000)
+        # Second half in a fresh process, reading the state left behind.
+        run_until(1000)
+
+        conn = duckdb.connect(os.path.join(state_dir, "state.db"), read_only=True)
+        total = conn.execute("SELECT sum(count) FROM agg").fetchone()[0]
+        offsets = conn.execute("SELECT sum(\"offset\") FROM sqlflow_offsets").fetchone()[0]
+
+    # Every event is accounted for across the restart.
+    assert total == 2000, f"aggregate lost rows across the restart: {total}"
+    assert offsets == 1999, f"stored offset should be the last processed: {offsets}"
+```
+
+The config `dev/config/examples/kafka.stateful.window.yml` is the tumbling-window example plus `pipeline.state.path: /state/state.db`, an hour bucket, and a close predicate of `bucket < now() - INTERVAL '1' HOUR` so the window never closes during the test. `duckdb` is already a Python dependency via `requirements.txt`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make sqlflow-image SQLFLOW_IMAGE=turbolytics/sql-flow:statetest && SQLFLOW_IMAGE=turbolytics/sql-flow:statetest pytest tests/release -k crash -v`
+Expected: FAIL. Before Task 6 the image ignores `state.path`; expect the config to be rejected or `state.db` to be absent.
+
+- [ ] **Step 3: (implementation is Tasks 1-6)**
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: the same command, after rebuilding the image.
+Expected: PASS, `total == 2000`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/release/test_image.py dev/config/examples/kafka.stateful.window.yml
+git commit -m "test: window state and offsets survive a restart"
+```
+
+---
+
+## Task 7b: Benchmark the cost of durability
+
+**Files:**
+- Create: `dev/config/examples/benchmark.stateful.mem.yml`
+- Modify: `scripts/benchmark-container.sh` (accept a state path), `README.md` (publish the numbers)
+
+**Interfaces:**
+- Consumes: Tasks 1-6.
+- Produces: a published throughput and memory comparison, in-memory versus disk-backed state.
+
+This design adds a DuckDB transaction commit to every batch. That is a real,
+unmeasured cost on the hot path, and the README currently publishes ~927k
+msgs/sec for `StructuredBatch` with no state. Shipping durability without
+saying what it costs would repeat the mistake this whole plan exists to
+correct: a claim nobody checked.
+
+The benchmark must answer three questions an evaluator will ask.
+
+1. **What does a disk-backed state pipeline cost versus an in-memory one?**
+   Same config, same data, `state.path` set and unset.
+2. **Does `batch_size` change the answer?** One fsync per batch means the cost
+   per message falls as batches grow; at 500 it may dominate, at 5000 it may
+   vanish. The existing harness already sweeps batch size.
+3. **Does state grow the memory footprint?** The README's claim is a flat
+   quarter GiB across handlers and batch sizes. DuckDB backed by a file has a
+   buffer pool; verify the claim still holds or restate it.
+
+- [ ] **Step 1: Write the benchmark config**
+
+`dev/config/examples/benchmark.stateful.mem.yml` is `benchmark.inferred.mem.yml`
+plus a `pipeline.state.path` templated from an environment variable, and a
+windowed `tables.sql` block so the pipeline actually writes state rather than
+just paying for an empty commit:
+
+```yaml
+tables:
+  sql:
+    - name: agg_city_count
+      sql: |
+        CREATE TABLE IF NOT EXISTS agg_city_count (
+          bucket TIMESTAMPTZ, city VARCHAR, count INT
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS agg_city_count_idx
+          ON agg_city_count (bucket, city);
+```
+
+with the handler upserting into it, exactly as `tumbling.window.yml` does. The
+state path comes from `{{ SQLFLOW_STATE_PATH|default('') }}` so one config
+serves both arms of the comparison.
+
+- [ ] **Step 2: Teach the harness a state path**
+
+`scripts/benchmark-container.sh` already takes `NUM_MESSAGES`, `BATCH_SIZE` and
+`CONFIG`. Add a fourth, optional, passed through as `SQLFLOW_STATE_PATH` inside
+the container and pointed at a container-local path so the file lives on the
+container filesystem rather than a bind mount — a bind mount on Docker Desktop
+measures the mount, not the engine, the same way host port-forwarding
+understates throughput by ~10x (README, "Benchmarks must run inside the docker
+network").
+
+- [ ] **Step 3: Run both arms**
+
+```bash
+make start-backing-services
+for bs in 500 2000 5000; do
+  make benchmark-container NUM_MESSAGES=300000 BATCH_SIZE=$bs \
+    CONFIG=dev/config/examples/benchmark.stateful.mem.yml
+  make benchmark-container NUM_MESSAGES=300000 BATCH_SIZE=$bs \
+    CONFIG=dev/config/examples/benchmark.stateful.mem.yml \
+    STATE_PATH=/tmp/bench-state.db
+done
+```
+
+Record throughput and both memory figures for each. Every run uses a fresh
+topic and consumer group, so runs are hermetic — but delete the state file
+between runs, or the second run resumes from the first's offsets and consumes
+nothing.
+
+- [ ] **Step 4: Publish the numbers, whatever they are**
+
+Add a table to the README's Benchmarks section:
+
+| Handler | `batch_size` | State | Throughput | Peak memory |
+|---|---|---|---|---|
+
+State the cost as a percentage in prose. If durability costs 30% at
+`batch_size: 500` and 3% at 5000, say exactly that and recommend a floor. If it
+costs more than expected, that is a finding to report, not a number to bury —
+`state_commit_latency` from Task 4 will show where the time goes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dev/config/examples/benchmark.stateful.mem.yml scripts/benchmark-container.sh README.md
+git commit -m "bench: measure the cost of disk-backed state"
+```
+
+---
+
+## Task 8: Phase 0 — state the guarantee
+
+**Files:**
+- Modify: `README.md` (the Kafka source section, and Sinks)
+
+**Interfaces:** documentation only.
+
+This is the piece that was shippable before any of the above; it is last here only because half of it describes Task 4's behaviour. Write it after the code lands so it describes what is true.
+
+- [ ] **Step 1: Write the section**
+
+Add under Sources → Kafka, after the existing offsets paragraph:
+
+```markdown
+## Delivery guarantees
+
+SQLFlow gives two different guarantees, and which one applies depends on where
+the data lands.
+
+**Pipeline state — exactly-once relative to offsets.** With
+`pipeline.state.path` set, the tables your handler writes and the Kafka offsets
+that produced them are committed in a single DuckDB transaction. A crash
+replays exactly the batches whose state was not committed, so a windowed
+aggregate is neither short nor double-counted across a restart. The state file
+is the source of truth; the offsets committed back to Kafka are advisory, for
+lag monitoring.
+
+**External sinks — at-least-once.** Kafka, ClickHouse, Iceberg and
+`sqlcommand` are flushed before the transaction commits, so a crash between the
+flush and the commit replays that batch and the sink sees those rows twice.
+Use a sink that tolerates it: `ReplacingMergeTree` in ClickHouse, an upsert in
+`sqlcommand`, or a downstream dedupe on a key.
+
+**Without `pipeline.state.path`, DuckDB is in memory.** Handler state does not
+survive the process, and a crash mid-window loses that window's aggregate while
+its offsets are already committed — silently, with the consumer group showing
+no lag. Set a state path for any pipeline that aggregates.
+```
+
+Also correct the Tumbling windows section, which currently implies durability it does not have, and add `pipeline.state` to the config shape block and the environment table.
+
+- [ ] **Step 2: Check the claims against the code**
+
+Re-read Task 4's ordering and confirm each sentence matches it. If they disagree, the documentation is wrong, not the code.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: state the delivery guarantees for state and for sinks"
+```
+
+---
+
+## Out of scope
+
+Named so nobody expands the plan mid-flight:
+
+- **Declarative windows** (watermarks, session windows, lateness policy, engine-owned eviction). This is Phase 3 and it is a config-surface change; it should be designed against this state model once it exists.
+- **Watermark delay metric.** Cannot exist until declarative windows do: the engine has no watermark to be delayed against while "closed" is arbitrary user SQL.
+- **Per-key state metrics.** `state_table_rows` counts rows per table, which is the honest proxy available today. "Keys" is not a concept the engine has until windows are declarative.
+- **Pushing metrics.** The Prometheus endpoint is scrape-only. OTLP export is a separate decision.
+- **Multi-process or partitioned state.** DuckDB is a single-writer embedded database; one state file belongs to one pipeline process. Two processes on one file is not supported and should error rather than corrupt — worth its own task later, not here.
+- **State compaction or retention.** The `sqlflow_offsets` table is bounded by partition count, but user window tables are bounded only by the user's own delete predicate. Phase 3's eviction policy addresses that.
+
+## Self-review
+
+- **Spec coverage.** Durability: config path (Task 2), DuckDB on disk (Task 1), offsets table (Task 3), atomic commit (Task 4), resume (Task 5), wiring (Task 6), acceptance gate (Task 7). Observability: consumer lag (5b), the stats snapshot and its gauges (5c), the `/stats` endpoint for a running pipeline (5d), the CLI for a stopped one (5e). Documentation: Task 8. Both design decisions from the 2026-09-02 conversation are honoured — offsets live in DuckDB, durability comes from a disk-backed database — as is the requirement that observability ship with the feature rather than after it.
+- **Requested metrics, and where each lands.** On-disk size → `state_db_size_bytes` (5c). Row counts → `state_table_rows{table}` (5c). Offset lag → `consumer_lag{topic,partition}` (5b). The commit this design introduces → `state_commit_latency` / `state_commit_count` (Task 4, since that is where the commit is written). Per-pipeline on-disk stats → `/stats` (5d) live, `sqlflow stats` (5e) offline.
+- **Placeholders.** Task 6 deliberately has no unit test, with the reason stated and the gate named. Task 1's first test contains a scan that must be replaced with the `countRows` helper; that instruction is explicit rather than left as "fix this".
+- **Type consistency.** `Mark`, `OffsetStore`, `Save`, `Load`, `Init`, `SeekTo`, `WithStateStore`, `StateStats`, `TableStat`, `OffsetStat`, `CollectStateStats` are used identically wherever they appear. `Save` never commits; only Task 4 commits. `StateStats` is produced once (5c) and rendered by two consumers (5d, 5e), so the endpoint and the CLI cannot drift.
+- **Gap found on review.** Task 4's step list did not mention the commit-latency instrument, which the metrics summary above assigns to it. Add `state_commit_latency` (histogram, seconds) and `state_commit_count` (counter) to `metrics.go` in Task 4's Step 3, recorded around `conn.Commit(ctx)`. Without it the one new source of per-batch latency this design introduces would be invisible.

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -116,6 +116,29 @@ func TestConfigValidate_ReportsMissingFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestConfigValidate_AcceptsStatePath(t *testing.T) {
+	path := writeTempConfig(t, `
+pipeline:
+  batch_size: 10
+  state:
+    path: /var/lib/sqlflow/state.db
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      auto_offset_reset: earliest
+      topics: [t]
+  handler:
+    type: handlers.InferredMemBatch
+    sql: SELECT 1
+  sink:
+    type: noop
+`)
+
+	assert.NoError(t, validateConfig(path))
+}
+
 func writeTempConfig(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "config.yml")

--- a/internal/cli/run/metrics.go
+++ b/internal/cli/run/metrics.go
@@ -1,12 +1,14 @@
 package run
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/turbolytics/sql-flow/internal/core"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -17,9 +19,52 @@ import (
 // endpoint, so dashboards and scrape configs carry over unchanged.
 const metricsPort = ":8000"
 
+// statsFunc reports a snapshot of the pipeline's durable state. It returns a
+// nil snapshot, and no error, for a pipeline that has no state database.
+type statsFunc func() (*core.StateStats, error)
+
+// newHTTPMux builds the server the pipeline exposes: Prometheus scraping, and
+// a JSON view of durable state.
+//
+// The two are on one mux deliberately. DuckDB takes an exclusive lock on the
+// state file, so no other process can read it while the pipeline runs -- not
+// even read-only. A running pipeline is the only thing that can report its own
+// state, which makes this endpoint the live half of observability rather than
+// a convenience.
+func newHTTPMux(registry *prom.Registry, stats statsFunc) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	if registry != nil {
+		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	}
+
+	if stats != nil {
+		mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+			state, err := stats()
+			if err != nil {
+				// A monitoring system must see the failure, not a
+				// healthy-looking blank.
+				http.Error(w, fmt.Sprintf("collecting state stats: %v", err),
+					http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			// state is nil for a pipeline with no state database, which
+			// encodes as null: absent state and empty state are different
+			// facts and a dashboard should be able to tell them apart.
+			if err := json.NewEncoder(w).Encode(map[string]any{"state": state}); err != nil {
+				return
+			}
+		})
+	}
+
+	return mux
+}
+
 // newMeterProvider starts the exporter named by --metrics. An empty name
 // disables metrics entirely.
-func newMeterProvider(name string, l *zap.Logger) (metric.MeterProvider, error) {
+func newMeterProvider(name string, l *zap.Logger, stats statsFunc) (metric.MeterProvider, error) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "":
 		return nil, nil
@@ -31,8 +76,7 @@ func newMeterProvider(name string, l *zap.Logger) (metric.MeterProvider, error) 
 			return nil, fmt.Errorf("prometheus exporter: %w", err)
 		}
 
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+		mux := newHTTPMux(registry, stats)
 
 		go func() {
 			l.Info("serving prometheus metrics", zap.String("addr", metricsPort+"/metrics"))

--- a/internal/cli/run/metrics_test.go
+++ b/internal/cli/run/metrics_test.go
@@ -1,0 +1,83 @@
+package run
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/zeebo/assert"
+)
+
+// DuckDB takes an exclusive lock on the state file, so a second process
+// cannot read it while the pipeline holds it -- not even read-only. A running
+// pipeline therefore has to serve its own stats.
+func TestStatsHandler_ReportsState(t *testing.T) {
+	want := &core.StateStats{
+		Path:      "/state/state.db",
+		SizeBytes: 4096,
+		Tables:    []core.TableStat{{Name: "agg", Rows: 24}},
+		Offsets:   []core.OffsetStat{{Topic: "events", Partition: 0, Offset: 999, LeaderEpoch: 7}},
+	}
+
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return want, nil })
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	state, ok := got["state"].(map[string]any)
+	assert.That(t, ok)
+	assert.Equal(t, "/state/state.db", state["path"])
+	assert.Equal(t, float64(4096), state["size_bytes"])
+
+	tables, ok := state["tables"].([]any)
+	assert.That(t, ok)
+	assert.Equal(t, float64(24), tables[0].(map[string]any)["rows"])
+
+	offsets, ok := state["offsets"].([]any)
+	assert.That(t, ok)
+	assert.Equal(t, float64(999), offsets[0].(map[string]any)["offset"])
+}
+
+// A pipeline with no state path still answers, with a null state block. The
+// endpoint stays useful for the counters even when nothing is durable.
+func TestStatsHandler_NullStateWithoutAStateDatabase(t *testing.T) {
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return nil, nil })
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var got map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.That(t, got["state"] == nil)
+}
+
+// A failure reading state is reported as a server error rather than an empty
+// success, so a monitoring system sees the problem instead of a healthy-looking
+// blank.
+func TestStatsHandler_ReportsCollectionFailure(t *testing.T) {
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) {
+		return nil, errors.New("state database unreadable")
+	})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// With no stats provider at all -- metrics enabled but state unwired -- the
+// endpoint must not be registered as a half-working route.
+func TestStatsHandler_AbsentWithoutAProvider(t *testing.T) {
+	mux := newHTTPMux(nil, nil)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -334,14 +334,40 @@ func NewCommand() *cobra.Command {
 				}(m)
 			}
 			defer func() {
+				// Close the open transaction first. The managers' final poll
+				// runs on this connection, and its close predicate is
+				// evaluated against the transaction's clock -- which is
+				// frozen at the last commit until this runs.
+				if err := turbine.SyncState(context.Background()); err != nil {
+					l.Error("failed to sync state before final poll", zap.Error(err))
+				}
 				stopManagers()
 				managerWG.Wait()
+				// And again afterwards, so what that poll published is
+				// actually deleted. Without this the delete is rolled back
+				// when the connection closes, and every clean shutdown
+				// guarantees a republished window on the next start.
+				if err := turbine.SyncState(context.Background()); err != nil {
+					l.Error("failed to sync state after final poll", zap.Error(err))
+				}
 			}()
 
+			// Cancelled before the reader connection closes. Left running, a
+			// gauge sample can be mid-query on statsConn while the deferred
+			// Close runs, which is a use-after-free inside DuckDB rather than
+			// anything the race detector can see.
+			statusCtx, stopStatus := context.WithCancel(context.Background())
+			var statusWG sync.WaitGroup
+			statusWG.Add(1)
 			go func() {
-				if err := turbine.StatusLoop(context.Background()); err != nil {
+				defer statusWG.Done()
+				if err := turbine.StatusLoop(statusCtx); err != nil {
 					l.Error("failed to start status loop", zap.Error(err))
 				}
+			}()
+			defer func() {
+				stopStatus()
+				statusWG.Wait()
 			}()
 
 			stats, err := turbine.ConsumeLoop(context.Background(), maxMsgs)

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -108,8 +109,34 @@ func NewCommand() *cobra.Command {
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
-			// Initialize ADBC connection using driver manager
-			conn, err := duckdb.Open(context.Background())
+			// A pipeline that declares a state path gets a DuckDB backed by
+			// that file, so window state and the offsets that produced it
+			// survive a crash. Without one, state is in memory and is lost --
+			// while its offsets have already been committed.
+			statePath := ""
+			if conf.Pipeline.State != nil {
+				statePath = conf.Pipeline.State.Path
+			}
+			if statePath != "" {
+				if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+					return fmt.Errorf("creating state directory for %q: %w", statePath, err)
+				}
+			}
+
+			// The handle is kept, not just a connection: a second connection
+			// is what lets /stats read committed state without contending
+			// with the writer.
+			db, err := duckdb.OpenPath(context.Background(), statePath)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := db.Close(); err != nil {
+					l.Error("failed to close DuckDB database", zap.Error(err))
+				}
+			}()
+
+			conn, err := db.Connect(context.Background())
 			if err != nil {
 				return err
 			}
@@ -136,11 +163,79 @@ func NewCommand() *cobra.Command {
 			// the table managers and the debug API.
 			lock := &sync.Mutex{}
 
+			// State wiring. Everything below is skipped for a pipeline with no
+			// state path, which then behaves exactly as it did before.
+			var (
+				turbineOpts []core.TurbineOption
+				statsFn     statsFunc
+				storedMarks *core.Marks
+			)
+			if statePath != "" {
+				offsets := core.NewOffsetStore(conn)
+				if err := offsets.Init(context.Background()); err != nil {
+					return fmt.Errorf("initializing offsets table: %w", err)
+				}
+
+				// Read the durable positions before autocommit is turned off,
+				// so setup is committed and the read is straightforward.
+				storedMarks, err = offsets.Load(context.Background())
+				if err != nil {
+					return fmt.Errorf("loading stored offsets: %w", err)
+				}
+
+				// Every batch from here on is one transaction: the handler's
+				// writes and the offsets that produced them commit together.
+				po, ok := conn.(adbc.PostInitOptions)
+				if !ok {
+					return fmt.Errorf("state requires a connection supporting transactions")
+				}
+				if err := po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled); err != nil {
+					return fmt.Errorf("disabling autocommit for state: %w", err)
+				}
+
+				stateConn, ok := conn.(interface {
+					Commit(context.Context) error
+					Rollback(context.Context) error
+				})
+				if !ok {
+					return fmt.Errorf("state requires a connection supporting commit and rollback")
+				}
+				turbineOpts = append(turbineOpts, core.WithStateStore(offsets, stateConn))
+
+				// A connection of its own for reading: it sees committed state
+				// only, so a scrape never blocks a batch and never reports
+				// rows a rollback then erased.
+				statsConn, err := db.Connect(context.Background())
+				if err != nil {
+					return fmt.Errorf("opening state reader connection: %w", err)
+				}
+				defer func() {
+					if err := statsConn.Close(); err != nil {
+						l.Error("failed to close state reader connection", zap.Error(err))
+					}
+				}()
+
+				var statsMu sync.Mutex
+				statsFn = func() (*core.StateStats, error) {
+					// One ADBC connection is not safe for concurrent use, and
+					// the status loop and any number of scrapes share this
+					// one. The lock guards the reader, never the writer.
+					statsMu.Lock()
+					defer statsMu.Unlock()
+					return core.CollectStateStats(context.Background(), statsConn, statePath)
+				}
+				turbineOpts = append(turbineOpts, core.WithStateStats(statsFn))
+
+				l.Info("pipeline state is durable",
+					zap.String("path", statePath),
+					zap.Int("resuming_partitions", storedMarks.Len()))
+			}
+
 			if withHTTPDebug {
 				startDebugServer(conn, lock, l)
 			}
 
-			meterProvider, err := newMeterProvider(metricsExporter, l, nil)
+			meterProvider, err := newMeterProvider(metricsExporter, l, statsFn)
 			if err != nil {
 				return err
 			}
@@ -156,6 +251,19 @@ func NewCommand() *cobra.Command {
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create source: %w", err)
+			}
+
+			// Resume where the durable state left off. The state database is
+			// the source of truth; a disagreement with Kafka is resolved in
+			// its favour, immediately.
+			if storedMarks != nil && !storedMarks.Empty() {
+				seeker, ok := src.(interface{ SeekTo(*core.Marks) error })
+				if !ok {
+					return fmt.Errorf("source %q cannot resume from stored offsets", conf.Pipeline.Source.Type)
+				}
+				if err := seeker.SeekTo(storedMarks); err != nil {
+					return fmt.Errorf("resuming from stored offsets: %w", err)
+				}
 			}
 
 			sink, err := sinks.New(conf.Pipeline.Sink, conn)
@@ -200,8 +308,10 @@ func NewCommand() *cobra.Command {
 				flushInterval,
 				lock,
 				errorPolicies,
-				core.WithTurbineLogger(l),
-				core.WithMetrics(pipelineMetrics),
+				append([]core.TurbineOption{
+					core.WithTurbineLogger(l),
+					core.WithMetrics(pipelineMetrics),
+				}, turbineOpts...)...,
 			)
 
 			managedTables, err := buildManagedTables(conf, conn, lock, l)

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -140,7 +140,7 @@ func NewCommand() *cobra.Command {
 				startDebugServer(conn, lock, l)
 			}
 
-			meterProvider, err := newMeterProvider(metricsExporter, l)
+			meterProvider, err := newMeterProvider(metricsExporter, l, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/schemas/config.json
+++ b/internal/cli/schemas/config.json
@@ -688,6 +688,18 @@
           "required": [
             "policy"
           ]
+        },
+        "state": {
+          "type": "object",
+          "description": "Where the pipeline keeps its DuckDB state. Absent means in-memory, and state is lost on a crash.",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "File backing the pipeline's DuckDB database. Window state and Kafka offsets are stored here and committed together."
+            }
+          },
+          "required": ["path"],
+          "additionalProperties": false
         }
       },
       "required": [

--- a/internal/cli/schemas/config.json
+++ b/internal/cli/schemas/config.json
@@ -698,7 +698,9 @@
               "description": "File backing the pipeline's DuckDB database. Window state and Kafka offsets are stored here and committed together."
             }
           },
-          "required": ["path"],
+          "required": [
+            "path"
+          ],
           "additionalProperties": false
         }
       },

--- a/internal/cli/testdata/config_example.golden
+++ b/internal/cli/testdata/config_example.golden
@@ -159,3 +159,7 @@ pipeline:
         table: <string>
       # Console output sink configuration.
       console:
+  # Where the pipeline keeps its DuckDB state. Absent means in-memory, and state is lost on a crash.
+  state:
+    # File backing the pipeline's DuckDB database. Window state and Kafka offsets are stored here and committed together.
+    path: <string>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,16 +166,25 @@ type OnError struct {
 	DLQ    *Sink  `yaml:"dlq,omitempty"`
 }
 
+// StateConf points the pipeline's DuckDB at a file, so tables the handler
+// writes -- window state above all -- survive a restart. Offsets are stored in
+// the same database, which is what makes state and offsets recoverable
+// together.
+type StateConf struct {
+	Path string `yaml:"path"`
+}
+
 // Pipeline
 type Pipeline struct {
-	Name                 string   `yaml:"name,omitempty"`
-	Description          string   `yaml:"description,omitempty"`
-	Source               Source   `yaml:"source"`
-	Handler              Handler  `yaml:"handler"`
-	Sink                 Sink     `yaml:"sink"`
-	BatchSize            int      `yaml:"batch_size,omitempty"`
-	FlushIntervalSeconds int      `yaml:"flush_interval_seconds,omitempty"`
-	OnError              *OnError `yaml:"on_error,omitempty"`
+	Name                 string     `yaml:"name,omitempty"`
+	Description          string     `yaml:"description,omitempty"`
+	Source               Source     `yaml:"source"`
+	Handler              Handler    `yaml:"handler"`
+	Sink                 Sink       `yaml:"sink"`
+	BatchSize            int        `yaml:"batch_size,omitempty"`
+	FlushIntervalSeconds int        `yaml:"flush_interval_seconds,omitempty"`
+	State                *StateConf `yaml:"state,omitempty"`
+	OnError              *OnError   `yaml:"on_error,omitempty"`
 }
 
 // Conf

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -26,6 +26,22 @@ func renderString(t *testing.T, body string, overrides map[string]string) string
 	return strings.TrimSpace(string(out))
 }
 
+func loadString(t *testing.T, body string) *Conf {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	conf, err := Load(path, nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	return conf
+}
+
 // The config spec is Jinja2: filter arguments are parenthesized. pongo2's
 // colon syntax is not interchangeable, and every example config uses Jinja.
 func TestRenderTemplate_JinjaDefaultFilter(t *testing.T) {
@@ -184,4 +200,47 @@ pipeline:
 	_, err := Load(path, nil)
 	assert.Error(t, err)
 	assert.That(t, strings.Contains(err.Error(), "bath_size"))
+}
+
+// A pipeline may name a file for its DuckDB state. Absent, state stays in
+// memory and is lost on a crash.
+func TestLoad_StatePath(t *testing.T) {
+	conf := loadString(t, `
+pipeline:
+  batch_size: 10
+  state:
+    path: /var/lib/sqlflow/state.db
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      topics: [t]
+  handler:
+    type: handlers.InferredMemBatch
+    sql: SELECT 1
+  sink:
+    type: noop
+`)
+	assert.That(t, conf.Pipeline.State != nil)
+	assert.Equal(t, "/var/lib/sqlflow/state.db", conf.Pipeline.State.Path)
+}
+
+func TestLoad_StateAbsentIsNil(t *testing.T) {
+	conf := loadString(t, `
+pipeline:
+  batch_size: 10
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      topics: [t]
+  handler:
+    type: handlers.InferredMemBatch
+    sql: SELECT 1
+  sink:
+    type: noop
+`)
+	assert.That(t, conf.Pipeline.State == nil)
 }

--- a/internal/core/marks.go
+++ b/internal/core/marks.go
@@ -1,0 +1,83 @@
+package core
+
+import "sort"
+
+// Marks records the last position the pipeline has finished with in each
+// partition it has read: a message written to the handler, or one dropped by
+// an error policy.
+//
+// Topic-then-partition nesting is the natural shape for this and the awkward
+// one to pass around. Owning it here keeps two rules in one place rather than
+// repeated at every call site: a partition only ever moves forward, and
+// iteration is ordered so anything rendered from it -- the stats endpoint, the
+// CLI -- is stable between runs.
+type Marks struct {
+	m map[string]map[int32]Mark
+}
+
+func NewMarks() *Marks {
+	return &Marks{m: map[string]map[int32]Mark{}}
+}
+
+// Advance records a position, ignoring one that would move a partition
+// backwards. Offsets arrive in order within a partition, so the guard only
+// matters if a source redelivers -- and a redelivery must not rewind a
+// position that has already been committed.
+func (m *Marks) Advance(topic string, partition int32, mark Mark) {
+	parts, ok := m.m[topic]
+	if !ok {
+		parts = map[int32]Mark{}
+		m.m[topic] = parts
+	}
+	if cur, seen := parts[partition]; seen && cur.Offset >= mark.Offset {
+		return
+	}
+	parts[partition] = mark
+}
+
+// Get reports the position recorded for a partition. The boolean distinguishes
+// "no position yet" from a position at offset zero, which is a real place in
+// the log.
+func (m *Marks) Get(topic string, partition int32) (Mark, bool) {
+	parts, ok := m.m[topic]
+	if !ok {
+		return Mark{}, false
+	}
+	mark, ok := parts[partition]
+	return mark, ok
+}
+
+// Len is the number of partitions held, across all topics.
+func (m *Marks) Len() int {
+	n := 0
+	for _, parts := range m.m {
+		n += len(parts)
+	}
+	return n
+}
+
+func (m *Marks) Empty() bool { return m.Len() == 0 }
+
+// Each calls fn for every position, ordered by topic then partition. The order
+// is deliberate: map iteration is random, and callers render these into JSON
+// and log lines where a shuffling order makes diffs unreadable.
+func (m *Marks) Each(fn func(topic string, partition int32, mark Mark)) {
+	topics := make([]string, 0, len(m.m))
+	for topic := range m.m {
+		topics = append(topics, topic)
+	}
+	sort.Strings(topics)
+
+	for _, topic := range topics {
+		parts := m.m[topic]
+		partitions := make([]int32, 0, len(parts))
+		for p := range parts {
+			partitions = append(partitions, p)
+		}
+		sort.Slice(partitions, func(i, j int) bool { return partitions[i] < partitions[j] })
+
+		for _, p := range partitions {
+			fn(topic, p, parts[p])
+		}
+	}
+}

--- a/internal/core/marks_test.go
+++ b/internal/core/marks_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zeebo/assert"
+)
+
+// Advance carries the invariant that a partition only moves forward, so a
+// redelivered message cannot rewind a position that has already been
+// committed. The rule used to live inline in Turbine.mark; it belongs with
+// the data it constrains.
+func TestMarks_AdvanceNeverGoesBackwards(t *testing.T) {
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 1})
+	m.Advance("events", 0, Mark{Offset: 4, LeaderEpoch: 1})
+
+	got, ok := m.Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(10), got.Offset)
+}
+
+func TestMarks_AdvanceMovesForward(t *testing.T) {
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 4, LeaderEpoch: 1})
+	m.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 2})
+
+	got, _ := m.Get("events", 0)
+	assert.Equal(t, int64(10), got.Offset)
+	assert.Equal(t, int32(2), got.LeaderEpoch)
+}
+
+func TestMarks_TracksPartitionsIndependently(t *testing.T) {
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 5})
+	m.Advance("events", 1, Mark{Offset: 99})
+	m.Advance("other", 0, Mark{Offset: 1})
+
+	assert.Equal(t, 3, m.Len())
+
+	p0, _ := m.Get("events", 0)
+	p1, _ := m.Get("events", 1)
+	other, _ := m.Get("other", 0)
+	assert.Equal(t, int64(5), p0.Offset)
+	assert.Equal(t, int64(99), p1.Offset)
+	assert.Equal(t, int64(1), other.Offset)
+}
+
+func TestMarks_EmptyAndMissing(t *testing.T) {
+	m := NewMarks()
+	assert.That(t, m.Empty())
+	assert.Equal(t, 0, m.Len())
+
+	_, ok := m.Get("nope", 0)
+	assert.That(t, !ok)
+
+	m.Advance("events", 0, Mark{Offset: 1})
+	assert.That(t, !m.Empty())
+	assert.Equal(t, 1, m.Len())
+}
+
+// Offset 0 is a real position, not "unset": a mark at 0 means the first
+// message was processed, and Advance must not treat it as absent.
+func TestMarks_ZeroOffsetIsAPosition(t *testing.T) {
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 0, LeaderEpoch: 3})
+
+	got, ok := m.Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(0), got.Offset)
+	assert.Equal(t, int32(3), got.LeaderEpoch)
+	assert.Equal(t, 1, m.Len())
+}
+
+// Sorted iteration keeps /stats output and CLI diffs stable between runs; map
+// order would shuffle them for no reason.
+func TestMarks_EachIteratesInSortedOrder(t *testing.T) {
+	m := NewMarks()
+	m.Advance("zeta", 0, Mark{Offset: 1})
+	m.Advance("alpha", 2, Mark{Offset: 2})
+	m.Advance("alpha", 0, Mark{Offset: 3})
+	m.Advance("alpha", 10, Mark{Offset: 4})
+
+	var order []string
+	m.Each(func(topic string, partition int32, mark Mark) {
+		order = append(order, fmt.Sprintf("%s/%d", topic, partition))
+	})
+	// Partitions sort numerically, so 10 comes after 2 rather than before it.
+	assert.Equal(t, []string{"alpha/0", "alpha/2", "alpha/10", "zeta/0"}, order)
+}
+
+func TestMarks_EachOverEmptyIsANoop(t *testing.T) {
+	m := NewMarks()
+	called := 0
+	m.Each(func(string, int32, Mark) { called++ })
+	assert.Equal(t, 0, called)
+}

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -19,6 +19,8 @@ type Metrics struct {
 	BatchProcessingLatency metric.Float64Histogram
 	StateCommitLatency     metric.Float64Histogram
 	StateCommitCount       metric.Int64Counter
+	StateSizeBytes         metric.Int64Gauge
+	StateTableRows         metric.Int64Gauge
 	ConsumerLag            metric.Int64Gauge
 }
 
@@ -114,6 +116,22 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		metric.WithUnit("commits"),
 	); err != nil {
 		return nil, fmt.Errorf("state_commit_count: %w", err)
+	}
+
+	if m.StateSizeBytes, err = meter.Int64Gauge(
+		"state_db_size_bytes",
+		metric.WithDescription("Size on disk of the pipeline's state database"),
+		metric.WithUnit("By"),
+	); err != nil {
+		return nil, fmt.Errorf("state_db_size_bytes: %w", err)
+	}
+
+	if m.StateTableRows, err = meter.Int64Gauge(
+		"state_table_rows",
+		metric.WithDescription("Rows in each managed state table"),
+		metric.WithUnit("rows"),
+	); err != nil {
+		return nil, fmt.Errorf("state_table_rows: %w", err)
 	}
 
 	return &m, nil

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -17,6 +17,8 @@ type Metrics struct {
 	SinkFlushNumRows       metric.Int64Gauge
 	SinkFlushCount         metric.Int64Counter
 	BatchProcessingLatency metric.Float64Histogram
+	StateCommitLatency     metric.Float64Histogram
+	StateCommitCount       metric.Int64Counter
 	ConsumerLag            metric.Int64Gauge
 }
 
@@ -96,6 +98,22 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		metric.WithUnit("messages"),
 	); err != nil {
 		return nil, fmt.Errorf("consumer_lag: %w", err)
+	}
+
+	if m.StateCommitLatency, err = meter.Float64Histogram(
+		"state_commit_latency",
+		metric.WithDescription("Latency of committing state and offsets together"),
+		metric.WithUnit("s"),
+	); err != nil {
+		return nil, fmt.Errorf("state_commit_latency: %w", err)
+	}
+
+	if m.StateCommitCount, err = meter.Int64Counter(
+		"state_commit_count",
+		metric.WithDescription("Number of state transactions committed"),
+		metric.WithUnit("commits"),
+	); err != nil {
+		return nil, fmt.Errorf("state_commit_count: %w", err)
 	}
 
 	return &m, nil

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -17,6 +17,7 @@ type Metrics struct {
 	SinkFlushNumRows       metric.Int64Gauge
 	SinkFlushCount         metric.Int64Counter
 	BatchProcessingLatency metric.Float64Histogram
+	ConsumerLag            metric.Int64Gauge
 }
 
 // NewMetrics builds the instruments from a meter provider. Passing a noop
@@ -87,6 +88,14 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		metric.WithUnit("seconds"),
 	); err != nil {
 		return nil, fmt.Errorf("batch_processing_latency: %w", err)
+	}
+
+	if m.ConsumerLag, err = meter.Int64Gauge(
+		"consumer_lag",
+		metric.WithDescription("Messages between the last one processed and the partition's high watermark"),
+		metric.WithUnit("messages"),
+	); err != nil {
+		return nil, fmt.Errorf("consumer_lag: %w", err)
 	}
 
 	return &m, nil

--- a/internal/core/offsets.go
+++ b/internal/core/offsets.go
@@ -11,7 +11,7 @@ import (
 
 // offsetsTable is where a pipeline's Kafka positions live in DuckDB, next to
 // the state the offsets describe. Keeping both in one database is what lets a
-// later commit write them together in a single transaction: state and the
+// later commit writes them together in a single transaction: state and the
 // offset that produced it can never disagree after a crash.
 const offsetsTable = "sqlflow_offsets"
 

--- a/internal/core/offsets.go
+++ b/internal/core/offsets.go
@@ -1,0 +1,166 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// offsetsTable is where a pipeline's Kafka positions live in DuckDB, next to
+// the state the offsets describe. Keeping both in one database is what lets a
+// later commit write them together in a single transaction: state and the
+// offset that produced it can never disagree after a crash.
+const offsetsTable = "sqlflow_offsets"
+
+// OffsetStore persists Marks to DuckDB. It holds no lock and starts no
+// transaction of its own: Save issues writes on the connection it is given,
+// and it is the caller's job to commit -- typically together with the batch
+// that advanced those offsets.
+type OffsetStore struct {
+	conn adbc.Connection
+}
+
+// NewOffsetStore wraps a DuckDB connection. The connection is expected to be
+// the same one the pipeline uses for its batch writes, so offsets land in the
+// same transaction as the state they describe.
+func NewOffsetStore(conn adbc.Connection) *OffsetStore {
+	return &OffsetStore{conn: conn}
+}
+
+// Init creates the offsets table if it does not already exist. It is safe to
+// call on every start, including against a state file from a previous run.
+func (s *OffsetStore) Init(ctx context.Context) error {
+	stmt, err := s.conn.NewStatement()
+	if err != nil {
+		return fmt.Errorf("creating statement: %w", err)
+	}
+	defer stmt.Close()
+
+	if err := stmt.SetSqlQuery(`
+		CREATE TABLE IF NOT EXISTS ` + offsetsTable + ` (
+		    topic        VARCHAR NOT NULL,
+		    partition    INTEGER NOT NULL,
+		    "offset"     BIGINT  NOT NULL,
+		    leader_epoch INTEGER NOT NULL,
+		    PRIMARY KEY (topic, partition)
+		)
+	`); err != nil {
+		return fmt.Errorf("setting create-table query: %w", err)
+	}
+	if _, err := stmt.ExecuteUpdate(ctx); err != nil {
+		return fmt.Errorf("creating offsets table: %w", err)
+	}
+	return nil
+}
+
+// Save upserts one row per topic/partition in marks. It does not commit: the
+// caller owns the transaction, so these writes can land together with
+// whatever state change they are recording the position for.
+func (s *OffsetStore) Save(ctx context.Context, marks *Marks) error {
+	var writeErr error
+	marks.Each(func(topic string, partition int32, mark Mark) {
+		if writeErr != nil {
+			return
+		}
+
+		stmt, err := s.conn.NewStatement()
+		if err != nil {
+			writeErr = fmt.Errorf("creating statement: %w", err)
+			return
+		}
+		defer stmt.Close()
+
+		if err := stmt.SetSqlQuery(fmt.Sprintf(`
+			INSERT INTO %s (topic, partition, "offset", leader_epoch)
+			VALUES ('%s', %d, %d, %d)
+			ON CONFLICT (topic, partition) DO UPDATE SET
+			    "offset" = EXCLUDED."offset",
+			    leader_epoch = EXCLUDED.leader_epoch
+		`, offsetsTable, escapeSQLString(topic), partition, mark.Offset, mark.LeaderEpoch)); err != nil {
+			writeErr = fmt.Errorf("setting upsert query: %w", err)
+			return
+		}
+		if _, err := stmt.ExecuteUpdate(ctx); err != nil {
+			writeErr = fmt.Errorf("upserting offset for %s/%d: %w", topic, partition, err)
+			return
+		}
+	})
+	return writeErr
+}
+
+// Load returns every position recorded in the offsets table. A store with no
+// rows yet returns an empty, non-nil Marks -- the caller must not treat that
+// as offset zero.
+func (s *OffsetStore) Load(ctx context.Context) (*Marks, error) {
+	stmt, err := s.conn.NewStatement()
+	if err != nil {
+		return nil, fmt.Errorf("creating statement: %w", err)
+	}
+	defer stmt.Close()
+
+	if err := stmt.SetSqlQuery(fmt.Sprintf(
+		`SELECT topic, partition, "offset", leader_epoch FROM %s`, offsetsTable,
+	)); err != nil {
+		return nil, fmt.Errorf("setting select query: %w", err)
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("querying offsets: %w", err)
+	}
+	defer reader.Release()
+
+	marks := NewMarks()
+	for reader.Next() {
+		rec := reader.Record()
+
+		topics, ok := rec.Column(0).(*array.String)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for topic column: %T", rec.Column(0))
+		}
+		partitions, ok := rec.Column(1).(*array.Int32)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for partition column: %T", rec.Column(1))
+		}
+		offsets, ok := rec.Column(2).(*array.Int64)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for offset column: %T", rec.Column(2))
+		}
+		leaderEpochs, ok := rec.Column(3).(*array.Int32)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for leader_epoch column: %T", rec.Column(3))
+		}
+
+		for i := 0; i < int(rec.NumRows()); i++ {
+			// Clone: topics.Value(i) aliases the record's backing buffer,
+			// which is released -- and can be freed or reused -- once this
+			// function returns.
+			marks.Advance(strings.Clone(topics.Value(i)), partitions.Value(i), Mark{
+				Offset:      offsets.Value(i),
+				LeaderEpoch: leaderEpochs.Value(i),
+			})
+		}
+	}
+	if err := reader.Err(); err != nil {
+		return nil, fmt.Errorf("reading offsets: %w", err)
+	}
+
+	return marks, nil
+}
+
+// escapeSQLString doubles single quotes so a topic name containing one cannot
+// break out of the string literal it is interpolated into.
+func escapeSQLString(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			out = append(out, '\'', '\'')
+			continue
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}

--- a/internal/core/offsets_test.go
+++ b/internal/core/offsets_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/turbolytics/sql-flow/internal/duckdb"
+	"github.com/zeebo/assert"
+)
+
+func newStateConn(t *testing.T, path string) adbc.Connection {
+	t.Helper()
+	if os.Getenv("SQLFLOW_DUCKDB_LIB") == "" {
+		os.Setenv("SQLFLOW_DUCKDB_LIB", "/opt/homebrew/lib/libduckdb.dylib")
+	}
+	db, err := duckdb.OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	t.Cleanup(func() { conn.Close(); db.Close() })
+	return conn
+}
+
+// Offsets round-trip through DuckDB, which is what lets a restart resume from
+// the position that produced the state currently in the database.
+func TestOffsetStore_RoundTrip(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+
+	in := NewMarks()
+	in.Advance("events", 0, Mark{Offset: 41, LeaderEpoch: 7})
+	in.Advance("events", 1, Mark{Offset: 8, LeaderEpoch: 7})
+	assert.NoError(t, s.Save(context.Background(), in))
+
+	out, err := s.Load(context.Background())
+	assert.NoError(t, err)
+	p0, ok := out.Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(41), p0.Offset)
+	assert.Equal(t, int32(7), p0.LeaderEpoch)
+	p1, _ := out.Get("events", 1)
+	assert.Equal(t, int64(8), p1.Offset)
+}
+
+// Saving the same partition again advances it rather than duplicating it.
+func TestOffsetStore_SaveIsAnUpsert(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+
+	first := NewMarks()
+	first.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 1})
+	assert.NoError(t, s.Save(context.Background(), first))
+	second := NewMarks()
+	second.Advance("events", 0, Mark{Offset: 99, LeaderEpoch: 2})
+	assert.NoError(t, s.Save(context.Background(), second))
+
+	out, err := s.Load(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, out.Len())
+	got, _ := out.Get("events", 0)
+	assert.Equal(t, int64(99), got.Offset)
+	assert.Equal(t, int32(2), got.LeaderEpoch)
+}
+
+// A fresh state file has no offsets; the caller must treat that as "start
+// where auto_offset_reset says", not as offset zero.
+func TestOffsetStore_LoadEmptyIsEmptyNotZero(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+
+	out, err := s.Load(context.Background())
+	assert.NoError(t, err)
+	assert.That(t, out.Empty())
+}
+
+// Init runs on every start, including against an existing state file.
+func TestOffsetStore_InitIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+	assert.NoError(t, s.Init(context.Background()))
+}

--- a/internal/core/stats.go
+++ b/internal/core/stats.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// batchTable is the transient table the inferred handlers create per batch.
+// Like the offsets table it is engine machinery, not user state, and its row
+// count changes on every batch -- reporting it would be noise.
+const batchTable = "batch"
+
+// TableStat is one managed table and how much is in it.
+type TableStat struct {
+	Name string `json:"name"`
+	Rows int64  `json:"rows"`
+}
+
+// OffsetStat is one partition's durable position.
+type OffsetStat struct {
+	Topic       string `json:"topic"`
+	Partition   int32  `json:"partition"`
+	Offset      int64  `json:"offset"`
+	LeaderEpoch int32  `json:"leader_epoch"`
+}
+
+// StateStats is a snapshot of a pipeline's durable state: how large it is,
+// what is in it, and how far through the stream it has committed.
+//
+// It is produced once and rendered by two consumers -- the /stats endpoint of
+// a running pipeline and the CLI reading a stopped one -- so the two can never
+// disagree about what a pipeline's state contains.
+type StateStats struct {
+	Path      string       `json:"path"`
+	SizeBytes int64        `json:"size_bytes"`
+	Tables    []TableStat  `json:"tables"`
+	Offsets   []OffsetStat `json:"offsets"`
+}
+
+// CollectStateStats reads a snapshot of the state database.
+//
+// The connection should be one dedicated to reading, not the connection the
+// pipeline writes on. Connections to a DuckDB database have independent
+// transaction state, so a reader sees committed rows only: the numbers here
+// describe what would survive a crash at this moment, and collecting them
+// cannot block the writer or be blocked by it.
+func CollectStateStats(ctx context.Context, conn adbc.Connection, path string) (*StateStats, error) {
+	stats := &StateStats{
+		Path:    path,
+		Tables:  []TableStat{},
+		Offsets: []OffsetStat{},
+	}
+
+	if path != "" {
+		// A database that has never been flushed to disk has no file yet;
+		// that is a size of zero, not an error.
+		if info, err := os.Stat(path); err == nil {
+			stats.SizeBytes = info.Size()
+		}
+	}
+
+	names, err := userTables(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range names {
+		rows, err := countRows(ctx, conn, name)
+		if err != nil {
+			return nil, err
+		}
+		stats.Tables = append(stats.Tables, TableStat{Name: name, Rows: rows})
+	}
+
+	// Read through the store rather than a second query, so there is one
+	// definition of the offsets schema.
+	marks, err := NewOffsetStore(conn).Load(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading offsets: %w", err)
+	}
+	// Each iterates sorted, so the result is ordered without sorting again.
+	marks.Each(func(topic string, partition int32, m Mark) {
+		stats.Offsets = append(stats.Offsets, OffsetStat{
+			Topic:       topic,
+			Partition:   partition,
+			Offset:      m.Offset,
+			LeaderEpoch: m.LeaderEpoch,
+		})
+	})
+
+	return stats, nil
+}
+
+// userTables lists the tables that hold pipeline state, excluding the engine's
+// own. The result is sorted so repeated calls render identically.
+func userTables(ctx context.Context, conn adbc.Connection) ([]string, error) {
+	stmt, err := conn.NewStatement()
+	if err != nil {
+		return nil, fmt.Errorf("creating statement: %w", err)
+	}
+	defer stmt.Close()
+
+	if err := stmt.SetSqlQuery(
+		`SELECT table_name FROM duckdb_tables() WHERE schema_name = 'main' ORDER BY table_name`,
+	); err != nil {
+		return nil, fmt.Errorf("setting table-list query: %w", err)
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing tables: %w", err)
+	}
+	defer reader.Release()
+
+	var names []string
+	for reader.Next() {
+		rec := reader.Record()
+		col, ok := rec.Column(0).(*array.String)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for table_name column: %T", rec.Column(0))
+		}
+		for i := 0; i < int(rec.NumRows()); i++ {
+			name := col.Value(i)
+			if name == offsetsTable || name == batchTable {
+				continue
+			}
+			// Clone: the value aliases the record's backing buffer, which is
+			// released -- and can be freed or reused -- when this returns.
+			names = append(names, strings.Clone(name))
+		}
+	}
+	if err := reader.Err(); err != nil {
+		return nil, fmt.Errorf("reading table list: %w", err)
+	}
+
+	sort.Strings(names)
+	return names, nil
+}
+
+func countRows(ctx context.Context, conn adbc.Connection, table string) (int64, error) {
+	stmt, err := conn.NewStatement()
+	if err != nil {
+		return 0, fmt.Errorf("creating statement: %w", err)
+	}
+	defer stmt.Close()
+
+	// Quoted: a managed table may be named anything the user's DDL allows.
+	query := fmt.Sprintf(`SELECT count(*) FROM "%s"`, strings.ReplaceAll(table, `"`, `""`))
+	if err := stmt.SetSqlQuery(query); err != nil {
+		return 0, fmt.Errorf("setting count query for %q: %w", table, err)
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("counting rows in %q: %w", table, err)
+	}
+	defer reader.Release()
+
+	var count int64
+	for reader.Next() {
+		rec := reader.Record()
+		if rec.NumRows() == 0 {
+			continue
+		}
+		col, ok := rec.Column(0).(*array.Int64)
+		if !ok {
+			return 0, fmt.Errorf("unexpected type for count column: %T", rec.Column(0))
+		}
+		count = col.Value(0)
+	}
+	if err := reader.Err(); err != nil {
+		return 0, fmt.Errorf("reading count for %q: %w", table, err)
+	}
+	return count, nil
+}

--- a/internal/core/stats_test.go
+++ b/internal/core/stats_test.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/turbolytics/sql-flow/internal/duckdb"
+	"github.com/zeebo/assert"
+)
+
+func execSQL(tb testing.TB, conn adbc.Connection, sql string) {
+	tb.Helper()
+
+	stmt, err := conn.NewStatement()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer stmt.Close()
+
+	if err := stmt.SetSqlQuery(sql); err != nil {
+		tb.Fatal(err)
+	}
+	if _, err := stmt.ExecuteUpdate(context.Background()); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+// The stats snapshot answers the two questions an operator has about a
+// stateful pipeline: is my state growing without bound, and where am I in the
+// stream. It reports the user's tables and the stored offsets, and must not
+// leak the engine's own bookkeeping tables into either.
+func TestCollectStateStats(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+	saved := NewMarks()
+	saved.Advance("events", 0, Mark{Offset: 41, LeaderEpoch: 7})
+	assert.NoError(t, s.Save(context.Background(), saved))
+
+	execSQL(t, conn, "CREATE TABLE agg (city VARCHAR, n INTEGER)")
+	execSQL(t, conn, "INSERT INTO agg VALUES ('NYC', 1), ('SF', 2), ('LA', 3)")
+
+	stats, err := CollectStateStats(context.Background(), conn, path)
+	assert.NoError(t, err)
+
+	assert.Equal(t, path, stats.Path)
+	assert.That(t, stats.SizeBytes > 0)
+
+	// sqlflow_offsets is engine bookkeeping, not user state.
+	assert.Equal(t, 1, len(stats.Tables))
+	assert.Equal(t, "agg", stats.Tables[0].Name)
+	assert.Equal(t, int64(3), stats.Tables[0].Rows)
+
+	assert.Equal(t, 1, len(stats.Offsets))
+	assert.Equal(t, "events", stats.Offsets[0].Topic)
+	assert.Equal(t, int32(0), stats.Offsets[0].Partition)
+	assert.Equal(t, int64(41), stats.Offsets[0].Offset)
+	assert.Equal(t, int32(7), stats.Offsets[0].LeaderEpoch)
+}
+
+// A fresh state file reports zero tables rather than failing, so the endpoint
+// is useful on a pipeline that has not processed anything yet.
+func TestCollectStateStats_EmptyState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
+
+	stats, err := CollectStateStats(context.Background(), conn, path)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(stats.Tables))
+	assert.Equal(t, 0, len(stats.Offsets))
+	assert.That(t, stats.SizeBytes >= 0)
+}
+
+// The transient batch table the inferred handlers create per batch is engine
+// machinery too; reporting it as user state would be noise that changes on
+// every batch.
+func TestCollectStateStats_ExcludesTheBatchTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
+
+	execSQL(t, conn, "CREATE TABLE batch (i INTEGER)")
+	execSQL(t, conn, "CREATE TABLE agg (i INTEGER)")
+
+	stats, err := CollectStateStats(context.Background(), conn, path)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(stats.Tables))
+	assert.Equal(t, "agg", stats.Tables[0].Name)
+}
+
+// Tables and offsets are sorted so /stats output and CLI diffs stay stable
+// between runs; DuckDB's row order and map iteration are not guaranteed.
+func TestCollectStateStats_IsDeterministicallyOrdered(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+	saved := NewMarks()
+	saved.Advance("zeta", 0, Mark{Offset: 1})
+	saved.Advance("alpha", 2, Mark{Offset: 2})
+	saved.Advance("alpha", 0, Mark{Offset: 3})
+	assert.NoError(t, s.Save(context.Background(), saved))
+
+	execSQL(t, conn, "CREATE TABLE zulu (i INTEGER)")
+	execSQL(t, conn, "CREATE TABLE alpha (i INTEGER)")
+	execSQL(t, conn, "CREATE TABLE mike (i INTEGER)")
+
+	stats, err := CollectStateStats(context.Background(), conn, path)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"alpha", "mike", "zulu"},
+		[]string{stats.Tables[0].Name, stats.Tables[1].Name, stats.Tables[2].Name})
+
+	assert.Equal(t, "alpha", stats.Offsets[0].Topic)
+	assert.Equal(t, int32(0), stats.Offsets[0].Partition)
+	assert.Equal(t, "alpha", stats.Offsets[1].Topic)
+	assert.Equal(t, int32(2), stats.Offsets[1].Partition)
+	assert.Equal(t, "zeta", stats.Offsets[2].Topic)
+}
+
+// Stats read a dedicated connection, so an in-flight batch stays invisible
+// until it commits. Without this the endpoint would report rows that a
+// rollback then erased -- a durability feature reporting numbers that never
+// survived anything.
+func TestCollectStateStats_DoesNotSeeUncommittedWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+
+	db, err := duckdb.OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	writer, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer writer.Close()
+	reader, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer reader.Close()
+
+	assert.NoError(t, NewOffsetStore(writer).Init(context.Background()))
+	execSQL(t, writer, "CREATE TABLE agg (city VARCHAR)")
+	execSQL(t, writer, "INSERT INTO agg VALUES ('NYC')")
+
+	// The writer goes transactional, as a stateful pipeline does, and adds a
+	// row it has not committed.
+	po, ok := writer.(adbc.PostInitOptions)
+	assert.That(t, ok)
+	assert.NoError(t, po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+	execSQL(t, writer, "INSERT INTO agg VALUES ('SF')")
+
+	stats, err := CollectStateStats(context.Background(), reader, path)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Tables[0].Rows)
+
+	committer, ok := writer.(interface{ Commit(context.Context) error })
+	assert.That(t, ok)
+	assert.NoError(t, committer.Commit(context.Background()))
+
+	stats, err = CollectStateStats(context.Background(), reader, path)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), stats.Tables[0].Rows)
+}
+
+// A table name is read out of a record reader, whose backing buffer is freed
+// when the reader is released. Returning a string that aliases it would hand
+// callers memory that can be reused underneath them.
+func TestCollectStateStats_TableNamesSurviveReaderRelease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
+
+	execSQL(t, conn, "CREATE TABLE a_table_with_a_deliberately_long_name (i INTEGER)")
+
+	stats, err := CollectStateStats(context.Background(), conn, path)
+	assert.NoError(t, err)
+
+	// Churn the allocator: if the name aliased the reader's buffer, this is
+	// where it would be corrupted.
+	for i := 0; i < 200; i++ {
+		_, err := CollectStateStats(context.Background(), conn, path)
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, "a_table_with_a_deliberately_long_name", stats.Tables[0].Name)
+}

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -143,12 +143,31 @@ const (
 	phaseHandlerInvoke = "handler.invoke"
 )
 
+// offsetSaver writes positions into the pipeline's state database. It is an
+// interface so the ordering tests need no DuckDB; OffsetStore implements it.
+type offsetSaver interface {
+	Save(ctx context.Context, marks *Marks) error
+}
+
+// stateTx is the transaction boundary on the state database. ADBC connections
+// with autocommit disabled satisfy it.
+type stateTx interface {
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
+}
+
 type Turbine struct {
 	source        Source
 	sink          Sink
 	handler       Handler
 	batchSize     int
 	flushInterval time.Duration
+
+	// offsets and stateTx are set together, and only when the pipeline has a
+	// state database. Both nil means the historical behaviour: no transaction,
+	// and the source's own commit is the only durable record of progress.
+	offsets offsetSaver
+	stateTx stateTx
 
 	// marks is the last position finished with, per topic and partition; what
 	// commitSource hands a MarkCommitter.
@@ -165,6 +184,16 @@ type Turbine struct {
 func WithTurbineLogger(l *zap.Logger) TurbineOption {
 	return func(t *Turbine) {
 		t.logger = l
+	}
+}
+
+// WithStateStore makes each batch transactional: the handler's writes to the
+// state database and the offsets that produced them commit together, so a
+// crash can never leave one without the other.
+func WithStateStore(offsets offsetSaver, tx stateTx) TurbineOption {
+	return func(t *Turbine) {
+		t.offsets = offsets
+		t.stateTx = tx
 	}
 }
 
@@ -478,6 +507,57 @@ func (t *Turbine) commitSource() error {
 	return t.source.Commit()
 }
 
+// rollbackState discards this batch's uncommitted state writes. Used on the
+// paths that fail before commitState is reached.
+func (t *Turbine) rollbackState(ctx context.Context) {
+	if t.stateTx == nil {
+		return
+	}
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if err := t.stateTx.Rollback(ctx); err != nil {
+		t.logger.Error("rollback failed", zap.Error(err))
+	}
+}
+
+// commitState writes the processed offsets into the state database and commits
+// them together with whatever the handler wrote in this batch. Any failure
+// rolls the whole transaction back, leaving the durable offsets where they
+// were so the batch is replayed rather than lost.
+//
+// A pipeline with no state database does nothing here.
+func (t *Turbine) commitState(ctx context.Context) error {
+	if t.offsets == nil || t.stateTx == nil {
+		return nil
+	}
+
+	c0 := time.Now()
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if err := t.offsets.Save(ctx, t.marks); err != nil {
+		if rbErr := t.stateTx.Rollback(ctx); rbErr != nil {
+			t.logger.Error("rollback after failed offset save", zap.Error(rbErr))
+		}
+		return fmt.Errorf("saving offsets: %w", err)
+	}
+
+	if err := t.stateTx.Commit(ctx); err != nil {
+		// The commit itself failed, so the transaction is still open and
+		// still holds this batch's writes; roll it back explicitly rather
+		// than leaving them to leak into the next batch.
+		if rbErr := t.stateTx.Rollback(ctx); rbErr != nil {
+			t.logger.Error("rollback after failed commit", zap.Error(rbErr))
+		}
+		return fmt.Errorf("committing state: %w", err)
+	}
+
+	t.metrics.StateCommitLatency.Record(ctx, time.Since(c0).Seconds())
+	t.metrics.StateCommitCount.Add(ctx, 1)
+	return nil
+}
+
 // processBatch invokes the handler on the buffered messages, writes the
 // result to the sink, commits the source, and resets the handler for the
 // next batch.
@@ -515,6 +595,9 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	if err := t.flush(batch); err != nil {
 		t.stats.NumErrors++
 		t.logger.Error("error flushing sink", zap.Error(err))
+		// The handler's writes are still uncommitted in the state
+		// transaction; discard them with the batch they belong to.
+		t.rollbackState(ctx)
 		if batch != nil {
 			batch.Release()
 		}
@@ -529,8 +612,25 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 		t.metrics.SinkFlushNumRows.Record(ctx, batch.NumRows())
 	}
 
+	// The state transaction closes after the sink has flushed and before the
+	// source is committed. That order is the guarantee: a crash between the
+	// flush and the commit replays the batch, so an external sink may see a
+	// duplicate -- recoverable -- while state and offsets stay consistent.
+	// Committing first would move the offsets past rows the sink never
+	// received, which loses them silently.
+	if err := t.commitState(ctx); err != nil {
+		t.stats.NumErrors++
+		t.logger.Error("error committing state", zap.Error(err))
+		if batch != nil {
+			batch.Release()
+		}
+		return err
+	}
+
 	// Committed only after the sink has flushed, so a crash replays the
-	// batch rather than losing it.
+	// batch rather than losing it. With a state database this is advisory:
+	// the durable position is the one in the state transaction above, and
+	// this keeps the consumer group's lag readable.
 	if err := t.commitSource(); err != nil {
 		t.logger.Error("error committing source", zap.Error(err))
 		if batch != nil {

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -183,8 +183,22 @@ type Turbine struct {
 	stats       *Stats
 	errorPolicy PipelineErrorPolicies
 
+	// lagAttrCache keeps one attribute set per topic and partition, so the
+	// per-message lag metric costs no allocation. Touched only by mark, on
+	// the consume-loop goroutine.
+	//
+	// The cached value is the variadic slice itself, not just the option:
+	// passing options one by one reallocates the slice on every call.
+	lagAttrCache map[lagKey][]metric.RecordOption
+
 	logger  *zap.Logger
 	metrics *Metrics
+}
+
+// lagKey identifies one topic and partition for the lag attribute cache.
+type lagKey struct {
+	topic     string
+	partition int32
 }
 
 func WithTurbineLogger(l *zap.Logger) TurbineOption {
@@ -367,6 +381,20 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 					return nil, err
 				}
 				numBatchMessages = 0
+				continue
+			}
+			// Nothing buffered, but an idle stateful pipeline still has to
+			// close its open transaction. DuckDB's now() returns the
+			// transaction's start time, so a transaction left open freezes
+			// the clock every window predicate is evaluated against, and a
+			// pipeline that stops receiving messages stops closing windows --
+			// silently, with the rows still reported as live state. This tick
+			// is also what makes a table manager's deletes durable while no
+			// messages are arriving.
+			if err := t.commitState(ctx); err != nil {
+				t.stats.NumErrors++
+				t.logger.Error("error committing state on idle tick", zap.Error(err))
+				return nil, err
 			}
 			continue
 		case <-ctx.Done():
@@ -528,11 +556,33 @@ func (t *Turbine) mark(m Message) {
 	// offset 9 with a watermark of 10 is lag zero.
 	if m.HighWatermark > 0 {
 		t.metrics.ConsumerLag.Record(context.Background(), m.HighWatermark-m.Offset-1,
-			metric.WithAttributes(
-				attribute.String("topic", m.Topic),
-				attribute.Int("partition", int(m.Partition)),
-			))
+			t.lagAttrs(m.Topic, m.Partition)...)
 	}
+}
+
+// lagAttrs returns the cached attribute set for one topic and partition.
+//
+// Building it inline costs an allocation per message whatever the metrics
+// configuration: metric.WithAttributes allocates before any provider decides
+// to discard the measurement. Benchmarked against a noop provider, that took
+// mark from 17.5 ns and no allocations to 224 ns and four -- around 19% of a
+// core at the throughput this engine advertises, spent on garbage.
+//
+// A plain map needs no lock: mark runs only on the consume-loop goroutine.
+func (t *Turbine) lagAttrs(topic string, partition int32) []metric.RecordOption {
+	key := lagKey{topic: topic, partition: partition}
+	if opts, ok := t.lagAttrCache[key]; ok {
+		return opts
+	}
+	opts := []metric.RecordOption{metric.WithAttributes(
+		attribute.String("topic", topic),
+		attribute.Int("partition", int(partition)),
+	)}
+	if t.lagAttrCache == nil {
+		t.lagAttrCache = make(map[lagKey][]metric.RecordOption)
+	}
+	t.lagAttrCache[key] = opts
+	return opts
 }
 
 // commitSource commits what the pipeline has processed. A source that can
@@ -605,6 +655,19 @@ func (t *Turbine) commitState(ctx context.Context) error {
 	return nil
 }
 
+// SyncState closes the open state transaction, making everything written
+// since the last commit durable. A pipeline with no state database does
+// nothing.
+//
+// Shutdown uses it twice: once before the table managers run their final
+// poll, so that poll sees a current clock rather than one frozen at the last
+// batch, and once after, so the rows that poll published are actually deleted
+// instead of being rolled back when the connection closes and republished on
+// the next start.
+func (t *Turbine) SyncState(ctx context.Context) error {
+	return t.commitState(ctx)
+}
+
 // processBatch invokes the handler on the buffered messages, writes the
 // result to the sink, commits the source, and resets the handler for the
 // next batch.
@@ -634,6 +697,10 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 		if err := t.sink.WriteTable(batch); err != nil {
 			t.stats.NumErrors++
 			t.logger.Error("error writing batch to sink", zap.Error(err))
+			// Same reasoning as the flush path below: this batch's handler
+			// writes are still uncommitted, and leaving them open would let
+			// the next batch's commit adopt them along with its own offsets.
+			t.rollbackState(ctx)
 			batch.Release()
 			return err
 		}
@@ -678,12 +745,22 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	// batch rather than losing it. With a state database this is advisory:
 	// the durable position is the one in the state transaction above, and
 	// this keeps the consumer group's lag readable.
+	//
+	// Which is why a failure here is fatal only without a state database.
+	// Once the offsets are durable, killing the pipeline over a rebalance or
+	// a commit timeout trades a readable lag figure for an outage, and the
+	// restart then has to fight its way back into the group.
 	if err := t.commitSource(); err != nil {
-		t.logger.Error("error committing source", zap.Error(err))
-		if batch != nil {
-			batch.Release()
+		if t.stateTx != nil {
+			t.logger.Warn("failed to commit offsets to the source; durable offsets are already committed",
+				zap.Error(err))
+		} else {
+			t.logger.Error("error committing source", zap.Error(err))
+			if batch != nil {
+				batch.Release()
+			}
+			return err
 		}
-		return err
 	}
 
 	b3 := time.Now()

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -29,6 +29,10 @@ type Message struct {
 	// log truncation. Only meaningful when HasMetadata is true; a source with
 	// no positions leaves it zero along with the rest.
 	LeaderEpoch int32
+	// HighWatermark is the partition's high watermark at fetch time, so lag
+	// can be computed against the position last processed. Zero for sources
+	// without one.
+	HighWatermark int64
 }
 
 // Mark is the position of the last message the pipeline has finished with in
@@ -443,6 +447,16 @@ func (t *Turbine) mark(m Message) {
 		return
 	}
 	t.marks.Advance(m.Topic, m.Partition, Mark{Offset: m.Offset, LeaderEpoch: m.LeaderEpoch})
+
+	// -1 because a mark names the last *processed* offset: having processed
+	// offset 9 with a watermark of 10 is lag zero.
+	if m.HighWatermark > 0 {
+		t.metrics.ConsumerLag.Record(context.Background(), m.HighWatermark-m.Offset-1,
+			metric.WithAttributes(
+				attribute.String("topic", m.Topic),
+				attribute.Int("partition", int(m.Partition)),
+			))
+	}
 }
 
 // commitSource commits what the pipeline has processed. A source that can

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -169,6 +169,12 @@ type Turbine struct {
 	offsets offsetSaver
 	stateTx stateTx
 
+	// stateStats reads a snapshot of durable state for the gauges. It reads a
+	// connection dedicated to reading, never the one batches are written on,
+	// so a scrape cannot stall the pipeline. Nil when there is no state
+	// database.
+	stateStats func() (*StateStats, error)
+
 	// marks is the last position finished with, per topic and partition; what
 	// commitSource hands a MarkCommitter.
 	marks       *Marks
@@ -194,6 +200,15 @@ func WithStateStore(offsets offsetSaver, tx stateTx) TurbineOption {
 	return func(t *Turbine) {
 		t.offsets = offsets
 		t.stateTx = tx
+	}
+}
+
+// WithStateStats supplies the snapshot function backing the state gauges. It
+// must read a connection dedicated to reading; passing the pipeline's writer
+// would let a scrape contend with batch processing.
+func WithStateStats(fn func() (*StateStats, error)) TurbineOption {
+	return func(t *Turbine) {
+		t.stateStats = fn
 	}
 }
 
@@ -253,9 +268,41 @@ func (t *Turbine) StatusLoop(ctx context.Context) error {
 		select {
 		case <-ticker.C:
 			t.logThroughput()
+			t.recordStateGauges(ctx)
 		case <-ctx.Done():
 			return nil
 		}
+	}
+}
+
+// recordStateGauges samples the state database for the size and row-count
+// gauges. It runs on StatusLoop's existing tick rather than its own ticker,
+// and reads the dedicated reader connection, so it neither adds a goroutine
+// nor competes with the writer.
+//
+// A pipeline with no state database records nothing at all rather than
+// reporting zero: an absent series and a genuinely empty state are different
+// facts, and a dashboard should be able to distinguish them.
+func (t *Turbine) recordStateGauges(ctx context.Context) {
+	if t.stateStats == nil {
+		return
+	}
+
+	stats, err := t.stateStats()
+	if err != nil {
+		// Never fatal: the pipeline keeps running and keeps serving its
+		// other metrics even when state cannot be read.
+		t.logger.Error("collecting state stats", zap.Error(err))
+		return
+	}
+	if stats == nil {
+		return
+	}
+
+	t.metrics.StateSizeBytes.Record(ctx, stats.SizeBytes)
+	for _, tbl := range stats.Tables {
+		t.metrics.StateTableRows.Record(ctx, tbl.Rows,
+			metric.WithAttributes(attribute.String("table", tbl.Name)))
 	}
 }
 

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -42,9 +42,9 @@ type Mark struct {
 // position. The pipeline prefers it to Commit, because a source that reads
 // ahead of the pipeline -- the Kafka source polls into a buffer -- has fetched
 // messages the pipeline has not processed, and committing "everything fetched"
-// commits those too. Marks are keyed by topic then partition.
+// commits those too.
 type MarkCommitter interface {
-	CommitMarks(marks map[string]map[int32]Mark) error
+	CommitMarks(marks *Marks) error
 }
 
 // HasMetadata reports whether the source supplied provenance for this message.
@@ -148,7 +148,7 @@ type Turbine struct {
 
 	// marks is the last position finished with, per topic and partition; what
 	// commitSource hands a MarkCommitter.
-	marks       map[string]map[int32]Mark
+	marks       *Marks
 	lock        *sync.Mutex
 	running     bool
 	stats       *Stats
@@ -187,7 +187,7 @@ func NewTurbine(
 ) *Turbine {
 	t := &Turbine{
 		source:        source,
-		marks:         map[string]map[int32]Mark{},
+		marks:         NewMarks(),
 		sink:          sink,
 		handler:       handler,
 		batchSize:     batchSize,
@@ -442,17 +442,7 @@ func (t *Turbine) mark(m Message) {
 	if !m.HasMetadata() {
 		return
 	}
-	parts, ok := t.marks[m.Topic]
-	if !ok {
-		parts = map[int32]Mark{}
-		t.marks[m.Topic] = parts
-	}
-	// Offsets arrive in order within a partition; the guard only matters if
-	// a source ever redelivers.
-	if cur, ok := parts[m.Partition]; ok && cur.Offset >= m.Offset {
-		return
-	}
-	parts[m.Partition] = Mark{Offset: m.Offset, LeaderEpoch: m.LeaderEpoch}
+	t.marks.Advance(m.Topic, m.Partition, Mark{Offset: m.Offset, LeaderEpoch: m.LeaderEpoch})
 }
 
 // commitSource commits what the pipeline has processed. A source that can
@@ -466,7 +456,7 @@ func (t *Turbine) mark(m Message) {
 // the consumer group showing no lag.
 func (t *Turbine) commitSource() error {
 	if mc, ok := t.source.(MarkCommitter); ok {
-		if len(t.marks) == 0 {
+		if t.marks.Empty() {
 			return nil
 		}
 		return mc.CommitMarks(t.marks)

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -643,3 +643,43 @@ func TestProcessBatch_NoStateStoreIsUnchanged(t *testing.T) {
 	assert.Equal(t, []string{"flush"}, events)
 	assert.Equal(t, 1, len(src.marks))
 }
+
+// The state gauges are recorded on StatusLoop's existing tick, from the
+// dedicated reader connection -- not the pipeline's writer -- so a scrape can
+// never stall batch processing.
+func TestRecordStateGauges_ReportsSizeAndRows(t *testing.T) {
+	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 4)
+
+	calls := 0
+	tb.stateStats = func() (*StateStats, error) {
+		calls++
+		return &StateStats{
+			Path:      "/state/state.db",
+			SizeBytes: 4096,
+			Tables:    []TableStat{{Name: "agg", Rows: 24}, {Name: "other", Rows: 7}},
+		}, nil
+	}
+
+	tb.recordStateGauges(context.Background())
+	assert.Equal(t, 1, calls)
+}
+
+// A pipeline with no state database records nothing rather than reporting
+// zero: an absent series and a genuinely empty state are different facts, and
+// a dashboard should be able to tell them apart.
+func TestRecordStateGauges_NoProviderRecordsNothing(t *testing.T) {
+	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 4)
+	// stateStats is nil; this must not panic.
+	tb.recordStateGauges(context.Background())
+}
+
+// A failure collecting stats must not take the status loop down with it --
+// the pipeline keeps running and keeps serving its other metrics.
+func TestRecordStateGauges_SurvivesCollectionFailure(t *testing.T) {
+	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 4)
+	tb.stateStats = func() (*StateStats, error) {
+		return nil, errors.New("state database unreadable")
+	}
+
+	tb.recordStateGauges(context.Background())
+}

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -459,3 +459,187 @@ func TestConsumeLoop_MarksTrackEachPartition(t *testing.T) {
 	assert.Equal(t, int64(102), mark0.Offset)
 	assert.Equal(t, int64(501), mark1.Offset)
 }
+
+// --- Task 4: transactional batch -------------------------------------------
+
+// orderingSink records the calls made to it, so the sequence that makes state
+// and offsets atomic can be asserted rather than assumed.
+type orderingSink struct {
+	events *[]string
+	fail   bool
+}
+
+func (s *orderingSink) WriteTable(batch arrow.Table) error { return nil }
+
+func (s *orderingSink) Flush() error {
+	if s.fail {
+		*s.events = append(*s.events, "flush-failed")
+		return errors.New("sink unreachable")
+	}
+	*s.events = append(*s.events, "flush")
+	return nil
+}
+
+func (s *orderingSink) Batch() (arrow.Table, error) { return nil, nil }
+
+// fakeOffsetStore stands in for the DuckDB-backed store so the ordering test
+// needs no database.
+type fakeOffsetStore struct {
+	events *[]string
+	saved  []*Marks
+	fail   bool
+}
+
+func (s *fakeOffsetStore) Save(ctx context.Context, marks *Marks) error {
+	if s.fail {
+		*s.events = append(*s.events, "save-offsets-failed")
+		return errors.New("disk full")
+	}
+	*s.events = append(*s.events, "save-offsets")
+	copied := NewMarks()
+	marks.Each(func(topic string, partition int32, mk Mark) {
+		copied.Advance(topic, partition, mk)
+	})
+	s.saved = append(s.saved, copied)
+	return nil
+}
+
+// txConn records the transaction boundary calls.
+type txConn struct {
+	events *[]string
+	fail   bool
+}
+
+func (c *txConn) Commit(ctx context.Context) error {
+	if c.fail {
+		*c.events = append(*c.events, "commit-failed")
+		return errors.New("commit rejected")
+	}
+	*c.events = append(*c.events, "commit")
+	return nil
+}
+
+func (c *txConn) Rollback(ctx context.Context) error {
+	*c.events = append(*c.events, "rollback")
+	return nil
+}
+
+// The external sink must flush BEFORE the transaction commits. A crash
+// between them replays the batch -- a duplicate the sink can absorb -- rather
+// than committing offsets for rows the sink never received, which loses them
+// with the consumer group reporting no lag.
+func TestProcessBatch_FlushesSinkBeforeCommittingState(t *testing.T) {
+	var events []string
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	store := &fakeOffsetStore{events: &events}
+	conn := &txConn{events: &events}
+
+	tb := NewTurbine(src, &fakeHandler{}, &orderingSink{events: &events}, 4,
+		time.Second, &sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(store, conn))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"flush", "save-offsets", "commit"}, events)
+}
+
+// A sink failure must roll the transaction back, so the offsets on disk stay
+// where they were and the batch is replayed on restart.
+func TestProcessBatch_RollsBackWhenSinkFails(t *testing.T) {
+	var events []string
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	store := &fakeOffsetStore{events: &events}
+	conn := &txConn{events: &events}
+
+	tb := NewTurbine(src, &fakeHandler{}, &orderingSink{events: &events, fail: true}, 4,
+		time.Second, &sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(store, conn))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.Error(t, err)
+	assert.Equal(t, []string{"flush-failed", "rollback"}, events)
+}
+
+// A failure saving offsets must roll back too: state written by the handler
+// in this transaction has to go with the offsets that describe it.
+func TestProcessBatch_RollsBackWhenOffsetSaveFails(t *testing.T) {
+	var events []string
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	store := &fakeOffsetStore{events: &events, fail: true}
+	conn := &txConn{events: &events}
+
+	tb := NewTurbine(src, &fakeHandler{}, &orderingSink{events: &events}, 4,
+		time.Second, &sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(store, conn))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.Error(t, err)
+	assert.Equal(t, []string{"flush", "save-offsets-failed", "rollback"}, events)
+}
+
+// A commit failure is fatal to the batch and must not be followed by a Kafka
+// commit: the durable offsets did not move, so Kafka's must not either.
+func TestProcessBatch_CommitFailureDoesNotCommitSource(t *testing.T) {
+	var events []string
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	store := &fakeOffsetStore{events: &events}
+	conn := &txConn{events: &events, fail: true}
+
+	tb := NewTurbine(src, &fakeHandler{}, &orderingSink{events: &events}, 4,
+		time.Second, &sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(store, conn))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.Error(t, err)
+	assert.Equal(t, []string{"flush", "save-offsets", "commit-failed", "rollback"}, events)
+	// Kafka must not have been told anything.
+	assert.Equal(t, 0, len(src.marks))
+}
+
+// The offsets handed to the store are the ones the pipeline processed, not
+// whatever the source has fetched ahead to.
+func TestProcessBatch_SavesTheProcessedOffsets(t *testing.T) {
+	var events []string
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	store := &fakeOffsetStore{events: &events}
+
+	tb := NewTurbine(src, &fakeHandler{}, &orderingSink{events: &events}, 4,
+		time.Second, &sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(store, &txConn{events: &events}))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(store.saved))
+	got, ok := store.saved[0].Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(3), got.Offset)
+}
+
+// Without a state store the pipeline behaves exactly as before: no
+// transaction calls at all, and the source is still committed.
+func TestProcessBatch_NoStateStoreIsUnchanged(t *testing.T) {
+	var events []string
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+
+	tb := newTestTurbine(src, &fakeHandler{}, &orderingSink{events: &events}, 4)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"flush"}, events)
+	assert.Equal(t, 1, len(src.marks))
+}

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -38,17 +38,17 @@ func (f *fakeSource) Close() error  { return nil }
 // the marks it was handed at each commit.
 type markingSource struct {
 	fakeSource
-	marks []map[string]map[int32]Mark
+	marks []*Marks
 }
 
-func (m *markingSource) CommitMarks(marks map[string]map[int32]Mark) error {
-	copied := map[string]map[int32]Mark{}
-	for topic, parts := range marks {
-		copied[topic] = map[int32]Mark{}
-		for p, mk := range parts {
-			copied[topic][p] = mk
-		}
-	}
+func (m *markingSource) CommitMarks(marks *Marks) error {
+	// Copied because the pipeline keeps advancing the same Marks after this
+	// returns; without the copy every recorded commit would show the final
+	// state.
+	copied := NewMarks()
+	marks.Each(func(topic string, partition int32, mk Mark) {
+		copied.Advance(topic, partition, mk)
+	})
 	m.marks = append(m.marks, copied)
 	return nil
 }
@@ -432,8 +432,12 @@ func TestConsumeLoop_CommitsOnlyProcessedMarks(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 2, len(src.marks))
-	assert.Equal(t, Mark{Offset: 19, LeaderEpoch: 7}, src.marks[0]["events"][0])
-	assert.Equal(t, Mark{Offset: 29, LeaderEpoch: 7}, src.marks[1]["events"][0])
+	first, ok := src.marks[0].Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, Mark{Offset: 19, LeaderEpoch: 7}, first)
+	second, ok := src.marks[1].Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, Mark{Offset: 29, LeaderEpoch: 7}, second)
 	// A source that can take marks must not also get the blanket commit.
 	assert.Equal(t, 0, src.commits)
 }
@@ -450,6 +454,8 @@ func TestConsumeLoop_MarksTrackEachPartition(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(src.marks))
-	assert.Equal(t, int64(102), src.marks[0]["events"][0].Offset)
-	assert.Equal(t, int64(501), src.marks[0]["events"][1].Offset)
+	mark0, _ := src.marks[0].Get("events", 0)
+	mark1, _ := src.marks[0].Get("events", 1)
+	assert.Equal(t, int64(102), mark0.Offset)
+	assert.Equal(t, int64(501), mark1.Offset)
 }

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -332,11 +332,18 @@ type blockingSource struct {
 	release chan struct{}
 }
 
+// Same reason as newIdleSource: allocate off the consume-loop goroutine.
+func newBlockingSource(batch []Message) *blockingSource {
+	return &blockingSource{
+		batch:   batch,
+		ch:      make(chan []Message),
+		release: make(chan struct{}),
+	}
+}
+
 func (s *blockingSource) Start() error { return nil }
 
 func (s *blockingSource) Stream() <-chan []Message {
-	s.ch = make(chan []Message)
-	s.release = make(chan struct{})
 	go func() {
 		s.ch <- s.batch
 		<-s.release
@@ -351,7 +358,7 @@ func (s *blockingSource) Close() error  { return nil }
 // A batch that never reaches batch_size must still be flushed once the flush
 // interval elapses, otherwise a low-traffic topic stalls forever.
 func TestConsumeLoop_FlushesPartialBatchOnFlushInterval(t *testing.T) {
-	src := &blockingSource{batch: messages(10)}
+	src := newBlockingSource(messages(10))
 	sink := &fakeSink{}
 
 	tb := NewTurbine(src, &fakeHandler{}, sink, 1000, 50*time.Millisecond,
@@ -682,4 +689,123 @@ func TestRecordStateGauges_SurvivesCollectionFailure(t *testing.T) {
 	}
 
 	tb.recordStateGauges(context.Background())
+}
+
+// idleSource never delivers a batch, so the consume loop only ever wakes on
+// the flush ticker. It is the shape of a pipeline whose topic has gone quiet.
+type idleSource struct {
+	ch      chan []Message
+	release chan struct{}
+}
+
+// Channels are allocated here, not in Stream: Stream runs on the consume-loop
+// goroutine while the test closes release from its own.
+func newIdleSource() *idleSource {
+	return &idleSource{
+		ch:      make(chan []Message),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *idleSource) Start() error { return nil }
+
+func (s *idleSource) Stream() <-chan []Message {
+	go func() {
+		<-s.release
+		close(s.ch)
+	}()
+	return s.ch
+}
+
+func (s *idleSource) Commit() error { return nil }
+func (s *idleSource) Close() error  { return nil }
+
+// An idle stateful pipeline must still close its transaction on the flush
+// tick. DuckDB's now() is the transaction's start time, so a transaction held
+// open freezes the clock that every window close predicate is evaluated
+// against, and a pipeline that stops receiving messages silently stops
+// closing windows.
+func TestConsumeLoop_IdleTickCommitsTheStateTransaction(t *testing.T) {
+	var events []string
+	src := newIdleSource()
+	store := &fakeOffsetStore{events: &events}
+	conn := &txConn{events: &events}
+
+	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 1000,
+		25*time.Millisecond, &sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(store, conn))
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = tb.ConsumeLoop(context.Background(), 0)
+		close(done)
+	}()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		tb.lock.Lock()
+		n := 0
+		for _, e := range events {
+			if e == "commit" {
+				n++
+			}
+		}
+		tb.lock.Unlock()
+		if n >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("idle pipeline never committed; events=%v", events)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	close(src.release)
+	<-done
+}
+
+// The same tick on a pipeline with no state database must stay the no-op it
+// always was: no commit, no offset save, nothing.
+func TestConsumeLoop_IdleTickIsANoopWithoutState(t *testing.T) {
+	src := newIdleSource()
+	sink := &fakeSink{}
+
+	tb := NewTurbine(src, &fakeHandler{}, sink, 1000,
+		10*time.Millisecond, &sync.Mutex{}, PipelineErrorPolicies{})
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = tb.ConsumeLoop(context.Background(), 0)
+		close(done)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	close(src.release)
+	<-done
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	// An idle pipeline must not flush anything to the sink.
+	assert.Equal(t, int64(0), sink.rows)
+}
+
+// The lag metric must not allocate per message. metric.WithAttributes builds
+// its attribute set before any provider decides whether to keep the
+// measurement, so building it inline cost an allocation on every message even
+// with metrics switched off.
+func BenchmarkMark(b *testing.B) {
+	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 1000)
+	msg := Message{
+		Topic: "events", Partition: 0, Offset: 1,
+		LeaderEpoch: 1, HighWatermark: 1000,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msg.Offset = int64(i)
+		tb.mark(msg)
+	}
 }

--- a/internal/duckdb/open.go
+++ b/internal/duckdb/open.go
@@ -31,21 +31,60 @@ func LibPath() string {
 	return DefaultLinuxLibPath
 }
 
-// Open returns an in-memory DuckDB connection over ADBC.
-func Open(ctx context.Context) (adbc.Connection, error) {
-	var drv drivermgr.Driver
-	db, err := drv.NewDatabase(map[string]string{
+// DB is an open DuckDB database. It exists to hold the ADBC database handle,
+// which is what allows more than one connection against the same file.
+//
+// That matters twice over. A file-backed database is how pipeline state
+// survives a crash, and a second connection is how that state can be read --
+// by the stats endpoint -- without disturbing the writer: connections have
+// independent transaction state, so a reader sees committed rows only and
+// never blocks the pipeline.
+type DB struct {
+	db   adbc.Database
+	path string
+}
+
+// OpenPath opens a DuckDB database over ADBC. A non-empty path is a file, so
+// tables created on it outlive the process; an empty path is in-memory.
+func OpenPath(ctx context.Context, path string) (*DB, error) {
+	opts := map[string]string{
 		"driver":     LibPath(),
 		"entrypoint": "duckdb_adbc_init",
-	})
+	}
+	if path != "" {
+		opts["path"] = path
+	}
+
+	var drv drivermgr.Driver
+	database, err := drv.NewDatabase(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize DuckDB driver: %w", err)
 	}
 
-	conn, err := db.Open(ctx)
+	return &DB{db: database, path: path}, nil
+}
+
+// Connect opens one connection to the database. Each connection carries its
+// own transaction state.
+func (d *DB) Connect(ctx context.Context) (adbc.Connection, error) {
+	conn, err := d.db.Open(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open DuckDB connection: %w", err)
 	}
-
 	return conn, nil
+}
+
+// Path is the file backing the database, empty when it is in-memory.
+func (d *DB) Path() string { return d.path }
+
+func (d *DB) Close() error { return d.db.Close() }
+
+// Open returns a single in-memory DuckDB connection, for callers that need no
+// handle of their own.
+func Open(ctx context.Context) (adbc.Connection, error) {
+	db, err := OpenPath(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	return db.Connect(ctx)
 }

--- a/internal/duckdb/open_test.go
+++ b/internal/duckdb/open_test.go
@@ -1,0 +1,156 @@
+package duckdb
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/zeebo/assert"
+)
+
+func exec(tb testing.TB, conn adbc.Connection, sql string) {
+	tb.Helper()
+
+	stmt, err := conn.NewStatement()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer stmt.Close()
+
+	if err := stmt.SetSqlQuery(sql); err != nil {
+		tb.Fatal(err)
+	}
+	if _, err := stmt.ExecuteUpdate(context.Background()); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func queryInt64(tb testing.TB, conn adbc.Connection, sql string) int64 {
+	tb.Helper()
+
+	stmt, err := conn.NewStatement()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer stmt.Close()
+
+	if err := stmt.SetSqlQuery(sql); err != nil {
+		tb.Fatal(err)
+	}
+	reader, _, err := stmt.ExecuteQuery(context.Background())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer reader.Release()
+
+	for reader.Next() {
+		rec := reader.Record()
+		if rec.NumRows() > 0 {
+			switch col := rec.Column(0).(type) {
+			case *array.Int64:
+				return col.Value(0)
+			case *array.Int32:
+				return int64(col.Value(0))
+			}
+		}
+	}
+	return -1
+}
+
+// A pipeline that declares a state path must get a DuckDB backed by that file,
+// so window state survives the process. In-memory state is lost on a crash
+// while its offsets are already committed -- silently, with the consumer group
+// reporting no lag.
+func TestOpenPath_PersistsAcrossProcesses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+
+	db, err := OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+
+	exec(t, conn, "CREATE TABLE agg (city VARCHAR, n INTEGER)")
+	exec(t, conn, "INSERT INTO agg VALUES ('NYC', 7)")
+	conn.Close()
+	assert.NoError(t, db.Close())
+
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr)
+
+	// A second handle over the same file sees the committed row.
+	db2, err := OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	defer db2.Close()
+	conn2, err := db2.Connect(context.Background())
+	assert.NoError(t, err)
+	defer conn2.Close()
+
+	assert.Equal(t, int64(7), queryInt64(t, conn2, "SELECT n FROM agg WHERE city = 'NYC'"))
+}
+
+// An empty path keeps today's in-memory behaviour, so a config without a state
+// path is unaffected.
+func TestOpenPath_EmptyPathIsInMemory(t *testing.T) {
+	db, err := OpenPath(context.Background(), "")
+	assert.NoError(t, err)
+	defer db.Close()
+
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "CREATE TABLE t (i INTEGER)")
+	assert.Equal(t, "", db.Path())
+}
+
+// Holding the database handle is the point of this type: a second connection
+// is what lets stats be read without disturbing the writer. Each connection
+// has its own transaction state, so an uncommitted batch stays invisible.
+func TestDB_SecondConnectionSeesOnlyCommittedState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+
+	db, err := OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	writer, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer writer.Close()
+	reader, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer reader.Close()
+
+	exec(t, writer, "CREATE TABLE agg (i INTEGER)")
+	exec(t, writer, "INSERT INTO agg VALUES (1)")
+	assert.Equal(t, int64(1), queryInt64(t, reader, "SELECT count(*) FROM agg"))
+
+	// The writer goes transactional, as the pipeline does, and adds a row it
+	// has not committed.
+	po, ok := writer.(adbc.PostInitOptions)
+	assert.That(t, ok)
+	assert.NoError(t, po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+	exec(t, writer, "INSERT INTO agg VALUES (2)")
+
+	// The reader must not see it: stats report what would survive a crash.
+	assert.Equal(t, int64(1), queryInt64(t, reader, "SELECT count(*) FROM agg"))
+
+	committer, ok := writer.(interface{ Commit(context.Context) error })
+	assert.That(t, ok)
+	assert.NoError(t, committer.Commit(context.Background()))
+
+	assert.Equal(t, int64(2), queryInt64(t, reader, "SELECT count(*) FROM agg"))
+}
+
+// Open keeps working for callers that want one connection and no handle.
+func TestOpen_StillReturnsAUsableConnection(t *testing.T) {
+	conn, err := Open(context.Background())
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	exec(t, conn, "CREATE TABLE t (i INTEGER)")
+	exec(t, conn, "INSERT INTO t VALUES (3)")
+	assert.Equal(t, int64(3), queryInt64(t, conn, "SELECT i FROM t"))
+}

--- a/internal/kafka/seek.go
+++ b/internal/kafka/seek.go
@@ -1,0 +1,87 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// OffsetSeeker carries the pipeline's durable positions into the consumer
+// group's join, so a restart resumes where the state database says it stopped
+// rather than where the group happens to sit.
+//
+// It exists because the obvious approach does not work. Committing those
+// positions before consumption starts issues an OffsetCommit with an empty
+// member ID, which Kafka accepts only while the group is Empty. The group is
+// not empty on exactly the restart this feature exists for: a killed process
+// stays a member until its session times out, so the commit fails with
+// UNKNOWN_MEMBER_ID and the pipeline crash-loops until the old session
+// expires. Measured 3/3 against a group with one other member.
+//
+// franz-go's AdjustFetchOffsetsFn runs inside the join instead, after the
+// group's committed offsets are fetched and before consumption begins. It
+// needs no commit and no member ID, so group membership stops mattering.
+type OffsetSeeker struct {
+	mu    sync.Mutex
+	marks *core.Marks
+}
+
+// NewOffsetSeeker returns a seeker holding no positions, which leaves the
+// group's own offsets untouched.
+func NewOffsetSeeker() *OffsetSeeker {
+	return &OffsetSeeker{}
+}
+
+// SetMarks records the positions to resume from. Call it before the first
+// poll; the join has not happened yet at that point.
+func (s *OffsetSeeker) SetMarks(marks *core.Marks) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.marks = marks
+}
+
+// Adjust replaces the group's committed offset with the durable one, for every
+// partition the pipeline holds a mark for. This is where a disagreement
+// between Kafka and the state database is settled, and the state database
+// wins.
+//
+// A stored mark names the last offset processed, so consumption resumes at the
+// next one -- the same +1 convention CommitMarks uses.
+//
+// Only partitions already present in the fetched map are touched. franz-go
+// assigns exactly the map this returns (consumer_group.go:1737), so adding a
+// partition here would make this member consume a partition the group never
+// assigned it. A partition with no mark keeps the group's offset, so a
+// pipeline that gains partitions still follows auto_offset_reset for them.
+func (s *OffsetSeeker) Adjust(_ context.Context, fetched map[string]map[int32]kgo.Offset) (map[string]map[int32]kgo.Offset, error) {
+	s.mu.Lock()
+	marks := s.marks
+	s.mu.Unlock()
+
+	if marks == nil || marks.Empty() {
+		return fetched, nil
+	}
+
+	adjusted := make(map[string]map[int32]kgo.Offset, len(fetched))
+	for topic, partitions := range fetched {
+		adjusted[topic] = make(map[int32]kgo.Offset, len(partitions))
+		for partition, offset := range partitions {
+			adjusted[topic][partition] = offset
+		}
+	}
+
+	marks.Each(func(topic string, partition int32, m core.Mark) {
+		partitions, ok := adjusted[topic]
+		if !ok {
+			return
+		}
+		if _, ok := partitions[partition]; !ok {
+			return
+		}
+		partitions[partition] = kgo.NewOffset().At(m.Offset + 1).WithEpoch(m.LeaderEpoch)
+	})
+
+	return adjusted, nil
+}

--- a/internal/kafka/seek_test.go
+++ b/internal/kafka/seek_test.go
@@ -1,0 +1,157 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/zeebo/assert"
+)
+
+func TestOffsetSeeker_NoMarksLeavesTheGroupOffsetsAlone(t *testing.T) {
+	s := NewOffsetSeeker()
+	fetched := map[string]map[int32]kgo.Offset{
+		"events": {0: kgo.NewOffset().At(60)},
+	}
+
+	got, err := s.Adjust(context.Background(), fetched)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(60), got["events"][0].EpochOffset().Offset)
+}
+
+// A stored mark names the last offset processed, so consumption resumes at the
+// next one.
+func TestOffsetSeeker_MarkOverridesTheGroupOffset(t *testing.T) {
+	s := NewOffsetSeeker()
+	marks := core.NewMarks()
+	marks.Advance("events", 0, core.Mark{Offset: 9, LeaderEpoch: 4})
+	s.SetMarks(marks)
+
+	got, err := s.Adjust(context.Background(), map[string]map[int32]kgo.Offset{
+		"events": {0: kgo.NewOffset().At(60)},
+	})
+	assert.NoError(t, err)
+
+	eo := got["events"][0].EpochOffset()
+	assert.Equal(t, int64(10), eo.Offset)
+	assert.Equal(t, int32(4), eo.Epoch)
+}
+
+// franz-go assigns exactly the map Adjust returns, so a partition invented
+// here becomes a partition this member consumes without the group ever
+// assigning it -- two consumers reading the same partition.
+func TestOffsetSeeker_NeverAddsAnUnassignedPartition(t *testing.T) {
+	s := NewOffsetSeeker()
+	marks := core.NewMarks()
+	marks.Advance("events", 0, core.Mark{Offset: 9})
+	marks.Advance("events", 7, core.Mark{Offset: 99})  // assigned elsewhere
+	marks.Advance("other", 0, core.Mark{Offset: 1234}) // topic not assigned
+	s.SetMarks(marks)
+
+	got, err := s.Adjust(context.Background(), map[string]map[int32]kgo.Offset{
+		"events": {0: kgo.NewOffset().At(60)},
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, 1, len(got["events"]))
+	assert.Equal(t, int64(10), got["events"][0].EpochOffset().Offset)
+}
+
+// A partition the pipeline holds no mark for keeps the group's own offset, so
+// a pipeline that gains a partition still follows auto_offset_reset for it.
+func TestOffsetSeeker_UnmarkedPartitionKeepsTheGroupOffset(t *testing.T) {
+	s := NewOffsetSeeker()
+	marks := core.NewMarks()
+	marks.Advance("events", 0, core.Mark{Offset: 9})
+	s.SetMarks(marks)
+
+	got, err := s.Adjust(context.Background(), map[string]map[int32]kgo.Offset{
+		"events": {0: kgo.NewOffset().At(60), 1: kgo.NewOffset().At(77)},
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, int64(10), got["events"][0].EpochOffset().Offset)
+	assert.Equal(t, int64(77), got["events"][1].EpochOffset().Offset)
+}
+
+// The regression this guards. Resuming used to work by committing the stored
+// positions before consumption started. That commit carries an empty member
+// ID, which Kafka accepts only while the group is Empty -- and the group is
+// not empty on exactly the restart durable state exists for, because a killed
+// process stays a member until its session times out. It failed with
+// UNKNOWN_MEMBER_ID, 3 times out of 3, and the pipeline crash-looped.
+//
+// SeekTo must therefore reach Kafka not at all.
+func TestSource_SeekToIssuesNoCommit(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-seek-nocommit-%d", time.Now().UnixNano())
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	produce(t, client, topic, 20)
+
+	seeker := NewOffsetSeeker()
+	src, err := NewSource(client, WithSeeker(seeker))
+	assert.NoError(t, err)
+
+	marks := core.NewMarks()
+	marks.Advance(topic, 0, core.Mark{Offset: 9})
+	assert.NoError(t, src.SeekTo(marks))
+
+	// Nothing was committed: the positions are held for the join instead.
+	assert.Equal(t, 0, len(client.CommittedOffsets()))
+}
+
+// End to end: the state database disagrees with the consumer group, and the
+// state database wins.
+func TestSource_SeekToResumesFromDurableOffsets(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-seek-resume-%d", time.Now().UnixNano())
+
+	producer := newTestClient(t, broker, topic, topic+"-producer")
+	produce(t, producer, topic, 100)
+	producer.Close()
+
+	// Push the group's own committed offset well past where the durable state
+	// says the pipeline got to, so "resumed from the state database" is
+	// distinguishable from "resumed from the group".
+	first := newTestClient(t, broker, topic, topic)
+	first.PollFetches(context.Background())
+	first.CommitOffsetsSync(context.Background(),
+		map[string]map[int32]kgo.EpochOffset{topic: {0: {Offset: 60, Epoch: -1}}}, nil)
+	first.Close()
+
+	seeker := NewOffsetSeeker()
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(broker),
+		kgo.ConsumerGroup(topic),
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.DisableAutoCommit(),
+		kgo.AdjustFetchOffsetsFn(seeker.Adjust),
+	)
+	assert.NoError(t, err)
+
+	src, err := NewSource(client, WithSeeker(seeker))
+	assert.NoError(t, err)
+	defer src.Close()
+
+	marks := core.NewMarks()
+	marks.Advance(topic, 0, core.Mark{Offset: 9, LeaderEpoch: -1})
+	assert.NoError(t, src.SeekTo(marks))
+
+	select {
+	case batch, ok := <-src.Stream():
+		assert.That(t, ok)
+		assert.That(t, len(batch) > 0)
+		// Processed through 9, so the next record read is 10 -- not the 60
+		// the consumer group would have given us.
+		assert.Equal(t, int64(10), batch[0].Offset)
+	case <-time.After(60 * time.Second):
+		t.Fatal("no records after seeking to the stored offsets")
+	}
+}

--- a/internal/kafka/source.go
+++ b/internal/kafka/source.go
@@ -85,6 +85,41 @@ func (k *Source) Commit() error {
 	return nil
 }
 
+// SeekTo resumes consumption from positions recorded in the pipeline's state
+// database, so a restart picks up where the durable state left off rather
+// than wherever the consumer group happens to sit.
+//
+// It works by committing those positions to the group before consumption
+// starts, which is deliberate. kgo.SetOffsets cannot do this: it "sets only
+// partitions that were previously consumed, any extra partitions are
+// skipped", so calling it before the first poll silently does nothing. A
+// group's start position comes from its committed offsets, so writing ours
+// there is what actually moves it.
+//
+// This also settles what happens when Kafka and the state database disagree:
+// the state database wins, and Kafka is made to agree with it immediately.
+//
+// A stored mark names the last offset processed, so consumption resumes at
+// the next one -- the same +1 convention CommitMarks uses, which is why this
+// delegates to it.
+//
+// Empty marks are a no-op rather than a seek to zero. "Nothing recorded" and
+// "recorded position zero" are different facts: the first must leave
+// auto_offset_reset in charge, and seeking to zero would silently replay an
+// entire topic on a pipeline's first run against a fresh state file.
+func (k *Source) SeekTo(marks *core.Marks) error {
+	if marks == nil || marks.Empty() {
+		return nil
+	}
+
+	if err := k.CommitMarks(marks); err != nil {
+		return fmt.Errorf("seeking to stored offsets: %w", err)
+	}
+
+	k.logger.Info("resuming from stored offsets", zap.Int("partitions", marks.Len()))
+	return nil
+}
+
 // CommitMarks commits exactly the positions the pipeline has finished with.
 //
 // Commit above commits everything this source has fetched, and the poll

--- a/internal/kafka/source.go
+++ b/internal/kafka/source.go
@@ -175,14 +175,17 @@ func (k *Source) Stream() <-chan []core.Message {
 			}
 
 			batch := make([]core.Message, 0, fetches.NumRecords())
-			fetches.EachRecord(func(r *kgo.Record) {
-				batch = append(batch, core.Message{
-					Value:       r.Value,
-					Topic:       r.Topic,
-					Partition:   r.Partition,
-					Offset:      r.Offset,
-					LeaderEpoch: r.LeaderEpoch,
-				})
+			fetches.EachPartition(func(p kgo.FetchTopicPartition) {
+				for _, r := range p.Records {
+					batch = append(batch, core.Message{
+						Value:         r.Value,
+						Topic:         r.Topic,
+						Partition:     r.Partition,
+						Offset:        r.Offset,
+						LeaderEpoch:   r.LeaderEpoch,
+						HighWatermark: p.HighWatermark,
+					})
+				}
 			})
 
 			if len(batch) == 0 {

--- a/internal/kafka/source.go
+++ b/internal/kafka/source.go
@@ -19,6 +19,7 @@ type Source struct {
 	streamChan    chan []core.Message
 	done          chan struct{}
 	closeOnce     sync.Once
+	seeker        *OffsetSeeker
 
 	logger *zap.Logger
 }
@@ -41,6 +42,15 @@ func WithLogger(logger *zap.Logger) Option {
 func WithChannelBuffer(size int) Option {
 	return func(s *Source) {
 		s.channelBuffer = size
+	}
+}
+
+// WithSeeker gives the source the seeker registered on its client, which is
+// what SeekTo writes durable positions into. The seeker has to be built before
+// the client, because it is a client option.
+func WithSeeker(seeker *OffsetSeeker) Option {
+	return func(s *Source) {
+		s.seeker = seeker
 	}
 }
 
@@ -89,19 +99,10 @@ func (k *Source) Commit() error {
 // database, so a restart picks up where the durable state left off rather
 // than wherever the consumer group happens to sit.
 //
-// It works by committing those positions to the group before consumption
-// starts, which is deliberate. kgo.SetOffsets cannot do this: it "sets only
-// partitions that were previously consumed, any extra partitions are
-// skipped", so calling it before the first poll silently does nothing. A
-// group's start position comes from its committed offsets, so writing ours
-// there is what actually moves it.
-//
-// This also settles what happens when Kafka and the state database disagree:
-// the state database wins, and Kafka is made to agree with it immediately.
-//
-// A stored mark names the last offset processed, so consumption resumes at
-// the next one -- the same +1 convention CommitMarks uses, which is why this
-// delegates to it.
+// The positions are handed to the seeker, which applies them during the
+// group's join. Committing them here instead does not work: that commit
+// carries an empty member ID and Kafka refuses it unless the group is Empty,
+// which it is not after a crash. See OffsetSeeker.
 //
 // Empty marks are a no-op rather than a seek to zero. "Nothing recorded" and
 // "recorded position zero" are different facts: the first must leave
@@ -112,9 +113,10 @@ func (k *Source) SeekTo(marks *core.Marks) error {
 		return nil
 	}
 
-	if err := k.CommitMarks(marks); err != nil {
-		return fmt.Errorf("seeking to stored offsets: %w", err)
+	if k.seeker == nil {
+		return fmt.Errorf("seeking to stored offsets: source was built without an offset seeker")
 	}
+	k.seeker.SetMarks(marks)
 
 	k.logger.Info("resuming from stored offsets", zap.Int("partitions", marks.Len()))
 	return nil

--- a/internal/kafka/source.go
+++ b/internal/kafka/source.go
@@ -92,14 +92,17 @@ func (k *Source) Commit() error {
 // batch it had committed offset 70,086. A crash then lost the difference
 // with the consumer group showing no lag. Kafka commits the next offset to
 // read, so a mark at offset N commits N+1.
-func (k *Source) CommitMarks(marks map[string]map[int32]core.Mark) error {
-	offsets := make(map[string]map[int32]kgo.EpochOffset, len(marks))
-	for topic, parts := range marks {
-		offsets[topic] = make(map[int32]kgo.EpochOffset, len(parts))
-		for p, m := range parts {
-			offsets[topic][p] = kgo.EpochOffset{Epoch: m.LeaderEpoch, Offset: m.Offset + 1}
-		}
+func (k *Source) CommitMarks(marks *core.Marks) error {
+	if marks == nil || marks.Empty() {
+		return nil
 	}
+	offsets := make(map[string]map[int32]kgo.EpochOffset, marks.Len())
+	marks.Each(func(topic string, partition int32, m core.Mark) {
+		if offsets[topic] == nil {
+			offsets[topic] = map[int32]kgo.EpochOffset{}
+		}
+		offsets[topic][partition] = kgo.EpochOffset{Epoch: m.LeaderEpoch, Offset: m.Offset + 1}
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), commitTimeout)
 	defer cancel()

--- a/internal/kafka/source_test.go
+++ b/internal/kafka/source_test.go
@@ -102,3 +102,38 @@ func TestSource_CommitMarksCommitsOnlyTheProcessedPosition(t *testing.T) {
 	// truncation, rather than the "unknown" sentinel.
 	assert.Equal(t, last.LeaderEpoch, committed.Epoch)
 }
+
+// Lag is only meaningful against the broker's high watermark, which arrives
+// on the fetch itself. Without it, an operator cannot tell a healthy pipeline
+// from one falling behind.
+func TestSource_MessagesCarryHighWatermark(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-hwm-%d", time.Now().UnixNano())
+
+	// A plain producer, not the group-consumer client newTestClient builds:
+	// that client starts background fetching as soon as it exists, which
+	// races the synchronous produce loop below and can return a fetch whose
+	// high watermark predates the last record produced.
+	producer, err := kgo.NewClient(kgo.SeedBrokers(broker), kgo.AllowAutoTopicCreation())
+	assert.NoError(t, err)
+	defer producer.Close()
+	produce(t, producer, topic, 10)
+
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	select {
+	case batch := <-src.Stream():
+		assert.That(t, len(batch) >= 1)
+		// Ten records were produced, so the high watermark is 10 and the
+		// first record sits 9 behind it.
+		assert.Equal(t, int64(10), batch[0].HighWatermark)
+		assert.Equal(t, int64(0), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for a message")
+	}
+}

--- a/internal/kafka/source_test.go
+++ b/internal/kafka/source_test.go
@@ -30,18 +30,19 @@ func brokerOrSkip(t *testing.T) string {
 	return broker
 }
 
-func newTestClient(t *testing.T, broker, topic, group string) *kgo.Client {
+func newTestClient(t *testing.T, broker, topic, group string, extra ...kgo.Opt) *kgo.Client {
 	t.Helper()
 	// Mirrors sources/init.go: a consumer group with autocommit off, so the
 	// only commits are the ones the source makes.
-	client, err := kgo.NewClient(
+	opts := []kgo.Opt{
 		kgo.SeedBrokers(broker),
 		kgo.ConsumerGroup(group),
 		kgo.ConsumeTopics(topic),
 		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
 		kgo.DisableAutoCommit(),
 		kgo.AllowAutoTopicCreation(),
-	)
+	}
+	client, err := kgo.NewClient(append(opts, extra...)...)
 	assert.NoError(t, err)
 	return client
 }
@@ -157,10 +158,11 @@ func TestSource_SeekToResumesFromStoredOffsets(t *testing.T) {
 	cancel()
 	producer.Close()
 
-	client := newTestClient(t, broker, topic, topic)
+	seeker := NewOffsetSeeker()
+	client := newTestClient(t, broker, topic, topic, kgo.AdjustFetchOffsetsFn(seeker.Adjust))
 	defer client.Close()
 
-	src, err := NewSource(client)
+	src, err := NewSource(client, WithSeeker(seeker))
 	assert.NoError(t, err)
 	defer src.Close()
 

--- a/internal/kafka/source_test.go
+++ b/internal/kafka/source_test.go
@@ -88,9 +88,9 @@ func TestSource_CommitMarksCommitsOnlyTheProcessedPosition(t *testing.T) {
 	}
 	last := got[49]
 
-	assert.NoError(t, src.CommitMarks(map[string]map[int32]core.Mark{
-		topic: {last.Partition: {Offset: last.Offset, LeaderEpoch: last.LeaderEpoch}},
-	}))
+	marks := core.NewMarks()
+	marks.Advance(topic, last.Partition, core.Mark{Offset: last.Offset, LeaderEpoch: last.LeaderEpoch})
+	assert.NoError(t, src.CommitMarks(marks))
 
 	// Kafka commits the *next* offset to read, so processing offset 49
 	// commits 50. Anything larger is a fetched-but-unprocessed message

--- a/internal/kafka/source_test.go
+++ b/internal/kafka/source_test.go
@@ -137,3 +137,78 @@ func TestSource_MessagesCarryHighWatermark(t *testing.T) {
 		t.Fatal("timed out waiting for a message")
 	}
 }
+
+// A restart must resume from the offsets recorded in the state database, not
+// from wherever the consumer group happens to sit. The state file is the
+// source of truth; Kafka's committed offsets are advisory.
+func TestSource_SeekToResumesFromStoredOffsets(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-seek-%d", time.Now().UnixNano())
+
+	// Produced with a plain client, before the group consumer exists: a
+	// client configured with ConsumerGroup starts fetching at construction
+	// and would race this loop.
+	producer, err := kgo.NewClient(kgo.SeedBrokers(broker), kgo.AllowAutoTopicCreation())
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	for i := 0; i < 100; i++ {
+		assert.NoError(t, producer.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte(`{"i":1}`)}).FirstErr())
+	}
+	cancel()
+	producer.Close()
+
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	// Resume as though offset 49 had been processed: the next record read
+	// must be 50, not 0.
+	resume := core.NewMarks()
+	resume.Advance(topic, 0, core.Mark{Offset: 49, LeaderEpoch: 0})
+	assert.NoError(t, src.SeekTo(resume))
+
+	select {
+	case batch := <-src.Stream():
+		assert.That(t, len(batch) >= 1)
+		assert.Equal(t, int64(50), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for a message")
+	}
+}
+
+// No stored offsets means no seek, so auto_offset_reset still governs the
+// first run against a fresh state file. Seeking to zero here would be wrong:
+// "nothing recorded" and "recorded position zero" are different facts.
+func TestSource_SeekToEmptyIsANoop(t *testing.T) {
+	broker := brokerOrSkip(t)
+	topic := fmt.Sprintf("turbine-seek-empty-%d", time.Now().UnixNano())
+
+	producer, err := kgo.NewClient(kgo.SeedBrokers(broker), kgo.AllowAutoTopicCreation())
+	assert.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, producer.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte(`{"i":1}`)}).FirstErr())
+	}
+	cancel()
+	producer.Close()
+
+	client := newTestClient(t, broker, topic, topic)
+	defer client.Close()
+
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+
+	assert.NoError(t, src.SeekTo(core.NewMarks()))
+	assert.NoError(t, src.SeekTo(nil))
+
+	select {
+	case batch := <-src.Stream():
+		assert.Equal(t, int64(0), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for a message")
+	}
+}

--- a/internal/managers/tumbling_test.go
+++ b/internal/managers/tumbling_test.go
@@ -2,7 +2,10 @@ package managers
 
 import (
 	"context"
+	"errors"
+	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -199,4 +202,350 @@ func TestTumbling_StartPollsUntilContextCancelled(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Start did not return after cancellation")
 	}
+}
+
+// --- Failure paths: a window must never be dropped -------------------------
+
+// failingSink fails on the nominated call, so each half of write-then-flush
+// can be exercised separately.
+type failingSink struct {
+	recordingSink
+	failWrite bool
+	failFlush bool
+}
+
+func (s *failingSink) WriteTable(batch arrow.Table) error {
+	if s.failWrite {
+		return errors.New("sink unreachable")
+	}
+	return s.recordingSink.WriteTable(batch)
+}
+
+func (s *failingSink) Flush() error {
+	if s.failFlush {
+		return errors.New("broker rejected the batch")
+	}
+	return s.recordingSink.Flush()
+}
+
+// A window that could not be written must stay in the table. Deleting it would
+// lose the aggregate with no record anywhere that it existed.
+func TestTumbling_SinkWriteFailureLeavesTheWindow(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	seedWindows(t, conn)
+
+	sink := &failingSink{failWrite: true}
+	m := newTestTumbling(conn, &sink.recordingSink)
+	m.sink = sink
+
+	err := m.Poll(context.Background())
+	assert.Error(t, err)
+
+	// All three rows survive: two closed, one open.
+	assert.Equal(t, int64(3), countRows(t, conn, "agg_cities_count"))
+}
+
+// The same holds for a flush failure. Flush is where a Kafka sink blocks on
+// broker acks, so this is the likely half to fail in production.
+func TestTumbling_SinkFlushFailureLeavesTheWindow(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	seedWindows(t, conn)
+
+	sink := &failingSink{failFlush: true}
+	m := newTestTumbling(conn, &sink.recordingSink)
+	m.sink = sink
+
+	err := m.Poll(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, int64(3), countRows(t, conn, "agg_cities_count"))
+}
+
+// A failed poll must be retryable: the next one publishes the same window
+// rather than skipping it.
+//
+// The retry re-writes rows the sink already received. WriteTable succeeded on
+// the first attempt and only Flush failed, so a Kafka sink has those rows
+// buffered and a retry sends them again. That is the at-least-once guarantee,
+// and it is why a window sink wants a key it can deduplicate on.
+func TestTumbling_RetriesAfterAFailedPoll(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	seedWindows(t, conn)
+
+	sink := &failingSink{failFlush: true}
+	m := newTestTumbling(conn, &sink.recordingSink)
+	m.sink = sink
+
+	assert.Error(t, m.Poll(context.Background()))
+
+	// The sink recovers.
+	sink.failFlush = false
+	assert.NoError(t, m.Poll(context.Background()))
+
+	// Four writes for two windows: both attempts wrote before the first one's
+	// flush failed.
+	rows, _ := sink.recordingSink.counts()
+	assert.Equal(t, int64(4), rows)
+
+	// The table is drained regardless, so the windows are not published a
+	// third time.
+	assert.Equal(t, int64(1), countRows(t, conn, "agg_cities_count"))
+}
+
+// A broken delete statement must surface as an error rather than silently
+// republishing the same window on every poll.
+func TestTumbling_DeleteFailureIsReported(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	seedWindows(t, conn)
+
+	sink := &recordingSink{}
+	m := NewTumbling(conn, collectSQL,
+		"DELETE FROM a_table_that_does_not_exist", time.Millisecond, sink, &sync.Mutex{})
+
+	err := m.Poll(context.Background())
+	assert.Error(t, err)
+
+	// The window was published before the delete failed, so it is still in
+	// the table and will be published again. That is at-least-once, and the
+	// error is what tells an operator to fix the SQL.
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(2), rows)
+	assert.Equal(t, int64(3), countRows(t, conn, "agg_cities_count"))
+}
+
+// --- Close logic: only closed windows move ---------------------------------
+
+// An open window must survive a poll untouched. Publishing it early would
+// emit a partial aggregate as if it were final.
+func TestTumbling_OpenWindowsAreNeitherPublishedNorDeleted(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+
+	exec(t, conn, `CREATE TABLE agg_cities_count (bucket TIMESTAMPTZ, city VARCHAR, count INT);`)
+	// Every row is inside the open window.
+	exec(t, conn, `INSERT INTO agg_cities_count VALUES
+		(now()::timestamptz, 'NYC', 3),
+		(now()::timestamptz, 'SF', 1);`)
+
+	sink := &recordingSink{}
+	m := newTestTumbling(conn, sink)
+	assert.NoError(t, m.Poll(context.Background()))
+
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(0), rows)
+	assert.Equal(t, int64(2), countRows(t, conn, "agg_cities_count"))
+}
+
+// A window that closes between two polls is published on the second, not
+// missed because the first poll saw it open.
+func TestTumbling_PublishesAWindowThatClosesBetweenPolls(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+
+	exec(t, conn, `CREATE TABLE agg_cities_count (bucket TIMESTAMPTZ, city VARCHAR, count INT);`)
+	exec(t, conn, `INSERT INTO agg_cities_count VALUES (now()::timestamptz, 'NYC', 3);`)
+
+	sink := &recordingSink{}
+	m := newTestTumbling(conn, sink)
+
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(0), rows)
+
+	// Age the row past the close predicate rather than sleeping for it.
+	exec(t, conn, `UPDATE agg_cities_count SET bucket = now()::timestamptz - INTERVAL '600' SECOND;`)
+
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ = sink.counts()
+	assert.Equal(t, int64(1), rows)
+	assert.Equal(t, int64(0), countRows(t, conn, "agg_cities_count"))
+}
+
+// Polling a table whose closed windows have already been published must not
+// publish them a second time.
+func TestTumbling_RepeatedPollsDoNotRepublish(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	seedWindows(t, conn)
+
+	sink := &recordingSink{}
+	m := newTestTumbling(conn, sink)
+
+	assert.NoError(t, m.Poll(context.Background()))
+	assert.NoError(t, m.Poll(context.Background()))
+	assert.NoError(t, m.Poll(context.Background()))
+
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(2), rows)
+}
+
+// --- Shutdown --------------------------------------------------------------
+
+// Start runs one final poll after its context is cancelled, so a window that
+// closes during shutdown is published rather than stranded in the table.
+func TestTumbling_FinalPollOnShutdownPublishesAClosedWindow(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	seedWindows(t, conn)
+
+	sink := &recordingSink{}
+	// A poll interval longer than the test guarantees the only poll that runs
+	// is the final one.
+	m := NewTumbling(conn, collectSQL, deleteSQL, time.Hour, sink, &sync.Mutex{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- m.Start(ctx) }()
+
+	// Nothing published yet: the ticker will not fire for an hour.
+	time.Sleep(50 * time.Millisecond)
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(0), rows)
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after cancellation")
+	}
+
+	rows, _ = sink.counts()
+	assert.Equal(t, int64(2), rows)
+	assert.Equal(t, int64(1), countRows(t, conn, "agg_cities_count"))
+}
+
+// A failing poll must not kill the manager: the rows stay and the next tick
+// retries them.
+func TestTumbling_StartSurvivesAFailedPoll(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	seedWindows(t, conn)
+
+	sink := &failingSink{failFlush: true}
+	m := NewTumbling(conn, collectSQL, deleteSQL, 5*time.Millisecond,
+		&sink.recordingSink, &sync.Mutex{})
+	m.sink = sink
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- m.Start(ctx) }()
+
+	time.Sleep(60 * time.Millisecond)
+	sink.failFlush = false
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if rows, _ := sink.recordingSink.counts(); rows >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("manager stopped polling after a failure")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after cancellation")
+	}
+}
+
+// --- Interaction with the pipeline's state transaction ---------------------
+
+// A stateful pipeline runs with autocommit disabled, and the manager shares
+// its connection. The manager's DELETE therefore lands inside the pipeline's
+// open transaction rather than committing on its own.
+//
+// That is correct, and these tests pin the two halves of why. Within the
+// process the manager sees its own delete, so a window is published once. The
+// delete becomes durable only when the pipeline commits its next batch, so a
+// crash in between republishes the window on restart -- at-least-once, the
+// same guarantee the sink path gives.
+func TestTumbling_DeleteJoinsThePipelineTransaction(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := duckdb.OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	writer, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer writer.Close()
+	observer, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer observer.Close()
+
+	seedWindows(t, writer)
+
+	// The pipeline turns autocommit off, as it does for a state path.
+	po, ok := writer.(adbc.PostInitOptions)
+	assert.That(t, ok)
+	assert.NoError(t, po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+
+	sink := &recordingSink{}
+	m := newTestTumbling(writer, sink)
+	assert.NoError(t, m.Poll(context.Background()))
+
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(2), rows)
+
+	// The manager sees its own delete, so a second poll republishes nothing.
+	assert.Equal(t, int64(1), countRows(t, writer, "agg_cities_count"))
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ = sink.counts()
+	assert.Equal(t, int64(2), rows)
+
+	// Another connection still sees all three rows: the delete is not
+	// durable yet. A crash here republishes those windows on restart.
+	assert.Equal(t, int64(3), countRows(t, observer, "agg_cities_count"))
+
+	// The pipeline's next batch commits, and the delete becomes durable.
+	committer, ok := writer.(interface{ Commit(context.Context) error })
+	assert.That(t, ok)
+	assert.NoError(t, committer.Commit(context.Background()))
+	assert.Equal(t, int64(1), countRows(t, observer, "agg_cities_count"))
+}
+
+// A rollback discards the manager's delete along with the batch that failed.
+// The window was already published, so the next poll publishes it again --
+// at-least-once rather than a lost window.
+func TestTumbling_DeleteRollsBackWithTheBatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := duckdb.OpenPath(context.Background(), path)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	writer, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	defer writer.Close()
+
+	seedWindows(t, writer)
+
+	po, ok := writer.(adbc.PostInitOptions)
+	assert.That(t, ok)
+	assert.NoError(t, po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+
+	sink := &recordingSink{}
+	m := newTestTumbling(writer, sink)
+	assert.NoError(t, m.Poll(context.Background()))
+	assert.Equal(t, int64(1), countRows(t, writer, "agg_cities_count"))
+
+	// The pipeline's batch fails and rolls back.
+	roller, ok := writer.(interface{ Rollback(context.Context) error })
+	assert.That(t, ok)
+	assert.NoError(t, roller.Rollback(context.Background()))
+
+	// The closed windows are back, and the next poll republishes them.
+	assert.Equal(t, int64(3), countRows(t, writer, "agg_cities_count"))
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(4), rows)
 }

--- a/internal/managers/tumbling_test.go
+++ b/internal/managers/tumbling_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -208,21 +209,24 @@ func TestTumbling_StartPollsUntilContextCancelled(t *testing.T) {
 
 // failingSink fails on the nominated call, so each half of write-then-flush
 // can be exercised separately.
+//
+// The flags are atomic because one test flips them while the manager's
+// goroutine is polling.
 type failingSink struct {
 	recordingSink
-	failWrite bool
-	failFlush bool
+	failWrite atomic.Bool
+	failFlush atomic.Bool
 }
 
 func (s *failingSink) WriteTable(batch arrow.Table) error {
-	if s.failWrite {
+	if s.failWrite.Load() {
 		return errors.New("sink unreachable")
 	}
 	return s.recordingSink.WriteTable(batch)
 }
 
 func (s *failingSink) Flush() error {
-	if s.failFlush {
+	if s.failFlush.Load() {
 		return errors.New("broker rejected the batch")
 	}
 	return s.recordingSink.Flush()
@@ -235,7 +239,8 @@ func TestTumbling_SinkWriteFailureLeavesTheWindow(t *testing.T) {
 	defer cleanup()
 	seedWindows(t, conn)
 
-	sink := &failingSink{failWrite: true}
+	sink := &failingSink{}
+	sink.failWrite.Store(true)
 	m := newTestTumbling(conn, &sink.recordingSink)
 	m.sink = sink
 
@@ -253,7 +258,8 @@ func TestTumbling_SinkFlushFailureLeavesTheWindow(t *testing.T) {
 	defer cleanup()
 	seedWindows(t, conn)
 
-	sink := &failingSink{failFlush: true}
+	sink := &failingSink{}
+	sink.failFlush.Store(true)
 	m := newTestTumbling(conn, &sink.recordingSink)
 	m.sink = sink
 
@@ -274,14 +280,15 @@ func TestTumbling_RetriesAfterAFailedPoll(t *testing.T) {
 	defer cleanup()
 	seedWindows(t, conn)
 
-	sink := &failingSink{failFlush: true}
+	sink := &failingSink{}
+	sink.failFlush.Store(true)
 	m := newTestTumbling(conn, &sink.recordingSink)
 	m.sink = sink
 
 	assert.Error(t, m.Poll(context.Background()))
 
 	// The sink recovers.
-	sink.failFlush = false
+	sink.failFlush.Store(false)
 	assert.NoError(t, m.Poll(context.Background()))
 
 	// Four writes for two windows: both attempts wrote before the first one's
@@ -425,7 +432,8 @@ func TestTumbling_StartSurvivesAFailedPoll(t *testing.T) {
 	defer cleanup()
 	seedWindows(t, conn)
 
-	sink := &failingSink{failFlush: true}
+	sink := &failingSink{}
+	sink.failFlush.Store(true)
 	m := NewTumbling(conn, collectSQL, deleteSQL, 5*time.Millisecond,
 		&sink.recordingSink, &sync.Mutex{})
 	m.sink = sink
@@ -435,7 +443,7 @@ func TestTumbling_StartSurvivesAFailedPoll(t *testing.T) {
 	go func() { done <- m.Start(ctx) }()
 
 	time.Sleep(60 * time.Millisecond)
-	sink.failFlush = false
+	sink.failFlush.Store(false)
 
 	deadline := time.After(5 * time.Second)
 	for {

--- a/internal/managers/tumbling_test.go
+++ b/internal/managers/tumbling_test.go
@@ -557,3 +557,58 @@ func TestTumbling_DeleteRollsBackWithTheBatch(t *testing.T) {
 	rows, _ := sink.counts()
 	assert.Equal(t, int64(4), rows)
 }
+
+// The bug this pins: with autocommit disabled the connection holds one open
+// transaction, and DuckDB's now() returns that transaction's start time. A
+// window close predicate written against now() is therefore evaluated against
+// a frozen clock, so a window that closes while the pipeline is idle is never
+// collected -- no error, no metric, and the rows keep being reported as live
+// state.
+//
+// Committing is what advances the clock, which is why the consume loop now
+// commits on its flush tick even with nothing buffered.
+func TestTumbling_ClockAdvancesOnlyAcrossACommit(t *testing.T) {
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+
+	exec(t, conn, `CREATE TABLE agg_cities_count (bucket TIMESTAMPTZ, city VARCHAR, count INT);`)
+	// One window, open now and closed two seconds from now.
+	exec(t, conn, `INSERT INTO agg_cities_count VALUES (now()::timestamptz, 'NYC', 3);`)
+
+	po, ok := conn.(adbc.PostInitOptions)
+	assert.That(t, ok)
+	assert.NoError(t, po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+	tx := conn.(interface {
+		Commit(context.Context) error
+		Rollback(context.Context) error
+	})
+
+	const closeAfter = `(now()::timestamptz - INTERVAL '2' SECOND)`
+	sink := &recordingSink{}
+	m := NewTumbling(conn,
+		`SELECT bucket, city, count FROM agg_cities_count WHERE bucket < `+closeAfter,
+		`DELETE FROM agg_cities_count WHERE bucket < `+closeAfter,
+		time.Hour, sink, &sync.Mutex{})
+
+	// This poll pins the transaction clock.
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(0), rows)
+
+	// Wall clock crosses the threshold.
+	time.Sleep(3 * time.Second)
+
+	// Still frozen, so still nothing -- this is the failure users would see.
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ = sink.counts()
+	assert.Equal(t, int64(0), rows)
+
+	// A commit is what moves the clock.
+	assert.NoError(t, tx.Commit(context.Background()))
+
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ = sink.counts()
+	assert.Equal(t, int64(1), rows)
+	assert.NoError(t, tx.Commit(context.Background()))
+	assert.Equal(t, int64(0), countRows(t, conn, "agg_cities_count"))
+}

--- a/internal/sources/init.go
+++ b/internal/sources/init.go
@@ -33,12 +33,18 @@ func New(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, 
 			resetOffset = kgo.NewOffset().AtEnd()
 		}
 
+		// Built before the client because it is a client option, and handed
+		// to the source afterwards so SeekTo can fill it in. With no marks
+		// set it leaves the group's own offsets alone.
+		seeker := tkafka.NewOffsetSeeker()
+
 		opts := []kgo.Opt{
 			kgo.SeedBrokers(brokers...),
 			kgo.ConsumerGroup(c.Kafka.GroupID),
 			kgo.ConsumeTopics(c.Kafka.Topics...),
 			kgo.ConsumeResetOffset(resetOffset),
 			kgo.DisableAutoCommit(),
+			kgo.AdjustFetchOffsetsFn(seeker.Adjust),
 			kgo.FetchMaxPartitionBytes(10 << 20), // 10MB per partition
 			kgo.FetchMaxBytes(100 << 20),         // 100MB total per broker
 		}
@@ -58,7 +64,7 @@ func New(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, 
 			return nil, fmt.Errorf("kafka client: %w", err)
 		}
 
-		k, err := tkafka.NewSource(client, tkafka.WithLogger(l))
+		k, err := tkafka.NewSource(client, tkafka.WithLogger(l), tkafka.WithSeeker(seeker))
 		return k, err
 
 	case "websocket":

--- a/scripts/benchmark-container.sh
+++ b/scripts/benchmark-container.sh
@@ -16,6 +16,11 @@ TOPIC="${BENCH_TOPIC:-benchmark-$(date +%s)}"
 # structured handler, the fastest path. benchmark.inferred.mem.yml measures
 # schema inference instead.
 CONFIG="${3:-${CONFIG:-dev/config/examples/benchmark.structured.mem.yml}}"
+# STATE_PATH makes the pipeline's DuckDB file-backed, so every batch commits
+# state and offsets in one transaction. The path is container-local on
+# purpose: a bind mount on Docker Desktop measures the mount, the same way
+# host port-forwarding understates throughput ~10x.
+STATE_PATH="${STATE_PATH:-}"
 NETWORK="dev_default"
 GO_IMAGE="golang:1.25-bookworm"
 RUN_IMAGE="debian:bookworm-slim"
@@ -24,6 +29,7 @@ echo "=== sqlflow benchmark (in-network) ==="
 echo "Messages:   $NUM_MESSAGES"
 echo "Batch size: $BATCH_SIZE"
 echo "Config:     $CONFIG"
+echo "State:      ${STATE_PATH:-in-memory}"
 echo ""
 
 # 1. Check Kafka is running
@@ -60,7 +66,7 @@ echo "Publishing complete."
 # 5. Run sqlflow in-network with a unique consumer group so re-runs start fresh
 GROUP_ID="benchmark-$(date +%s)"
 echo ""
-echo "--- Running sqlflow in-network (batch_size=$BATCH_SIZE, group=$GROUP_ID) ---"
+echo "--- Running sqlflow in-network (batch_size=$BATCH_SIZE, group=$GROUP_ID, state=${STATE_PATH:-memory}) ---"
 echo ""
 
 docker run --rm --network "$NETWORK" \
@@ -72,6 +78,7 @@ docker run --rm --network "$NETWORK" \
     -e SQLFLOW_GROUP_ID="$GROUP_ID" \
     -e SQLFLOW_TOPIC="$TOPIC" \
     -e SQLFLOW_BATCH_SIZE="$BATCH_SIZE" \
+    -e SQLFLOW_STATE_PATH="$STATE_PATH" \
     "$RUN_IMAGE" \
     sh -c '
         # Two memory numbers, sampled at 100ms because memory.peak needs

--- a/sqlflow/static/schemas/config.json
+++ b/sqlflow/static/schemas/config.json
@@ -688,6 +688,18 @@
           "required": [
             "policy"
           ]
+        },
+        "state": {
+          "type": "object",
+          "description": "Where the pipeline keeps its DuckDB state. Absent means in-memory, and state is lost on a crash.",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "File backing the pipeline's DuckDB database. Window state and Kafka offsets are stored here and committed together."
+            }
+          },
+          "required": ["path"],
+          "additionalProperties": false
         }
       },
       "required": [

--- a/sqlflow/static/schemas/config.json
+++ b/sqlflow/static/schemas/config.json
@@ -698,7 +698,9 @@
               "description": "File backing the pipeline's DuckDB database. Window state and Kafka offsets are stored here and committed together."
             }
           },
-          "required": ["path"],
+          "required": [
+            "path"
+          ],
           "additionalProperties": false
         }
       },

--- a/tests/release/test_image.py
+++ b/tests/release/test_image.py
@@ -15,8 +15,10 @@ import ast
 import json
 import os
 import subprocess
+import tempfile
 import time
 
+import duckdb
 import pytest
 import requests
 from confluent_kafka import Producer
@@ -331,3 +333,86 @@ def test_clickhouse_sink(image):
     # And the values are the ones that were published, not defaults.
     assert query(
         "SELECT count(DISTINCT action) FROM test.user_actions") == str(len(actions))
+
+
+def test_window_state_survives_a_restart(image):
+    """A crash mid-window must not lose the aggregate.
+
+    Before durable state, 2,000 events folded into an open window were lost
+    by killing the process: the offsets had already been committed, so the
+    consumer group showed lag 0, a restart replayed nothing, and the
+    aggregate stayed permanently short with no signal that anything was
+    wrong. State and offsets now commit together, so a restart resumes from
+    the durable position and completes the window.
+    """
+    topic = f"stateful-window-{int(time.time())}"
+    num_messages = 2000
+
+    network = Network().create()
+    kafka_ctr = KafkaContainer()
+    kafka_ctr.with_network(network)
+    kafka_ctr.with_network_aliases("kafka")
+    kafka_ctr.start()
+
+    producer = Producer({"bootstrap.servers": kafka_ctr.get_bootstrap_server()})
+    timestamp = "2026-09-02T12:00:00.000Z"
+    for i in range(num_messages):
+        producer.produce(topic, json.dumps({
+            "timestamp": timestamp,
+            "properties": {"city": "NYC"},
+            "user": {"id": str(i)},
+        }))
+    producer.flush()
+
+    with tempfile.TemporaryDirectory() as state_dir:
+        # The container writes the state file here; both runs share it, and
+        # the assertions below read it from the host afterwards.
+        os.chmod(state_dir, 0o777)
+
+        def run_half():
+            container = DockerContainer(image) \
+                .with_volume_mapping(settings.DEV_DIR, "/tmp/conf") \
+                .with_volume_mapping(state_dir, "/state", "rw") \
+                .with_env("SQLFLOW_KAFKA_BROKERS", "kafka:9092") \
+                .with_env("SQLFLOW_STATE_PATH", "/state/state.db") \
+                .with_env("SQLFLOW_TOPIC", topic) \
+                .with_env("SQLFLOW_GROUP_ID", topic) \
+                .with_network(network) \
+                .with_command(
+                    "run /tmp/conf/config/examples/kafka.stateful.window.yml "
+                    f"--max-msgs={num_messages // 2}")
+            container.start()
+            wait_for_logs(
+                container,
+                "consumer loop ending|max messages consumed",
+                timeout=120,
+            )
+            return container
+
+        # First half, then the process goes away with the window still open
+        # and nothing published.
+        run_half()
+
+        state_file = os.path.join(state_dir, "state.db")
+        assert os.path.exists(state_file), "the pipeline did not create its state file"
+
+        conn = duckdb.connect(state_file, read_only=True)
+        halfway = conn.execute("SELECT sum(count) FROM agg_city_count").fetchone()[0]
+        conn.close()
+        assert halfway == num_messages // 2, (
+            f"first run should have aggregated {num_messages // 2}, got {halfway}")
+
+        # Second half in a brand new process, reading the state left behind.
+        run_half()
+
+        conn = duckdb.connect(state_file, read_only=True)
+        total = conn.execute("SELECT sum(count) FROM agg_city_count").fetchone()[0]
+        offset = conn.execute('SELECT max("offset") FROM sqlflow_offsets').fetchone()[0]
+        conn.close()
+
+    # Every event is accounted for across the restart, and the durable
+    # position is the last message actually processed.
+    assert total == num_messages, (
+        f"aggregate lost rows across the restart: {total} of {num_messages}")
+    assert offset == num_messages - 1, (
+        f"stored offset should be the last processed message: {offset}")

--- a/tests/release/test_image.py
+++ b/tests/release/test_image.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 import tempfile
 import time
+from datetime import datetime, timezone
 
 import duckdb
 import pytest
@@ -355,7 +356,11 @@ def test_window_state_survives_a_restart(image):
     kafka_ctr.start()
 
     producer = Producer({"bootstrap.servers": kafka_ctr.get_bootstrap_server()})
-    timestamp = "2026-09-02T12:00:00.000Z"
+    # The current hour, so the window is still open for the length of the run
+    # and recovery is observed on a partial aggregate. A fixed timestamp goes
+    # stale: once it is more than an hour old the manager legitimately closes
+    # the window, publishes it and deletes the rows these assertions read.
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
     for i in range(num_messages):
         producer.produce(topic, json.dumps({
             "timestamp": timestamp,


### PR DESCRIPTION
## Summary

SQLFlow keeps window state and Kafka offsets in the same DuckDB file and
commits them in one transaction. A crash can no longer leave one without the
other, so a windowed pipeline survives a restart instead of silently losing
the window it was building.

Before this branch, a crash mid-window lost that window's aggregate while its
offsets were already committed. The consumer group reported no lag, the
restart replayed nothing, and the data was gone with no error anywhere.

Set `pipeline.state.path` to turn it on:

```yaml
pipeline:
  state:
    path: /var/lib/sqlflow/state.db
```

Without it nothing changes: DuckDB runs in memory and every code path this
branch adds is skipped.

## Delivery guarantees

- **Pipeline state is exactly-once relative to offsets.** The handler's writes
  and the offsets that produced them commit together. A replay neither
  double-counts nor skips.
- **External sinks are at-least-once.** The sink flushes before the
  transaction commits, so a crash in between replays the batch and the sink
  may see a duplicate. Give a sink a key it can deduplicate on.

The order is the guarantee: invoke → write → flush → save offsets → commit
state → commit source. Committing before the flush would move offsets past
rows the sink never received, which loses them silently.

## What's here

- Offsets stored in DuckDB, committed with the state that produced them
- `Marks` type replacing `map[string]map[int32]Mark`
- Resume on startup from the durable offsets, which beat the consumer group
- Five new metrics: `consumer_lag`, `state_commit_count`,
  `state_commit_latency`, `state_db_size_bytes`, `state_table_rows`
- `/stats` endpoint reporting what is on disk, read from a second connection
  so a scrape never blocks a batch
- Crash-recovery test in the release suite
- Benchmarks for what durability costs

## Two defects the final review found

Both broke windowed pipelines, which are the pipelines this feature exists
for. Both reproduce, and both are fixed in `13829ac`.

**An idle stateful pipeline stopped closing windows.** Disabling autocommit
holds one transaction open, and DuckDB's `now()` returns the transaction's
start time. Every window close predicate was therefore evaluated against a
clock frozen at the last batch commit, so a pipeline that stopped receiving
messages stopped closing windows — with no error, no metric, and
`state_table_rows` still reporting the stranded rows as live state.

Measured: `now()` identical 5 seconds apart under an open transaction,
advancing across a commit. End to end, a pipeline that consumed 20 messages
and went quiet published nothing for 45 seconds where its window should have
closed after 5. The same run on the fixed binary published in about 1 second.

The consume loop now commits on the flush tick even with nothing buffered,
which bounds clock staleness to `flush_interval_seconds` and makes a table
manager's deletes durable while no messages arrive.

**Resuming failed whenever the consumer group was not empty.** `SeekTo`
committed the stored positions before the client joined, so the `OffsetCommit`
carried an empty member ID — which Kafka accepts only while the group is
Empty. That is never true on the restart this feature exists for, because a
killed process stays a member until its session times out. Measured
`UNKNOWN_MEMBER_ID` 3 times out of 3 against a group with one other member;
the pipeline would have crash-looped until the old session expired.

Positions now go through franz-go's `AdjustFetchOffsetsFn`, which runs inside
the join after offsets are fetched. No commit and no member ID are involved,
so group membership stops mattering. Verified the override beats a group
committed at 60 and resumes at 10.

## Also fixed

- Roll back the state transaction when a sink write fails, matching the flush
  path. Latent today because every `processBatch` error is fatal.
- Stop killing a stateful pipeline when the advisory Kafka commit fails. The
  durable offsets are already committed, so a rebalance traded a readable lag
  figure for an outage.
- Cancel the status loop before closing the reader connection. A gauge sample
  mid-query during shutdown is a use-after-free inside DuckDB, which the race
  detector cannot see.
- Commit around the managers' final poll, so a clean shutdown stops
  guaranteeing a republished window.
- Cache the lag attribute set per topic and partition. It allocated on every
  message whatever the metrics config: 224 ns and 4 allocs per message, now
  41.75 ns and none.

## Performance

A transaction is one fsync per batch, so its cost per message falls as batches
grow. Same pipeline, same 300,000 messages:

| `batch_size` | State in memory | Durable state | Cost |
|---|---|---|---|
| 500 | ~95,600 msgs/sec | ~51,100 msgs/sec | 47% |
| 2000 | ~184,600 msgs/sec | ~130,600 msgs/sec | 29% |
| 5000 | ~201,600 msgs/sec | ~171,500 msgs/sec | 15% |

Use a batch of at least 5000 for a stateful pipeline. Peak working set stayed
within 191-218 MiB across every run, with and without state: durability costs
throughput, not memory.

## Testing

- Full suite green under `-race` across all 13 packages, zero data races
- The idle-tick regression test fails without its fix, verified by reverting
- Crash recovery end to end: run 1 consumes 1000 of 2000 then dies
  (aggregate 1000, offset 999); run 2 resumes and finishes (aggregate 2000,
  offset 1999). Before this work, run 2 consumed 0 and the aggregate stayed
  at 1000 permanently while the group reported no lag.
- Seeker tests cover the unassigned-partition case. franz-go assigns exactly
  the map `Adjust` returns, so inventing a partition there would make two
  consumers read the same one.

## Known limitations

- One state file belongs to one running pipeline. DuckDB locks it
  exclusively, so no other process can read it, not even read-only. Use
  `/stats`.
- Windows close on wall-clock time. There is no event-time watermarking and
  no late-arrival policy.
- `Save` rewrites every partition on every batch. Irrelevant at 1-8
  partitions, worth revisiting at 200.
