### PR TITLE
feat: add a Bluesky tumbling window example that sinks to Postgres

### DIFF
--- a/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
@@ -1,0 +1,82 @@
+# Counts Bluesky posts per minute by language in a 1-minute tumbling window
+# and writes each closed window to Postgres.
+commands:
+  - name: load postgres extension
+    sql: |
+      INSTALL postgres;
+      LOAD postgres;
+
+  - name: attach postgres
+    sql: |
+      ATTACH '{{ SQLFLOW_POSTGRES_URI|default('postgresql://postgres:postgres@sqlflow-postgres:5432/postgres') }}' AS pg (TYPE POSTGRES);
+
+  - name: declare the post schema
+    sql: |
+      CREATE TABLE IF NOT EXISTS posts (
+        time_us BIGINT,
+        commit STRUCT(
+          operation TEXT,
+          record STRUCT(langs TEXT[])
+        )
+      );
+
+tables:
+  sql:
+    - name: posts_per_minute_by_lang
+      sql: |
+        CREATE TABLE IF NOT EXISTS posts_per_minute_by_lang (
+          bucket TIMESTAMP,
+          lang TEXT,
+          posts INTEGER
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS posts_per_minute_by_lang_idx
+          ON posts_per_minute_by_lang (bucket, lang);
+
+      manager:
+        # The grace period outlives the batch wait on purpose. A batch flushes
+        # when it fills or after flush_interval_seconds, so an event from the
+        # last seconds of a window can reach DuckDB up to that long after the
+        # window ended. A grace period shorter than the batch wait publishes
+        # the window before those events land.
+        tumbling_window:
+          poll_interval_seconds: 10
+          collect_closed_windows_sql: |
+            SELECT bucket, lang, posts
+            FROM posts_per_minute_by_lang
+            WHERE bucket + INTERVAL '1 minute' < now()::TIMESTAMP - INTERVAL '60 seconds'
+          delete_closed_windows_sql: |
+            DELETE FROM posts_per_minute_by_lang
+            WHERE bucket + INTERVAL '1 minute' < now()::TIMESTAMP - INTERVAL '60 seconds'
+
+        sink:
+          type: sqlcommand
+          sqlcommand:
+            sql: |
+              INSERT INTO pg.posts_per_minute_by_lang (bucket, lang, posts)
+              SELECT bucket, lang, posts FROM sqlflow_sink_batch
+
+pipeline:
+  name: bluesky-posts-per-minute-by-lang
+  batch_size: 500
+
+  source:
+    type: websocket
+    websocket:
+      uri: 'wss://jetstream2.us-east.bsky.network/subscribe?wantedCollections=app.bsky.feed.post'
+
+  handler:
+    type: handlers.StructuredBatch
+    table: posts
+    sql: |
+      INSERT INTO posts_per_minute_by_lang
+      SELECT
+        date_trunc('minute', make_timestamp(time_us)) AS bucket,
+        coalesce(commit.record.langs[1], 'unknown') AS lang,
+        count(*) AS posts
+      FROM posts
+      WHERE commit.operation = 'create'
+      GROUP BY bucket, lang
+      ON CONFLICT (bucket, lang) DO UPDATE SET posts = posts + EXCLUDED.posts
+
+  sink:
+    type: noop


### PR DESCRIPTION
Adds `dev/config/examples/bluesky/bluesky.postgres.windowed.yml`: a 1-minute tumbling window over the Bluesky jetstream that counts posts per language and writes each closed window to Postgres.

The existing `bluesky.kafka.windowed.yml` publishes closed windows to Kafka. Nothing shipped shows a window landing in a database, which is the shape most people want first.

## Notes on the config

- **Declared schema.** `handlers.StructuredBatch` with the three fields the SQL reads. Bluesky events vary in shape, so a missing `langs` becomes NULL instead of depending on what a given batch contains.
- **60-second grace period.** Longer than the 30-second default batch wait, on purpose. A batch flushes when it fills or when `flush_interval_seconds` elapses, so an event from the final seconds of a window can reach DuckDB that long after the window ended. A grace period shorter than the batch wait publishes the window first and then deletes those rows unpublished.

## Depends on #174

The handler SQL filters with `WHERE commit.operation = 'create'`. On `main` that returns nothing, because StructuredBatch reuses a plan built against the empty table. Merge #174 first or this example writes an empty table.

## Verification

- `go test ./internal/cli/ ./internal/config/` passes, which includes the schema validation over every shipped example.
- Ran against the live jetstream for 11 minutes with the #174 build. Every closed window reached Postgres, no errors.