### PR TITLE
Drain the pipeline on SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,24 @@ pipeline's next batch. A crash in between republishes the window.
 Without a state path there is no state guarantee at all: handler state does not
 survive the process.
 
+## Graceful shutdown
+
+`SIGTERM` and `SIGINT` drain the pipeline. The drain runs in order:
+
+1. Stop consuming.
+2. Write the batch it had buffered.
+3. Run each table manager's final poll.
+4. Commit state and offsets.
+5. Exit 0.
+
+A supervisor that stops a pipeline this way loses nothing. Skipping the drain
+loses no data either, because the buffered batch replays from the last
+committed offset. It costs that duplicate work, and it republishes any window
+that closed during shutdown.
+
+The drain has no deadline. A sink that blocks holds the process open until the
+supervisor escalates to `SIGKILL`.
+
 ## Tumbling windows
 
 A table declared under `tables.sql` can carry a `manager`, which polls the table

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -17,9 +17,11 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/turbolytics/sql-flow/internal/config"
@@ -103,6 +105,15 @@ func NewCommand() *cobra.Command {
 					}
 				}()
 			}
+
+			// A supervisor stops a pipeline with SIGTERM. Go's default handler
+			// terminates the process without running any deferred function.
+			// Three deferred steps below would therefore never run: the final
+			// batch, the managers' last poll, and the state commit that makes
+			// their deletes durable.
+			ctx, stopSignals := signal.NotifyContext(
+				context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stopSignals()
 
 			conf, err := config.Load(configPath, map[string]string{})
 			if err != nil {
@@ -370,7 +381,12 @@ func NewCommand() *cobra.Command {
 				statusWG.Wait()
 			}()
 
-			stats, err := turbine.ConsumeLoop(context.Background(), maxMsgs)
+			stats, err := turbine.ConsumeLoop(ctx, maxMsgs)
+			// Restore default signal handling for the rest of the shutdown.
+			// The deferred drain below still has to run. Leaving the handler
+			// installed would swallow a second SIGTERM, so an operator could
+			// not interrupt a drain that hangs.
+			stopSignals()
 			if err != nil {
 				l.Error("failed to consume loop", zap.Error(err))
 				return err

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -398,8 +398,21 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 			}
 			continue
 		case <-ctx.Done():
-			t.logger.Warn("context done, stopping consumer loop")
+			t.logger.Info("context done, draining the consumer loop")
 			t.running = false
+			// The source delivered this batch, but nothing has written it yet.
+			// Returning without it drops the tail of every graceful shutdown.
+			//
+			// The drain runs on a context of its own. Every step below reaches
+			// DuckDB and the sink. The cancelled ctx would fail the exact work
+			// the drain exists to finish.
+			if numBatchMessages > 0 {
+				if err := t.processBatch(context.WithoutCancel(ctx), numBatchMessages); err != nil {
+					t.stats.NumErrors++
+					t.logger.Error("error draining the final batch", zap.Error(err))
+					return nil, err
+				}
+			}
 			t.logThroughput()
 			return t.stats, nil
 		}

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -390,6 +390,70 @@ func TestConsumeLoop_FlushesPartialBatchOnFlushInterval(t *testing.T) {
 	<-done
 }
 
+// drainHandler signals after every Write, so a test can cancel at the exact
+// point the batch finishes buffering. Polling the handler's counter instead
+// would race the consume-loop goroutine that owns it.
+type drainHandler struct {
+	fakeHandler
+	wrote chan struct{}
+}
+
+func (h *drainHandler) Write(msg []byte) error {
+	if err := h.fakeHandler.Write(msg); err != nil {
+		return err
+	}
+	h.wrote <- struct{}{}
+	return nil
+}
+
+// A supervisor's SIGTERM reaches the pipeline as a cancelled context. The
+// source has already delivered the batch buffered at that moment, and nothing
+// has written it. Returning without it drops the tail of every graceful
+// shutdown.
+func TestConsumeLoop_CancelDrainsTheBufferedBatch(t *testing.T) {
+	src := newBlockingSource(messages(10))
+	sink := &fakeSink{}
+	h := &drainHandler{wrote: make(chan struct{})}
+
+	// An hour, so nothing but the cancel can move this batch: reaching the
+	// sink here proves the drain ran, not the flush ticker.
+	tb := NewTurbine(src, h, sink, 1000, time.Hour, &sync.Mutex{}, PipelineErrorPolicies{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer close(src.release)
+
+	var (
+		stats *Stats
+		err   error
+		done  = make(chan struct{})
+	)
+	go func() {
+		defer close(done)
+		stats, err = tb.ConsumeLoop(ctx, 0)
+	}()
+
+	for i := 0; i < 10; i++ {
+		<-h.wrote
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("consume loop did not return after the context was cancelled")
+	}
+
+	assert.NoError(t, err)
+
+	sink.mu.Lock()
+	rows, flushes := sink.rows, sink.flushes
+	sink.mu.Unlock()
+
+	assert.Equal(t, int64(10), rows)
+	assert.Equal(t, 1, flushes)
+	assert.Equal(t, int64(10), stats.MessagesConsumed())
+}
+
 func TestConsumeLoop_WritesEveryMessageAcrossManyBatches(t *testing.T) {
 	src := &fakeSource{batches: [][]Message{messages(500), messages(500), messages(250)}}
 	sink := &fakeSink{}

--- a/tests/release/test_image.py
+++ b/tests/release/test_image.py
@@ -421,3 +421,80 @@ def test_window_state_survives_a_restart(image):
         f"aggregate lost rows across the restart: {total} of {num_messages}")
     assert offset == num_messages - 1, (
         f"stored offset should be the last processed message: {offset}")
+
+
+def test_sigterm_drains_the_buffered_batch(image):
+    """A supervisor stops a pipeline with SIGTERM, so SIGTERM must drain it.
+
+    Go terminates on SIGTERM without running any deferred function. The process
+    once died at once: exit 143, the buffered batch never written, the
+    managers' final poll never run.
+
+    The pipeline lost no data, because the offsets had not advanced either.
+    Every graceful stop still threw away its tail and replayed it.
+
+    This run publishes 300 messages against a batch size of 250, which leaves
+    50 buffered. The flush interval outlasts the run, so only the drain can
+    move them.
+    """
+    topic = f"sigterm-drain-{int(time.time())}"
+    num_messages = 300
+    batch_size = 250
+
+    network = Network().create()
+    kafka_ctr = KafkaContainer()
+    kafka_ctr.with_network(network)
+    kafka_ctr.with_network_aliases("kafka")
+    kafka_ctr.start()
+
+    producer = Producer({"bootstrap.servers": kafka_ctr.get_bootstrap_server()})
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    for i in range(num_messages):
+        producer.produce(topic, json.dumps({
+            "timestamp": timestamp,
+            "properties": {"city": "NYC"},
+            "user": {"id": str(i)},
+        }))
+    producer.flush()
+
+    with tempfile.TemporaryDirectory() as state_dir:
+        os.chmod(state_dir, 0o777)
+
+        # No --max-msgs: the pipeline runs until a signal stops it. A pipeline
+        # that exits on its own proves nothing here.
+        container = DockerContainer(image) \
+            .with_volume_mapping(settings.DEV_DIR, "/tmp/conf") \
+            .with_volume_mapping(state_dir, "/state", "rw") \
+            .with_env("SQLFLOW_KAFKA_BROKERS", "kafka:9092") \
+            .with_env("SQLFLOW_STATE_PATH", "/state/state.db") \
+            .with_env("SQLFLOW_TOPIC", topic) \
+            .with_env("SQLFLOW_GROUP_ID", topic) \
+            .with_env("SQLFLOW_BATCH_SIZE", str(batch_size)) \
+            .with_network(network) \
+            .with_command("run /tmp/conf/config/examples/kafka.stateful.window.yml")
+        container.start()
+
+        # The pipeline has consumed every message, so 50 remain buffered and
+        # wait for something to write them.
+        wait_for_logs(container, f"messages_consumed.*{num_messages}", timeout=120)
+
+        wrapped = container.get_wrapped_container()
+        wrapped.kill(signal="SIGTERM")
+        result = wrapped.wait(timeout=60)
+        exit_code = result["StatusCode"]
+
+        state_file = os.path.join(state_dir, "state.db")
+        conn = duckdb.connect(state_file, read_only=True)
+        total = conn.execute("SELECT sum(count) FROM agg_city_count").fetchone()[0]
+        offset = conn.execute('SELECT max("offset") FROM sqlflow_offsets').fetchone()[0]
+        conn.close()
+
+    # Without a handler this exits 2, not the 143 an unhandled SIGTERM usually
+    # produces. sqlflow runs as PID 1 here, and the kernel discards a signal
+    # that PID 1 has no handler for. The Go runtime re-raises it, gets nowhere,
+    # and falls back to exit(2). The same binary as an ordinary child exits 143.
+    assert exit_code == 0, f"SIGTERM should exit cleanly, got {exit_code}"
+    assert total == num_messages, (
+        f"drain lost the buffered batch: {total} of {num_messages}")
+    assert offset == num_messages - 1, (
+        f"stored offset should be the last processed message: {offset}")


### PR DESCRIPTION
## Summary

`sqlflow` handled no signals. Go terminates on SIGTERM without running any
deferred function. Three deferred shutdown steps therefore never ran: the
buffered batch, the table managers' final poll, and the state commit that makes
their deletes durable.

#158 added that drain. It ran only when `--max-msgs` stopped the pipeline.
Kubernetes, systemd, and `docker stop` all send SIGTERM, so the drain never ran
in production.

The pipeline lost no data. The offsets did not advance either, so the next start
replayed the batch. Each graceful stop cost duplicate work and republished any
window that closed during shutdown.

Closes #159.

## The fix

Three changes:

1. Install a signal context for SIGTERM and SIGINT.
2. Pass it to `ConsumeLoop`.
3. Drain the buffered batch when the context cancels.

The drain runs on `context.WithoutCancel`. Every step of a batch reaches DuckDB
and the sink. A cancelled context would fail the exact work the drain exists to
finish.

`ConsumeLoop` restores default signal handling when it returns. A second SIGTERM
then interrupts a drain that hangs.

## Evidence

One binary, built before and after the fix. Each run publishes 300 messages at
`batch_size` 250. The flush interval outlasts the run, so only a drain moves the
50-message remainder:

| | exit code | rows in state |
|---|---|---|
| before | 143 | 250 of 300 |
| after | 0 | 300 of 300 |

The unfixed log ends mid-run and carries no shutdown lines.

## Exit 2, not 143

The shipped image exits 2 in the unhandled case. An unhandled SIGTERM usually
gives 143.

`sqlflow` runs as PID 1 in the container. The kernel discards a signal that
PID 1 has no handler for. The Go runtime re-raises it, gets nowhere, and falls
back to `exit(2)`.

Running the same unfixed image with `--init` confirms the mechanism. `sqlflow`
becomes an ordinary child process and exits 143. As PID 1 it exits 2.

The old behaviour was worse than an abrupt death. The kernel ignored the signal,
and only a runtime fallback ended the process.

## Testing

Two tests cover the change:

- `TestConsumeLoop_CancelDrainsTheBufferedBatch` covers the drain.
- `test_sigterm_drains_the_buffered_batch` covers the signal wiring end to end
  against the built image.

Both earn their place. The unit test exercises `ConsumeLoop`, so removing the
`signal.NotifyContext` wiring leaves it green.

Each test fails without the fix. The unit test fails on the row count. The
release test fails on the exit code, against an image built from stashed source.

Results:

- Go suite under `-race`: green across 13 packages, zero data races
- Release suite: 8 passed, up from 7

## Documentation

The README claimed that a final poll runs on shutdown. That held only under
`--max-msgs`. It now holds on the path supervisors use.

A new "Graceful shutdown" section names the signals and describes the drain. The
section also states that the drain has no deadline. A blocked sink holds the
process open until the supervisor escalates to SIGKILL. #161 covers that
deadline.
