### PR TITLE
Fail loud on a corrupt or partial state file

### DIFF
--- a/internal/cli/exit_test.go
+++ b/internal/cli/exit_test.go
@@ -78,3 +78,46 @@ func TestRuntimeErrorDoesNotPrintTheFlagList(t *testing.T) {
 		t.Errorf("a runtime failure printed the usage text:\n%s", output)
 	}
 }
+
+// runArgs executes the CLI with args and reports the exit code and output.
+func runArgs(t *testing.T, args ...string) (int, string) {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := NewRootCommand()
+	cmd.SetArgs(args)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	return execute(cmd), out.String()
+}
+
+// A config path that does not exist is the user's to fix. Exiting retryable
+// would have a supervisor restart until someone notices.
+func TestExecute_MissingConfigIsTerminal(t *testing.T) {
+	code, output := runArgs(t, "run", "/nope/does-not-exist.yml")
+
+	assert.Equal(t, errs.ExitUserError, code)
+	assert.That(t, !errs.Retryable(code))
+	assert.That(t, strings.Contains(output, string(errs.CodeConfigNotFound)))
+}
+
+// Unparseable YAML does not become parseable on a retry.
+func TestExecute_MalformedConfigIsTerminal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.yml")
+	assert.NoError(t, os.WriteFile(path, []byte("pipeline:\n  name: [unclosed\n"), 0o644))
+
+	code, output := runArgs(t, "run", path)
+
+	assert.Equal(t, errs.ExitUserError, code)
+	assert.That(t, !errs.Retryable(code))
+	assert.That(t, strings.Contains(output, "user.config"))
+}
+
+// Suppressing usage for runtime errors must not suppress it for the errors
+// usage actually answers.
+func TestExecute_UsageErrorStillPrintsUsage(t *testing.T) {
+	_, output := runArgs(t, "run", "--not-a-real-flag")
+
+	if !strings.Contains(output, "Flags:") {
+		t.Errorf("a usage error lost its usage text:\n%s", output)
+	}
+}

--- a/internal/cli/exit_test.go
+++ b/internal/cli/exit_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/zeebo/assert"
+)
+
+const statefulExample = "../../dev/config/examples/kafka.stateful.window.yml"
+
+// corruptStateCommand points the stateful example at a file that is not a
+// DuckDB database, and captures everything the command prints.
+func corruptStateCommand(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	statePath := filepath.Join(t.TempDir(), "state.db")
+	assert.NoError(t, os.WriteFile(statePath, []byte("not a duckdb database"), 0o644))
+	t.Setenv("SQLFLOW_STATE_PATH", statePath)
+
+	var out bytes.Buffer
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"run", statefulExample, "--max-msgs", "1"})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	return cmd, &out
+}
+
+func runWithCorruptState(t *testing.T) (error, string) {
+	t.Helper()
+	cmd, out := corruptStateCommand(t)
+	return cmd.Execute(), out.String()
+}
+
+// The exit code is the whole point of the taxonomy: it is what a supervisor
+// reads. Exiting 1 marks the failure retryable, so the supervisor restarts
+// forever into the same bytes.
+func TestExecute_CorruptStateFileExitsTerminal(t *testing.T) {
+	cmd, _ := corruptStateCommand(t)
+
+	code := execute(cmd)
+
+	assert.Equal(t, errs.ExitStateCorrupt, code)
+	assert.That(t, !errs.Retryable(code))
+}
+
+// A successful command exits zero.
+func TestExecute_SuccessExitsZero(t *testing.T) {
+	cmd := NewRootCommand()
+	cmd.SetArgs([]string{"version"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Equal(t, errs.ExitOK, execute(cmd))
+}
+
+// Guards propagation rather than driving it: the code has to survive cobra's
+// error path to reach execute at all.
+func TestErrorCodeSurvivesCobra(t *testing.T) {
+	err, _ := runWithCorruptState(t)
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeStateCorrupt, errs.CodeOf(err))
+}
+
+// Failing loud means the operator sees the error. Cobra prints the full flag
+// list for any error a command returns, which buries the one line that says
+// what went wrong.
+func TestRuntimeErrorDoesNotPrintTheFlagList(t *testing.T) {
+	_, output := runWithCorruptState(t)
+
+	if strings.Contains(output, "Flags:") {
+		t.Errorf("a runtime failure printed the usage text:\n%s", output)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/turbolytics/sql-flow/internal/cli/run"
 	"github.com/turbolytics/sql-flow/internal/cli/tail"
+	"github.com/turbolytics/sql-flow/internal/errs"
 	"os"
 )
 
@@ -16,6 +17,14 @@ func NewRootCommand() *cobra.Command {
 		// The run function is called when the command is executed
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("Welcome to sqlflow!")
+		},
+		// Cobra prints the whole flag list for any error a command returns,
+		// which buries the one line that says what failed. Flags have already
+		// parsed by the time this runs, so a usage error still gets usage and
+		// a runtime failure does not.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return nil
 		},
 	}
 
@@ -34,10 +43,20 @@ func NewRootCommand() *cobra.Command {
 }
 
 func Execute() {
-	cmd := NewRootCommand()
-	// cobra has already reported the error on stderr by this point; printing
-	// it again here would duplicate every message.
+	os.Exit(execute(NewRootCommand()))
+}
+
+// execute runs the command and returns the code the process should exit with.
+//
+// The code is the part of the error taxonomy a supervisor actually reads, so
+// it has to come from the error rather than being a constant. Exiting 1 for
+// every failure marks a bad config and a corrupt state file as retryable, and
+// a supervisor then restarts both forever.
+//
+// Nothing is printed here: cobra has already reported the error on stderr.
+func execute(cmd *cobra.Command) int {
 	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
+		return errs.ExitCode(err)
 	}
+	return errs.ExitOK
 }

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -18,7 +18,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"runtime"
 	"sync"
 	"syscall"
@@ -131,16 +130,20 @@ func NewCommand() *cobra.Command {
 			if conf.Pipeline.State != nil {
 				statePath = conf.Pipeline.State.Path
 			}
-			if statePath != "" {
-				if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
-					return errs.Wrap(errs.CodeStateInternal, err, "creating state directory for %q", statePath)
-				}
-			}
 
 			// The handle is kept, not just a connection: a second connection
 			// is what lets /stats read committed state without contending
 			// with the writer.
-			db, err := duckdb.OpenPath(context.Background(), statePath)
+			//
+			// A declared state path goes through OpenState, which separates a
+			// first run from a damaged file. An empty path is in-memory and
+			// has nothing to recover, so it opens directly.
+			var db *duckdb.DB
+			if statePath != "" {
+				db, err = core.OpenState(context.Background(), statePath)
+			} else {
+				db, err = duckdb.OpenPath(context.Background(), "")
+			}
 			if err != nil {
 				return err
 			}
@@ -185,16 +188,20 @@ func NewCommand() *cobra.Command {
 				storedMarks *core.Marks
 			)
 			if statePath != "" {
+				// Both calls are returned as-is. They already carry a code, and
+				// the outermost code wins: re-wrapping either as
+				// CodeStateInternal would turn a corrupt state file into a
+				// retryable failure and hand a supervisor a crash loop.
 				offsets := core.NewOffsetStore(conn)
 				if err := offsets.Init(context.Background()); err != nil {
-					return errs.Wrap(errs.CodeStateInternal, err, "initializing offsets table")
+					return err
 				}
 
 				// Read the durable positions before autocommit is turned off,
 				// so setup is committed and the read is straightforward.
 				storedMarks, err = offsets.Load(context.Background())
 				if err != nil {
-					return errs.Wrap(errs.CodeStateInternal, err, "loading stored offsets")
+					return err
 				}
 
 				// Every batch from here on is one transaction: the handler's

--- a/internal/core/offsets.go
+++ b/internal/core/offsets.go
@@ -3,10 +3,12 @@ package core
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/errs"
 )
 
 // offsetsTable is where a pipeline's Kafka positions live in DuckDB, next to
@@ -30,9 +32,49 @@ func NewOffsetStore(conn adbc.Connection) *OffsetStore {
 	return &OffsetStore{conn: conn}
 }
 
-// Init creates the offsets table if it does not already exist. It is safe to
-// call on every start, including against a state file from a previous run.
+// offsetsSchema is the shape Load binds against, in column order. Init compares
+// an existing table to this rather than trusting it, because CREATE TABLE IF
+// NOT EXISTS accepts any table that merely shares the name.
+var offsetsSchema = []string{
+	"topic VARCHAR",
+	"partition INTEGER",
+	"offset BIGINT",
+	"leader_epoch INTEGER",
+}
+
+// Init prepares the offsets table, and refuses to run against a state file it
+// cannot read.
+//
+// The table is created only when it is absent, which is the first run. When it
+// is present, its schema has to match offsetsSchema exactly. A table that
+// carries the right name and the wrong shape means the file was written by
+// something else, or damaged; either way the positions in it cannot be trusted.
+//
+// The alternative -- CREATE TABLE IF NOT EXISTS, as this did before -- accepts
+// the damaged table, finds no readable positions, and replays the topic from
+// the beginning while reporting healthy. A silent restart from zero is worse
+// than a refusal to start, so this returns CodeStateCorrupt and changes
+// nothing on disk.
 func (s *OffsetStore) Init(ctx context.Context) error {
+	found, err := s.offsetsTableSchema(ctx)
+	if err != nil {
+		return errs.Wrap(errs.CodeStateCorrupt, err,
+			"reading the schema of %s from the state file", offsetsTable)
+	}
+
+	if len(found) > 0 {
+		if !slices.Equal(found, offsetsSchema) {
+			return errs.New(errs.CodeStateCorrupt,
+				"state file has a %s table this build cannot read; "+
+					"expected (%s), found (%s). The file has been left untouched: "+
+					"preserve it and report, or start from a new state path to resume service",
+				offsetsTable,
+				strings.Join(offsetsSchema, ", "),
+				strings.Join(found, ", "))
+		}
+		return nil
+	}
+
 	stmt, err := s.conn.NewStatement()
 	if err != nil {
 		return fmt.Errorf("creating statement: %w", err)
@@ -40,7 +82,7 @@ func (s *OffsetStore) Init(ctx context.Context) error {
 	defer stmt.Close()
 
 	if err := stmt.SetSqlQuery(`
-		CREATE TABLE IF NOT EXISTS ` + offsetsTable + ` (
+		CREATE TABLE ` + offsetsTable + ` (
 		    topic        VARCHAR NOT NULL,
 		    partition    INTEGER NOT NULL,
 		    "offset"     BIGINT  NOT NULL,
@@ -54,6 +96,48 @@ func (s *OffsetStore) Init(ctx context.Context) error {
 		return fmt.Errorf("creating offsets table: %w", err)
 	}
 	return nil
+}
+
+// offsetsTableSchema returns the table's columns as "name type" strings in
+// ordinal order, or nil when the table does not exist.
+func (s *OffsetStore) offsetsTableSchema(ctx context.Context) ([]string, error) {
+	stmt, err := s.conn.NewStatement()
+	if err != nil {
+		return nil, fmt.Errorf("creating statement: %w", err)
+	}
+	defer stmt.Close()
+
+	if err := stmt.SetSqlQuery(fmt.Sprintf(
+		`SELECT column_name || ' ' || data_type
+		 FROM information_schema.columns
+		 WHERE table_name = '%s'
+		 ORDER BY ordinal_position`, offsetsTable)); err != nil {
+		return nil, fmt.Errorf("setting schema query: %w", err)
+	}
+
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("querying schema: %w", err)
+	}
+	defer reader.Release()
+
+	var cols []string
+	for reader.Next() {
+		rec := reader.Record()
+		vals, ok := rec.Column(0).(*array.String)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for column description: %T", rec.Column(0))
+		}
+		for i := 0; i < int(rec.NumRows()); i++ {
+			// Clone: the value aliases the record's buffer, which is released
+			// when this function returns.
+			cols = append(cols, strings.Clone(vals.Value(i)))
+		}
+	}
+	if err := reader.Err(); err != nil {
+		return nil, fmt.Errorf("reading schema: %w", err)
+	}
+	return cols, nil
 }
 
 // Save upserts one row per topic/partition in marks. It does not commit: the
@@ -109,7 +193,10 @@ func (s *OffsetStore) Load(ctx context.Context) (*Marks, error) {
 
 	reader, _, err := stmt.ExecuteQuery(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("querying offsets: %w", err)
+		// Init already proved the table's schema, so a failure here is the file
+		// itself. A database truncated mid-write reports as a short read. Coded
+		// corrupt so a supervisor stops rather than re-reading the same bytes.
+		return nil, errs.Wrap(errs.CodeStateCorrupt, err, "reading offsets from the state file")
 	}
 	defer reader.Release()
 
@@ -145,7 +232,7 @@ func (s *OffsetStore) Load(ctx context.Context) (*Marks, error) {
 		}
 	}
 	if err := reader.Err(); err != nil {
-		return nil, fmt.Errorf("reading offsets: %w", err)
+		return nil, errs.Wrap(errs.CodeStateCorrupt, err, "reading offsets from the state file")
 	}
 
 	return marks, nil

--- a/internal/core/state.go
+++ b/internal/core/state.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/turbolytics/sql-flow/internal/duckdb"
+	"github.com/turbolytics/sql-flow/internal/errs"
+)
+
+// OpenState opens the DuckDB database backing a pipeline's durable state.
+//
+// It exists to separate two cases that duckdb.OpenPath cannot tell apart. A
+// path with no file is the first run, and creating it is correct. A path that
+// holds something DuckDB refuses to open is a damaged state file, and starting
+// over would replay from the beginning while reporting healthy.
+//
+// A damaged file is never repaired, moved, or truncated here. It holds the only
+// copy of the pipeline's positions, so it is evidence an operator needs.
+func OpenState(ctx context.Context, path string) (*duckdb.DB, error) {
+	info, err := os.Stat(path)
+	switch {
+	case err == nil && info.IsDir():
+		// A directory is a config mistake, not corruption. Saying so sends the
+		// operator to the config rather than to the state file.
+		return nil, errs.New(errs.CodeConfigInvalid,
+			"pipeline.state.path %q is a directory, not a file", path)
+
+	case os.IsNotExist(err):
+		// First run. DuckDB creates the file, but not the directories above it.
+		if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+			return nil, errs.Wrap(errs.CodeStateInternal, mkErr,
+				"creating state directory for %q", path)
+		}
+
+	case err != nil:
+		return nil, errs.Wrap(errs.CodeStateInternal, err, "reading state path %q", path)
+	}
+
+	db, err := duckdb.OpenPath(ctx, path)
+	if err != nil {
+		// The file exists and DuckDB will not open it. A restart reads the
+		// same bytes, so this is terminal rather than retryable.
+		return nil, errs.Wrap(errs.CodeStateCorrupt, err,
+			"state file %q exists but cannot be opened; it has been left untouched", path)
+	}
+	return db, nil
+}

--- a/internal/core/state_test.go
+++ b/internal/core/state_test.go
@@ -1,0 +1,208 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/zeebo/assert"
+)
+
+// exec runs one statement and reports whether DuckDB accepted it.
+func exec(t *testing.T, conn adbc.Connection, sql string) {
+	t.Helper()
+	stmt, err := conn.NewStatement()
+	assert.NoError(t, err)
+	defer stmt.Close()
+	assert.NoError(t, stmt.SetSqlQuery(sql))
+	_, err = stmt.ExecuteUpdate(context.Background())
+	assert.NoError(t, err)
+}
+
+// columnsOf reports the offsets table's columns as "name type" strings, so a
+// test can prove Init left a damaged table exactly as it found it.
+func columnsOf(t *testing.T, conn adbc.Connection) []string {
+	t.Helper()
+	stmt, err := conn.NewStatement()
+	assert.NoError(t, err)
+	defer stmt.Close()
+	assert.NoError(t, stmt.SetSqlQuery(fmt.Sprintf(
+		`SELECT column_name || ' ' || data_type FROM information_schema.columns
+		 WHERE table_name = '%s' ORDER BY ordinal_position`, offsetsTable)))
+	reader, _, err := stmt.ExecuteQuery(context.Background())
+	assert.NoError(t, err)
+	defer reader.Release()
+
+	var out []string
+	for reader.Next() {
+		rec := reader.Record()
+		col, ok := rec.Column(0).(*array.String)
+		assert.That(t, ok)
+		for i := 0; i < int(rec.NumRows()); i++ {
+			// Clone: the value aliases the record buffer, which the next
+			// call to Next may reuse.
+			out = append(out, strings.Clone(col.Value(i)))
+		}
+	}
+	return out
+}
+
+// A state file whose offsets table has the wrong columns is not a state file
+// this build can read. Creating it fresh would restart from the beginning and
+// call that healthy.
+func TestOffsetStore_InitRejectsWrongColumns(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	exec(t, conn, `CREATE TABLE `+offsetsTable+` (topic VARCHAR, partition INTEGER)`)
+
+	err := NewOffsetStore(conn).Init(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeStateCorrupt, errs.CodeOf(err))
+}
+
+// Right names, wrong types. Load only notices this when the table happens to
+// hold rows, so the check has to happen at open.
+func TestOffsetStore_InitRejectsWrongTypes(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	exec(t, conn, `CREATE TABLE `+offsetsTable+` (
+		topic VARCHAR, partition VARCHAR, "offset" VARCHAR, leader_epoch VARCHAR)`)
+
+	err := NewOffsetStore(conn).Init(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeStateCorrupt, errs.CodeOf(err))
+}
+
+// The error has to name the table and say what was wrong, or an operator
+// cannot tell a damaged state file from any other startup failure.
+func TestOffsetStore_InitNamesWhatIsWrong(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	exec(t, conn, `CREATE TABLE `+offsetsTable+` (topic VARCHAR, partition INTEGER)`)
+
+	err := NewOffsetStore(conn).Init(context.Background())
+
+	assert.Error(t, err)
+	msg := err.Error()
+	for _, want := range []string{offsetsTable, "offset"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+// Never truncate, recreate, or silently repair. A damaged table is evidence an
+// operator needs, and it is the only copy of the positions.
+func TestOffsetStore_InitLeavesADamagedTableUntouched(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	exec(t, conn, `CREATE TABLE `+offsetsTable+` (topic VARCHAR, partition INTEGER)`)
+	exec(t, conn, `INSERT INTO `+offsetsTable+` VALUES ('events', 3)`)
+	before := columnsOf(t, conn)
+
+	assert.Error(t, NewOffsetStore(conn).Init(context.Background()))
+
+	assert.DeepEqual(t, before, columnsOf(t, conn))
+	n, err := countRows(context.Background(), conn, offsetsTable)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+}
+
+// A fresh database is the normal first run and must still work.
+func TestOffsetStore_InitAcceptsAFreshDatabase(t *testing.T) {
+	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
+	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
+
+	marks, err := NewOffsetStore(conn).Load(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, marks.Len())
+}
+
+// A healthy file from a previous run resumes, and Init does not disturb it.
+func TestOffsetStore_InitAcceptsAPriorRunAndKeepsItsRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	conn := newStateConn(t, path)
+	s := NewOffsetStore(conn)
+	assert.NoError(t, s.Init(context.Background()))
+	m := NewMarks()
+	m.Advance("events", 0, Mark{Offset: 99, LeaderEpoch: 4})
+	assert.NoError(t, s.Save(context.Background(), m))
+
+	// Same file, second run.
+	assert.NoError(t, s.Init(context.Background()))
+
+	out, err := s.Load(context.Background())
+	assert.NoError(t, err)
+	got, ok := out.Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(99), got.Offset)
+}
+
+// A path that exists but is not a DuckDB database is a damaged state file, not
+// a fresh one. Exit terminal so a supervisor stops rather than crash-looping.
+func TestOpenState_RejectsAFileThatIsNotADatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	assert.NoError(t, os.WriteFile(path, []byte("not a duckdb database"), 0o644))
+
+	_, err := OpenState(context.Background(), path)
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeStateCorrupt, errs.CodeOf(err))
+	assert.Equal(t, errs.ExitStateCorrupt, errs.ExitCode(err))
+}
+
+// A zero-byte file is the shape a crash between create and first write leaves.
+func TestOpenState_RejectsAZeroByteFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	assert.NoError(t, os.WriteFile(path, nil, 0o644))
+
+	_, err := OpenState(context.Background(), path)
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeStateCorrupt, errs.CodeOf(err))
+}
+
+// A directory at the state path is a config mistake, not a damaged file. The
+// operator fixes the config, so it must not read as state corruption.
+func TestOpenState_ReportsADirectoryAsAConfigError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	assert.NoError(t, os.MkdirAll(path, 0o755))
+
+	_, err := OpenState(context.Background(), path)
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeConfigInvalid, errs.CodeOf(err))
+}
+
+// A missing file is the first run. It must open and create.
+func TestOpenState_CreatesAMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "state.db")
+
+	db, err := OpenState(context.Background(), path)
+	assert.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	conn, err := db.Connect(context.Background())
+	assert.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
+}
+
+// A damaged file must survive the failed start. It is the only copy of the
+// positions, and an operator needs it to recover them.
+func TestOpenState_LeavesADamagedFileOnDisk(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	content := []byte("not a duckdb database")
+	assert.NoError(t, os.WriteFile(path, content, 0o644))
+
+	_, err := OpenState(context.Background(), path)
+	assert.Error(t, err)
+
+	after, readErr := os.ReadFile(path)
+	assert.NoError(t, readErr)
+	assert.Equal(t, string(content), string(after))
+}

--- a/tests/release/test_image.py
+++ b/tests/release/test_image.py
@@ -75,20 +75,43 @@ def parse_rows(stdout):
 
 
 def run_docker_container(image, command):
+    _, stdout, stderr = run_image(image, command)
+    return stdout, stderr
+
+
+# Exit codes from internal/errs/exit.go. Restated here on purpose: these are
+# the contract a supervisor reads, so the release suite asserts the numbers
+# rather than importing whatever the build happens to define.
+EXIT_OK = 0
+EXIT_INTERNAL = 1
+EXIT_USER_ERROR = 10
+EXIT_SOURCE_UNREACHABLE = 11
+EXIT_SINK_UNREACHABLE = 12
+EXIT_RESOURCE_LIMIT = 13
+EXIT_STATE_CORRUPT = 14
+
+# A supervisor must stop on these rather than restart into the same failure.
+TERMINAL_EXITS = {EXIT_USER_ERROR, EXIT_STATE_CORRUPT}
+
+
+def run_image(image, command, volumes=None, env=None):
+    """Run the image and return (exit_code, stdout, stderr).
+
+    The exit code is the point: it is what a supervisor reads to decide
+    whether restarting can help, and run_docker_container drops it.
+    """
+    args = ["docker", "run", "--rm", "-v", f"{settings.DEV_DIR}:/tmp/conf"]
+    for host, container in (volumes or {}).items():
+        args += ["-v", f"{host}:{container}:rw"]
+    for key, value in (env or {}).items():
+        args += ["-e", f"{key}={value}"]
+    args.append(image)
+
     result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "-v",
-            f"{settings.DEV_DIR}:/tmp/conf",
-            "--rm",
-            image,
-        ] + command.split(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True
+        args + command.split(),
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
     )
-    return result.stdout, result.stderr
+    return result.returncode, result.stdout, result.stderr
 
 
 def test_sqlflow_docker_invoke_readme_example(image):
@@ -498,3 +521,50 @@ def test_sigterm_drains_the_buffered_batch(image):
         f"drain lost the buffered batch: {total} of {num_messages}")
     assert offset == num_messages - 1, (
         f"stored offset should be the last processed message: {offset}")
+
+
+def test_the_process_exit_code_carries_the_error_code(image):
+    """A supervisor reads the process's exit status, so the image must set it.
+
+    The mapping from error code to exit code is a Go unit test's job, and it
+    is covered there. What only the image can show is that the status survives
+    the entrypoint and PID 1 -- where exit codes have already surprised us
+    once: an unhandled SIGTERM exits 2 here and 143 as an ordinary child.
+
+    Two cases, one per class, rather than one per error: a user error and a
+    damaged state file. Both must be terminal, because a supervisor that
+    retries either loops forever.
+    """
+    with tempfile.TemporaryDirectory() as statedir:
+        os.chmod(statedir, 0o777)
+        state = os.path.join(statedir, "state.db")
+        with open(state, "wb") as fh:
+            fh.write(b"this is not a duckdb database")
+        os.chmod(state, 0o666)
+        before = open(state, "rb").read()
+
+        cases = [
+            ("missing config", EXIT_USER_ERROR, "user.config.not_found",
+             dict(command="run /tmp/conf/config/nope.yml")),
+            ("corrupt state file", EXIT_STATE_CORRUPT, "system.state.corrupt",
+             dict(command="run /tmp/conf/config/examples/kafka.stateful.window.yml"
+                          " --max-msgs=1",
+                  volumes={statedir: "/state"},
+                  env={"SQLFLOW_STATE_PATH": "/state/state.db",
+                       "SQLFLOW_KAFKA_BROKERS": "kafka:9092"})),
+        ]
+
+        for name, want_exit, want_code, kwargs in cases:
+            code, stdout, stderr = run_image(image, **kwargs)
+            output = stdout + stderr
+
+            assert code == want_exit, (
+                f"{name}: expected exit {want_exit}, got {code}\n{output}")
+            assert want_exit in TERMINAL_EXITS
+            assert want_code in output, f"{name}: no error code in\n{output}"
+            # Cobra prints the whole flag list for any error a command
+            # returns, which buries the one line saying what failed.
+            assert "Flags:" not in output, f"{name}: usage text buried the error"
+
+        # A damaged state file is the only copy of the pipeline's positions.
+        assert open(state, "rb").read() == before, "the damaged file was modified"


### PR DESCRIPTION
## Defect

A damaged state file started the pipeline over from nothing and reported healthy. Closes #160.

Three paths reached that outcome.

`CREATE TABLE IF NOT EXISTS` accepted any `sqlflow_offsets` table that merely shared the name. A table with the wrong columns or types yielded no readable positions, so the pipeline replayed the topic from the beginning.

A file DuckDB refused to open, and a truncated database, both surfaced uncoded. `CodeOf` mapped them to `system.internal.unexpected`, which exits 1 and is retryable, so a supervisor restarted forever into the same bytes.

`cli.Execute` exited 1 for every failure. Nothing called `errs.ExitCode`, so the exit-code table from #173 was dead. That reached past this issue: every user error, including a bad config and bad SQL, exited retryable.

## Fix

`Init` reads the offsets table's schema and compares it to the shape `Load` binds against, creating the table only when it is absent.

`OpenState` separates a missing file, which is the first run, from a path that exists and will not open, which is corruption. A directory at the state path reports as `user.config.invalid`, because the operator fixes the config rather than the file.

`execute` maps the error to its exit code, so a corrupt state file exits 14 and `Retryable` reports false for it.

Nothing repairs, truncates, or recreates the file. It holds the only copy of the pipeline's positions.

Two call sites in the run command now return state errors as-is. The outermost code wins, so re-wrapping either as `CodeStateInternal` would turn a corrupt state file back into a retryable failure and leave this change inert.

Cobra printed the full flag list for any error a command returned, which buried the line saying what failed. `SilenceUsage` moves into `PersistentPreRunE`, which runs after flag parsing, so a usage error still prints usage and a runtime failure does not.

## Evidence

Measured against libduckdb 1.5.2.

Nine probes established what each kind of damage does. Two were silent: a table with the wrong types, and a table missing the `offset` column, both of which loaded as zero marks.

The new tests fail on `main` for the right reasons. Four report "expected an error". Three report `system.internal.unexpected` where `system.state.corrupt` is required.

The binary, pointed at a 274KB DuckDB database truncated in half, exits 14 with one line naming the file, and leaves it byte-identical:

```
EXIT CODE: 14
Error: [system.state.corrupt] state file "/tmp/sf160b/state.db" exists but cannot
be opened; it has been left untouched: ... Could not read enough bytes from file ...
```

Reverting `execute` to `return 1` fails three exit-code tests, so they are not vacuous.

Full Go suite: 14 packages, 0 failures.

## Test placement

The first draft put eight error-handling tests in the release suite. Seven asserted what a Go test already proves and needed an image build to run at all.

One release test remains. It covers the category rather than each instance: two cases, one per error class, asserting the process exit status carries the error code and that a damaged state file survives the failed start. It runs in 1.4 seconds and starts no dependency container.

A release test earns its place when the failure cannot exist outside the packaged artifact. #159 found one: an unhandled SIGTERM exits 2 in the image where the same binary exits 143 as an ordinary child, because the kernel discards a signal PID 1 has no handler for. Exit status through the entrypoint is that kind of fact.

The rest moved to `internal/cli/exit_test.go`, where they run in 0.05 seconds.

## What breaks if this is wrong

A pipeline whose state file is damaged silently replays its topic from the beginning, or a supervisor crash-loops a failure no restart can fix.

## Follow-ups filed

- #189 — the release suite starts four Kafka containers instead of sharing one; broker startup dominates `make test-release`.
- #190 — `CREATE OR REPLACE TABLE` and `DROP`+`CREATE` in a config's startup DDL silently destroy durable window state on restart. Same failure class, reached through the config.
