### PR TITLE
fix: re-plan the StructuredBatch query on every batch

### DIFF
--- a/internal/handlers/structured.go
+++ b/internal/handlers/structured.go
@@ -222,6 +222,16 @@ func (h *StructuredBatchHandler) Invoke(ctx context.Context) (arrow.Table, error
 
 	t2 := time.Now()
 
+	// Re-prepared per batch, after the ingest. DuckDB's ADBC layer plans the
+	// statement when the SQL is set and keeps that plan until the catalog
+	// changes, which TRUNCATE and append never do. A plan built against the
+	// empty table folds its statistics in: a WHERE over a column becomes
+	// always-false and an expression over a list element becomes NULL, so
+	// every batch afterwards returns nothing or one group.
+	if err := h.queryStmt.SetSqlQuery(h.sql); err != nil {
+		return nil, fmt.Errorf("set query sql: %w", err)
+	}
+
 	// Query results back using the user's SQL
 	reader, _, err := h.queryStmt.ExecuteQuery(ctx)
 

--- a/internal/handlers/structured_test.go
+++ b/internal/handlers/structured_test.go
@@ -148,6 +148,81 @@ func TestStructuredBatchHandler_NestedStruct(t *testing.T) {
 	res.Release()
 }
 
+// The handler prepares its SQL before any batch exists. A WHERE over a struct
+// field must still see the rows of the batch that arrives afterwards, not the
+// empty table the statement was planned against.
+func TestStructuredBatchHandler_FilterSeesRowsIngestedAfterPrepare(t *testing.T) {
+	conn, cleanup := newTestADBCConn(t)
+	defer cleanup()
+
+	createTable(t, conn, `CREATE TABLE posts (time_us BIGINT, commit STRUCT(operation TEXT));`)
+
+	schema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "time_us", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "commit", Type: arrow.StructOf(
+				arrow.Field{Name: "operation", Type: arrow.BinaryTypes.String},
+			)},
+		}, nil)
+
+	h, err := NewStructuredBatchHandler(conn,
+		"SELECT time_us FROM posts WHERE commit.operation = 'create'",
+		"posts", schema)
+	assert.NoError(t, err)
+	assert.NoError(t, h.Init(context.Background()))
+
+	messages := []string{
+		`{"time_us": 1, "commit": {"operation": "create"}}`,
+		`{"time_us": 2, "commit": {"operation": "delete"}}`,
+		`{"time_us": 3, "commit": {"operation": "create"}}`,
+	}
+	for _, msg := range messages {
+		assert.NoError(t, h.Write([]byte(msg)))
+	}
+
+	res, err := h.Invoke(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), res.NumRows())
+	res.Release()
+}
+
+// Same defect, different symptom: an expression over a list element inside a
+// struct folds to NULL when planned against the empty table.
+func TestStructuredBatchHandler_ListElementSeesRowsIngestedAfterPrepare(t *testing.T) {
+	conn, cleanup := newTestADBCConn(t)
+	defer cleanup()
+
+	createTable(t, conn, `CREATE TABLE posts (record STRUCT(langs TEXT[]));`)
+
+	schema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "record", Type: arrow.StructOf(
+				arrow.Field{Name: "langs", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+			)},
+		}, nil)
+
+	h, err := NewStructuredBatchHandler(conn,
+		"SELECT coalesce(record.langs[1], 'unknown') AS lang, COUNT(*) AS cnt FROM posts GROUP BY lang ORDER BY lang",
+		"posts", schema)
+	assert.NoError(t, err)
+	assert.NoError(t, h.Init(context.Background()))
+
+	messages := []string{
+		`{"record": {"langs": ["en"]}}`,
+		`{"record": {"langs": ["pt"]}}`,
+		`{"record": {"langs": ["en"]}}`,
+	}
+	for _, msg := range messages {
+		assert.NoError(t, h.Write([]byte(msg)))
+	}
+
+	res, err := h.Invoke(context.Background())
+	assert.NoError(t, err)
+	// en and pt, not a single 'unknown' group.
+	assert.Equal(t, int64(2), res.NumRows())
+	res.Release()
+}
+
 func TestStructuredBatchHandler_LargeBatch(t *testing.T) {
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()


### PR DESCRIPTION
## Defect

`handlers.StructuredBatch` sets its SQL once, in the constructor, before any batch exists. DuckDB's ADBC layer prepares on `SetSqlQuery` and keeps that plan until the catalog changes. `TRUNCATE` and append never change the catalog, so the plan built against the empty table is reused for every batch, with the empty table's statistics folded in:

- A `WHERE` over a column folds to always-false. The batch returns no rows.
- An expression over a list element folds to `NULL`. A `GROUP BY` on it collapses to one group.

A plain projection still works, which is why the benchmarks never caught it. `InferredMemBatch` is unaffected: it creates its statement per batch.

## Fix

Set the SQL again on every `Invoke`, after the ingest, so DuckDB plans against the batch's statistics. One prepare per batch, the same cost `InferredMemBatch` already pays.

## Evidence

- Two new tests reproduce both symptoms against libduckdb 1.5.2. On `main` they fail with `2 != 0` and `2 != 1`. With this change they pass, along with the rest of the handlers package.
- Against the live Bluesky Jetstream feed, a tumbling window pipeline with `WHERE commit.operation = 'create'` wrote nothing to Postgres in seven minutes on `turbolytics/sql-flow:latest`. The same config with `SET disabled_optimizers = 'statistics_propagation'` wrote the expected per-language counts every minute.

## What breaks if this is wrong

Any `StructuredBatch` SQL with a filter silently drops every row again.