### PR TITLE
Sink: configurable retry and backoff policy

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -128,11 +128,11 @@ func devInvoke(
 	}
 
 	sink := sinks.NewConsoleSinkTo(out)
-	if err := sink.WriteTable(table); err != nil {
+	if err := sink.WriteTable(ctx, table); err != nil {
 		table.Release()
 		return nil, fmt.Errorf("failed to write results: %w", err)
 	}
-	if err := sink.Flush(); err != nil {
+	if err := sink.Flush(ctx); err != nil {
 		table.Release()
 		return nil, fmt.Errorf("failed to flush results: %w", err)
 	}

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -288,7 +288,10 @@ func NewCommand() *cobra.Command {
 				}
 			}
 
-			sink, err := sinks.New(conf.Pipeline.Sink, conn)
+			// The signal context, so a SIGTERM arriving while the sink dials
+			// its destination stops the start instead of waiting it out.
+			sink, err := sinks.NewWithContext(ctx, conf.Pipeline.Sink, conn,
+				sinks.WithMeterProvider(meterProvider))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/schemas/config.json
+++ b/internal/cli/schemas/config.json
@@ -182,6 +182,37 @@
                         "type": "object",
                         "description": "Console output sink configuration.",
                         "properties": {}
+                      },
+                      "retry": {
+                        "type": "object",
+                        "description": "Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.",
+                        "properties": {
+                          "max_attempts": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 4,
+                            "description": "Total attempts, including the first. 1 disables retrying."
+                          },
+                          "initial_backoff_ms": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 100,
+                            "description": "Wait before the first retry. Doubles each attempt."
+                          },
+                          "max_backoff_ms": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 2000,
+                            "description": "Ceiling on the backoff."
+                          },
+                          "deadline_seconds": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 10,
+                            "description": "Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on."
+                          }
+                        },
+                        "additionalProperties": false
                       }
                     },
                     "required": [
@@ -536,6 +567,37 @@
               "type": "object",
               "description": "Console output sink configuration.",
               "properties": {}
+            },
+            "retry": {
+              "type": "object",
+              "description": "Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.",
+              "properties": {
+                "max_attempts": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 4,
+                  "description": "Total attempts, including the first. 1 disables retrying."
+                },
+                "initial_backoff_ms": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 100,
+                  "description": "Wait before the first retry. Doubles each attempt."
+                },
+                "max_backoff_ms": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 2000,
+                  "description": "Ceiling on the backoff."
+                },
+                "deadline_seconds": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 10,
+                  "description": "Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on."
+                }
+              },
+              "additionalProperties": false
             }
           },
           "required": [
@@ -678,6 +740,37 @@
                   "type": "object",
                   "description": "Console output sink configuration.",
                   "properties": {}
+                },
+                "retry": {
+                  "type": "object",
+                  "description": "Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.",
+                  "properties": {
+                    "max_attempts": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "default": 4,
+                      "description": "Total attempts, including the first. 1 disables retrying."
+                    },
+                    "initial_backoff_ms": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 100,
+                      "description": "Wait before the first retry. Doubles each attempt."
+                    },
+                    "max_backoff_ms": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 2000,
+                      "description": "Ceiling on the backoff."
+                    },
+                    "deadline_seconds": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 10,
+                      "description": "Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on."
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [

--- a/internal/cli/testdata/config_example.golden
+++ b/internal/cli/testdata/config_example.golden
@@ -47,6 +47,16 @@ tables:
             table: <string>
           # Console output sink configuration.
           console:
+          # Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.
+          retry:
+            # Total attempts, including the first. 1 disables retrying.
+            max_attempts: <integer>
+            # Wait before the first retry. Doubles each attempt.
+            initial_backoff_ms: <integer>
+            # Ceiling on the backoff.
+            max_backoff_ms: <integer>
+            # Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on.
+            deadline_seconds: <integer>
 # List of User-Defined Functions (UDFs) to be used in SQL queries.
 udfs:
   -
@@ -124,6 +134,16 @@ pipeline:
       table: <string>
     # Console output sink configuration.
     console:
+    # Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.
+    retry:
+      # Total attempts, including the first. 1 disables retrying.
+      max_attempts: <integer>
+      # Wait before the first retry. Doubles each attempt.
+      initial_backoff_ms: <integer>
+      # Ceiling on the backoff.
+      max_backoff_ms: <integer>
+      # Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on.
+      deadline_seconds: <integer>
   # Global error handling strategy for the pipeline.
   on_error:
     # Defines how errors should be handled.
@@ -159,6 +179,16 @@ pipeline:
         table: <string>
       # Console output sink configuration.
       console:
+      # Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.
+      retry:
+        # Total attempts, including the first. 1 disables retrying.
+        max_attempts: <integer>
+        # Wait before the first retry. Doubles each attempt.
+        initial_backoff_ms: <integer>
+        # Ceiling on the backoff.
+        max_backoff_ms: <integer>
+        # Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on.
+        deadline_seconds: <integer>
   # Where the pipeline keeps its DuckDB state. Absent means in-memory, and state is lost on a crash.
   state:
     # File backing the pipeline's DuckDB database. Window state and Kafka offsets are stored here and committed together.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,20 @@ type Sink struct {
 	SQLCommand *SQLCommandSink `yaml:"sqlcommand,omitempty"`
 	Iceberg    *IcebergSink    `yaml:"iceberg,omitempty"`
 	Clickhouse *ClickhouseSink `yaml:"clickhouse,omitempty"`
+	Retry      *SinkRetry      `yaml:"retry,omitempty"`
+}
+
+// SinkRetry bounds how long a sink keeps trying a destination that is not
+// answering. Omit the block to accept the defaults; set max_attempts to 1 to
+// turn retrying off.
+//
+// The Kafka sink ignores this. franz-go already retries a produce with its own
+// backoff, and a second ladder on top of that one is worse than none.
+type SinkRetry struct {
+	MaxAttempts      int `yaml:"max_attempts,omitempty"`
+	InitialBackoffMS int `yaml:"initial_backoff_ms,omitempty"`
+	MaxBackoffMS     int `yaml:"max_backoff_ms,omitempty"`
+	DeadlineSeconds  int `yaml:"deadline_seconds,omitempty"`
 }
 
 // Tumbling Window Manager

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -71,9 +71,15 @@ type MetadataWriter interface {
 	WriteMessage(msg Message) error
 }
 
+// Sink is where a batch leaves the pipeline.
+//
+// Both write paths take a context so a sink that retries can be interrupted.
+// Without it, a retry ladder outlives the SIGTERM that asked the pipeline to
+// stop, and the graceful drain waits out the full retry deadline before it can
+// finish. See #110.
 type Sink interface {
-	WriteTable(batch arrow.Table) error
-	Flush() error
+	WriteTable(ctx context.Context, batch arrow.Table) error
+	Flush(ctx context.Context) error
 	Batch() (arrow.Table, error)
 }
 
@@ -450,7 +456,7 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 			if err := t.writeMessage(raw); err != nil {
 				t.recordError(ctx, err, phaseHandlerWrite, "error writing message")
 
-				if err := t.applyErrorPolicy(err, phaseHandlerWrite, string(raw.Value)); err != nil {
+				if err := t.applyErrorPolicy(ctx, err, phaseHandlerWrite, string(raw.Value)); err != nil {
 					return nil, err
 				}
 				// The message is dropped from the batch, but it was still
@@ -573,7 +579,7 @@ func (t *Turbine) recordError(ctx context.Context, err error, phase, message str
 // applyErrorPolicy decides what happens to a failed message or batch. It
 // returns a non-nil error only when the pipeline should stop. Counting and
 // logging belong to recordError, which every caller has already run.
-func (t *Turbine) applyErrorPolicy(cause error, phase, message string) error {
+func (t *Turbine) applyErrorPolicy(ctx context.Context, cause error, phase, message string) error {
 
 	switch t.errorPolicy.Policy {
 	case PolicyIgnore:
@@ -583,7 +589,7 @@ func (t *Turbine) applyErrorPolicy(cause error, phase, message string) error {
 		if t.errorPolicy.DLQSink == nil {
 			return fmt.Errorf("error policy is DLQ but no dlq sink is configured: %w", cause)
 		}
-		if err := t.writeDLQ(cause, phase, message); err != nil {
+		if err := t.writeDLQ(ctx, cause, phase, message); err != nil {
 			t.logger.Error("error writing to dlq", zap.Error(err))
 			return err
 		}
@@ -596,7 +602,7 @@ func (t *Turbine) applyErrorPolicy(cause error, phase, message string) error {
 
 // writeDLQ records one failed message or batch, in the same shape the Python
 // engine produces: error, message, phase and timestamp.
-func (t *Turbine) writeDLQ(cause error, phase, message string) error {
+func (t *Turbine) writeDLQ(ctx context.Context, cause error, phase, message string) error {
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "error", Type: arrow.BinaryTypes.String, Nullable: true},
 		{Name: "message", Type: arrow.BinaryTypes.String, Nullable: true},
@@ -618,10 +624,10 @@ func (t *Turbine) writeDLQ(cause error, phase, message string) error {
 	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
 	defer table.Release()
 
-	if err := t.errorPolicy.DLQSink.WriteTable(table); err != nil {
+	if err := t.errorPolicy.DLQSink.WriteTable(ctx, table); err != nil {
 		return err
 	}
-	return t.errorPolicy.DLQSink.Flush()
+	return t.errorPolicy.DLQSink.Flush(ctx)
 }
 
 // mark records that the pipeline has finished with a message -- written to
@@ -764,7 +770,7 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	if err != nil {
 		t.recordError(ctx, err, phaseHandlerInvoke, "error invoking handler")
 
-		if policyErr := t.applyErrorPolicy(err, phaseHandlerInvoke, "Handler invocation failed"); policyErr != nil {
+		if policyErr := t.applyErrorPolicy(ctx, err, phaseHandlerInvoke, "Handler invocation failed"); policyErr != nil {
 			return policyErr
 		}
 		// The batch yielded no table, so there is nothing to write; the
@@ -774,7 +780,7 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	}
 
 	if batch != nil {
-		if err := t.sink.WriteTable(batch); err != nil {
+		if err := t.sink.WriteTable(ctx, batch); err != nil {
 			t.recordError(ctx, err, phaseSinkWrite, "error writing batch to sink")
 			t.metrics.SinkFlushCount.Add(ctx, 1, t.resultAttrs(resultError)...)
 			// Same reasoning as the flush path below: this batch's handler
@@ -886,7 +892,7 @@ func (t *Turbine) logThroughput() {
 }
 
 func (t *Turbine) flush(ctx context.Context, batch arrow.Table) error {
-	if err := t.sink.Flush(); err != nil {
+	if err := t.sink.Flush(ctx); err != nil {
 		t.recordError(ctx, err, phaseSinkFlush, "flush error")
 		return err
 	}

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -105,14 +105,14 @@ type fakeSink struct {
 	released bool
 }
 
-func (s *fakeSink) WriteTable(batch arrow.Table) error {
+func (s *fakeSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.rows += batch.NumRows()
 	return nil
 }
 
-func (s *fakeSink) Flush() error {
+func (s *fakeSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.flushes++
@@ -193,7 +193,7 @@ type recordingSink struct {
 	flushes int
 }
 
-func (s *recordingSink) WriteTable(batch arrow.Table) error {
+func (s *recordingSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -212,7 +212,7 @@ func (s *recordingSink) WriteTable(batch arrow.Table) error {
 	return nil
 }
 
-func (s *recordingSink) Flush() error {
+func (s *recordingSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.flushes++
@@ -540,9 +540,9 @@ type orderingSink struct {
 	fail   bool
 }
 
-func (s *orderingSink) WriteTable(batch arrow.Table) error { return nil }
+func (s *orderingSink) WriteTable(ctx context.Context, batch arrow.Table) error { return nil }
 
-func (s *orderingSink) Flush() error {
+func (s *orderingSink) Flush(ctx context.Context) error {
 	if s.fail {
 		*s.events = append(*s.events, "flush-failed")
 		return errors.New("sink unreachable")

--- a/internal/managers/tumbling.go
+++ b/internal/managers/tumbling.go
@@ -115,12 +115,12 @@ func (m *Tumbling) Poll(ctx context.Context) error {
 
 	m.logger.Debug("publishing closed windows", zap.Int64("rows", closed.NumRows()))
 
-	if err := m.sink.WriteTable(closed); err != nil {
+	if err := m.sink.WriteTable(ctx, closed); err != nil {
 		return fmt.Errorf("writing closed windows: %w", err)
 	}
 	// Flushed before deleting, so a failure leaves the rows in the table to be
 	// retried rather than dropping them.
-	if err := m.sink.Flush(); err != nil {
+	if err := m.sink.Flush(ctx); err != nil {
 		return fmt.Errorf("flushing closed windows: %w", err)
 	}
 

--- a/internal/managers/tumbling_test.go
+++ b/internal/managers/tumbling_test.go
@@ -93,14 +93,14 @@ type recordingSink struct {
 	flushes int
 }
 
-func (s *recordingSink) WriteTable(batch arrow.Table) error {
+func (s *recordingSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.rows += batch.NumRows()
 	return nil
 }
 
-func (s *recordingSink) Flush() error {
+func (s *recordingSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.flushes++
@@ -218,18 +218,18 @@ type failingSink struct {
 	failFlush atomic.Bool
 }
 
-func (s *failingSink) WriteTable(batch arrow.Table) error {
+func (s *failingSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	if s.failWrite.Load() {
 		return errors.New("sink unreachable")
 	}
-	return s.recordingSink.WriteTable(batch)
+	return s.recordingSink.WriteTable(ctx, batch)
 }
 
-func (s *failingSink) Flush() error {
+func (s *failingSink) Flush(ctx context.Context) error {
 	if s.failFlush.Load() {
 		return errors.New("broker rejected the batch")
 	}
-	return s.recordingSink.Flush()
+	return s.recordingSink.Flush(context.Background())
 }
 
 // A window that could not be written must stay in the table. Deleting it would

--- a/internal/sinks/classify.go
+++ b/internal/sinks/classify.go
@@ -1,0 +1,72 @@
+package sinks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+
+	"github.com/turbolytics/sql-flow/internal/errs"
+)
+
+// isUnreachable reports whether an error means the pipeline could not talk to
+// the destination, as opposed to the destination answering and refusing.
+//
+// The distinction drives the retry ladder. A refused connection may succeed on
+// the next attempt; a rejected column never will. Before this, the ClickHouse
+// sink coded every failure from PrepareBatch as a rejected write -- and
+// PrepareBatch dials, so a refused connection was classified as the one thing
+// retry deliberately does not retry.
+func isUnreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Timeouts first: a net.Error carries its own verdict, and a driver's own
+	// timeout type satisfies the interface without being a syscall error.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	for _, target := range []error{
+		syscall.ECONNREFUSED,
+		syscall.ECONNRESET,
+		syscall.ECONNABORTED,
+		syscall.EHOSTUNREACH,
+		syscall.ENETUNREACH,
+		syscall.ENETDOWN,
+		syscall.EPIPE,
+		syscall.ETIMEDOUT,
+		io.EOF,
+		io.ErrUnexpectedEOF,
+		context.DeadlineExceeded,
+	} {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sinkError wraps a sink failure with the code its cause deserves, so one call
+// site gets both cases right.
+func sinkError(err error, format string, args ...any) error {
+	code := errs.CodeSinkWriteFailed
+	if isUnreachable(err) {
+		code = errs.CodeSinkUnreachable
+	}
+	return errs.Wrap(code, err, format, args...)
+}

--- a/internal/sinks/classify_test.go
+++ b/internal/sinks/classify_test.go
@@ -1,0 +1,82 @@
+package sinks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/zeebo/assert"
+)
+
+// Retry keys off the error code, so a driver failure that is really a network
+// problem has to be coded as one. Coding a refused connection as "the server
+// rejected the write" means the ladder never runs for the case it exists for.
+
+type fakeTimeout struct{}
+
+func (fakeTimeout) Error() string   { return "i/o timeout" }
+func (fakeTimeout) Timeout() bool   { return true }
+func (fakeTimeout) Temporary() bool { return true }
+
+func TestClassify_NetworkFailuresAreUnreachable(t *testing.T) {
+	for name, err := range map[string]error{
+		"connection refused":  syscall.ECONNREFUSED,
+		"connection reset":    syscall.ECONNRESET,
+		"host unreachable":    syscall.EHOSTUNREACH,
+		"network unreachable": syscall.ENETUNREACH,
+		"broken pipe":         syscall.EPIPE,
+		"eof":                 io.EOF,
+		"unexpected eof":      io.ErrUnexpectedEOF,
+		"dns failure":         &net.DNSError{Err: "no such host", Name: "clickhouse.invalid"},
+		"net op error":        &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED},
+		"timeout":             fakeTimeout{},
+		"deadline exceeded":   context.DeadlineExceeded,
+		// Wrapped the way a driver hands it back.
+		"wrapped refusal": fmt.Errorf("clickhouse: %w", syscall.ECONNREFUSED),
+	} {
+		if !isUnreachable(err) {
+			t.Errorf("%s: should be classified unreachable, was not (%v)", name, err)
+		}
+	}
+}
+
+// A server that answered and rejected the write is not unreachable. Retrying
+// a schema mismatch burns the deadline and reports it late.
+func TestClassify_ServerRejectionsAreNotUnreachable(t *testing.T) {
+	for name, err := range map[string]error{
+		"missing column": errors.New("code: 16, message: No such column city in table events"),
+		"type mismatch":  errors.New("code: 53, message: Type mismatch"),
+		"plain":          errors.New("something went wrong"),
+	} {
+		if isUnreachable(err) {
+			t.Errorf("%s: should not be classified unreachable", name)
+		}
+	}
+}
+
+func TestClassify_NilIsNotUnreachable(t *testing.T) {
+	assert.That(t, !isUnreachable(nil))
+}
+
+// sinkError applies the classification, so a call site can wrap once and get
+// the right code either way.
+func TestSinkError_CodesByCause(t *testing.T) {
+	network := sinkError(syscall.ECONNREFUSED, "clickhouse sink: prepare batch")
+	assert.Equal(t, errs.CodeSinkUnreachable, errs.CodeOf(network))
+	assert.That(t, errors.Is(network, syscall.ECONNREFUSED))
+
+	rejected := sinkError(errors.New("no such column"), "clickhouse sink: append")
+	assert.Equal(t, errs.CodeSinkWriteFailed, errs.CodeOf(rejected))
+}
+
+// The classification has to reach the ladder: an unreachable cause is
+// retried, a rejection is not.
+func TestSinkError_DrivesTheRetryDecision(t *testing.T) {
+	assert.That(t, retryable(sinkError(syscall.ECONNREFUSED, "prepare")))
+	assert.That(t, !retryable(sinkError(errors.New("no such column"), "append")))
+}

--- a/internal/sinks/clickhouse.go
+++ b/internal/sinks/clickhouse.go
@@ -134,7 +134,7 @@ func defaultClickhousePort(protocol clickhouse.Protocol, secure bool) string {
 	}
 }
 
-func (s *ClickhouseSink) WriteTable(batch arrow.Table) error {
+func (s *ClickhouseSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -150,7 +150,7 @@ func (s *ClickhouseSink) Batch() (arrow.Table, error) {
 	return nil, nil
 }
 
-func (s *ClickhouseSink) Flush() error {
+func (s *ClickhouseSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	tables := s.tables
 	s.tables = nil
@@ -179,7 +179,6 @@ func (s *ClickhouseSink) Flush() error {
 		}
 	}
 
-	ctx := context.Background()
 	batch, err := s.conn.PrepareBatch(ctx, s.insertStatement(schema))
 	if err != nil {
 		return errs.Wrap(errs.CodeSinkWriteFailed, err, "clickhouse sink: prepare batch")

--- a/internal/sinks/clickhouse.go
+++ b/internal/sinks/clickhouse.go
@@ -181,7 +181,7 @@ func (s *ClickhouseSink) Flush(ctx context.Context) error {
 
 	batch, err := s.conn.PrepareBatch(ctx, s.insertStatement(schema))
 	if err != nil {
-		return errs.Wrap(errs.CodeSinkWriteFailed, err, "clickhouse sink: prepare batch")
+		return sinkError(err, "clickhouse sink: prepare batch")
 	}
 
 	// The prepared batch knows the target column types, which the Arrow
@@ -197,9 +197,15 @@ func (s *ClickhouseSink) Flush(ctx context.Context) error {
 	}
 
 	if err := batch.Send(); err != nil {
-		return errs.Wrap(errs.CodeSinkWriteFailed, err, "clickhouse sink: send batch")
+		return sinkError(err, "clickhouse sink: send batch")
 	}
 	return nil
+}
+
+// Probe dials the server. clickhouse.Open only validates options, so this is
+// the first time the pipeline learns whether the destination is there.
+func (s *ClickhouseSink) Probe(ctx context.Context) error {
+	return s.conn.Ping(ctx)
 }
 
 func (s *ClickhouseSink) Close() error {

--- a/internal/sinks/clickhouse_test.go
+++ b/internal/sinks/clickhouse_test.go
@@ -145,14 +145,14 @@ func TestClickhouseSink_InsertsRows(t *testing.T) {
 	table := clickhouseFixtureTable(t)
 	defer table.Release()
 
-	assert.NoError(t, s.WriteTable(table))
-	assert.NoError(t, s.Flush())
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+	assert.NoError(t, s.Flush(context.Background()))
 
 	assert.Equal(t, uint64(2), clickhouseRowCount(t, s))
 
 	// The buffered table is released on flush; a second flush with nothing
 	// pending must be a no-op rather than a re-insert.
-	assert.NoError(t, s.Flush())
+	assert.NoError(t, s.Flush(context.Background()))
 	assert.Equal(t, uint64(2), clickhouseRowCount(t, s))
 }
 
@@ -165,8 +165,8 @@ func TestClickhouseSink_EmptyTableIsNoop(t *testing.T) {
 	table := array.NewTable(arrow.NewSchema(nil, nil), nil, 0)
 	defer table.Release()
 
-	assert.NoError(t, s.WriteTable(table))
-	assert.NoError(t, s.Flush())
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+	assert.NoError(t, s.Flush(context.Background()))
 }
 
 func TestClickhouseSink_NullsBecomeDefaults(t *testing.T) {
@@ -192,8 +192,8 @@ func TestClickhouseSink_NullsBecomeDefaults(t *testing.T) {
 	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
 	defer table.Release()
 
-	assert.NoError(t, s.WriteTable(table))
-	assert.NoError(t, s.Flush())
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+	assert.NoError(t, s.Flush(context.Background()))
 
 	var action *string
 	row := s.conn.QueryRow(context.Background(), "SELECT action FROM "+s.table+" WHERE user_id = 8")
@@ -281,8 +281,8 @@ func TestClickhouseSink_InsertsArrays(t *testing.T) {
 	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
 	defer table.Release()
 
-	assert.NoError(t, s.WriteTable(table))
-	assert.NoError(t, s.Flush())
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+	assert.NoError(t, s.Flush(context.Background()))
 	assert.Equal(t, uint64(3), clickhouseRowCount(t, s))
 
 	ctx := context.Background()
@@ -343,8 +343,8 @@ func TestClickhouseSink_InsertsNestedArrays(t *testing.T) {
 	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
 	defer table.Release()
 
-	assert.NoError(t, s.WriteTable(table))
-	assert.NoError(t, s.Flush())
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+	assert.NoError(t, s.Flush(context.Background()))
 
 	var matrix [][]int64
 	row := s.conn.QueryRow(context.Background(), "SELECT matrix FROM "+s.table+" WHERE id = 1")
@@ -391,8 +391,8 @@ func TestClickhouseSink_StringTemporalsAreNotShiftedByHostZone(t *testing.T) {
 	table := array.NewTableFromRecords(schema, []arrow.Record{rec})
 	defer table.Release()
 
-	assert.NoError(t, s.WriteTable(table))
-	assert.NoError(t, s.Flush())
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+	assert.NoError(t, s.Flush(context.Background()))
 
 	// Rendered by the server in its own zone (UTC in the dev stack), so a
 	// value parsed as Tokyo time would read 03:00, and the date 2026-08-31.

--- a/internal/sinks/console.go
+++ b/internal/sinks/console.go
@@ -2,6 +2,7 @@ package sinks
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"os"
 	"sync"
@@ -24,7 +25,7 @@ func NewConsoleSinkTo(w io.Writer) *ConsoleSink {
 	return &ConsoleSink{out: bufio.NewWriter(w)}
 }
 
-func (s *ConsoleSink) WriteTable(batch arrow.Table) error {
+func (s *ConsoleSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	rows, err := tableRowsAsJSON(batch)
 	if err != nil {
 		return err
@@ -45,7 +46,7 @@ func (s *ConsoleSink) WriteTable(batch arrow.Table) error {
 	return nil
 }
 
-func (s *ConsoleSink) Flush() error {
+func (s *ConsoleSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.out.Flush()

--- a/internal/sinks/iceberg.go
+++ b/internal/sinks/iceberg.go
@@ -59,7 +59,7 @@ func NewIcebergSink(ctx context.Context, catalogName, tableName string) (*Iceber
 	return &IcebergSink{table: tbl}, nil
 }
 
-func (s *IcebergSink) WriteTable(batch arrow.Table) error {
+func (s *IcebergSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -78,7 +78,7 @@ func (s *IcebergSink) Batch() (arrow.Table, error) {
 	return s.tables[len(s.tables)-1], nil
 }
 
-func (s *IcebergSink) Flush() error {
+func (s *IcebergSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	tables := s.tables
 	s.tables = nil
@@ -93,7 +93,6 @@ func (s *IcebergSink) Flush() error {
 		}
 	}()
 
-	ctx := context.Background()
 	for _, t := range tables {
 		if t.NumRows() == 0 {
 			continue

--- a/internal/sinks/init.go
+++ b/internal/sinks/init.go
@@ -12,12 +12,12 @@ import (
 
 type NoopSink struct{}
 
-func (n *NoopSink) WriteTable(batch arrow.Table) error {
+func (n *NoopSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	// No operation performed
 	return nil
 }
 
-func (n *NoopSink) Flush() error {
+func (n *NoopSink) Flush(ctx context.Context) error {
 	// No operation performed
 	return nil
 }

--- a/internal/sinks/init.go
+++ b/internal/sinks/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/core"
 	"github.com/turbolytics/sql-flow/internal/errs"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type NoopSink struct{}
@@ -27,8 +28,22 @@ func (n *NoopSink) Batch() (arrow.Table, error) {
 	return nil, nil
 }
 
-func New(sink config.Sink, conn adbc.Connection) (core.Sink, error) {
-	return NewWithContext(context.Background(), sink, conn)
+// Option configures how a sink is built.
+type Option func(*options)
+
+type options struct {
+	meterProvider metric.MeterProvider
+}
+
+// WithMeterProvider supplies the provider the retry counter records through.
+// Without one the counter records nothing, which is what a pipeline started
+// with no --metrics wants.
+func WithMeterProvider(mp metric.MeterProvider) Option {
+	return func(o *options) { o.meterProvider = mp }
+}
+
+func New(sink config.Sink, conn adbc.Connection, opts ...Option) (core.Sink, error) {
+	return NewWithContext(context.Background(), sink, conn, opts...)
 }
 
 // NewWithContext builds a sink and wraps it in a retry ladder where one helps.
@@ -41,59 +56,89 @@ func New(sink config.Sink, conn adbc.Connection) (core.Sink, error) {
 // failure there is not a network blip.
 //
 // That leaves the sinks that cross a network to somebody else's server.
-func NewWithContext(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
-	built, wrap, err := buildSink(ctx, sink, conn)
+func NewWithContext(ctx context.Context, sink config.Sink, conn adbc.Connection, opts ...Option) (core.Sink, error) {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	built, err := buildSink(ctx, sink, conn)
 	if err != nil {
 		return nil, err
 	}
 
+	// Checked before the pipeline consumes anything, so a destination that is
+	// not there fails the start rather than the first flush.
+	if err := probe(ctx, built); err != nil {
+		return nil, err
+	}
+
 	policy := RetryPolicyFrom(sink.Retry)
-	if !wrap || !policy.Enabled() {
+	if !retriesHelp(sink.Type) || !policy.Enabled() {
 		return built, nil
 	}
-	return newRetrying(built, policy), nil
+
+	r := newRetrying(built, policy)
+	r.onRetry = retryCounter(o.meterProvider, sink.Type)
+	return r, nil
 }
 
-// buildSink constructs the sink and reports whether a retry ladder belongs
-// around it.
-func buildSink(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, bool, error) {
+// retriesHelp reports whether a retry ladder belongs around a sink type.
+//
+// Only the sinks that cross a network to somebody else's server. Kafka is
+// excluded on purpose: it hands records to franz-go, which already retries a
+// produce with its own backoff, and a second ladder on top of that one delays
+// the report without improving delivery. Console, noop and sqlcommand reach
+// nothing that can be temporarily unavailable -- sqlcommand writes through the
+// pipeline's own DuckDB connection, and a failure there is not a blip.
+//
+// Kept as a function of the type alone so the policy is testable without
+// building a sink, which would dial.
+func retriesHelp(sinkType string) bool {
+	switch sinkType {
+	case "clickhouse", "iceberg":
+		return true
+	default:
+		return false
+	}
+}
+
+// buildSink constructs the sink itself. Whether a retry ladder belongs around
+// it is retriesHelp's decision, not this one's.
+func buildSink(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
 	switch sink.Type {
 	case "noop":
-		return &NoopSink{}, false, nil
+		return &NoopSink{}, nil
 
 	case "console", "":
 		// The Python engine falls back to console for an unset type.
-		return NewConsoleSink(), false, nil
+		return NewConsoleSink(), nil
 
 	case "kafka":
 		if sink.Kafka == nil {
-			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: kafka sink requires a kafka block")
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: kafka sink requires a kafka block")
 		}
-		s, err := NewKafkaSink(*sink.Kafka)
-		return s, false, err
+		return NewKafkaSink(*sink.Kafka)
 
 	case "sqlcommand":
 		if sink.SQLCommand == nil {
-			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: sqlcommand sink requires a sqlcommand block")
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: sqlcommand sink requires a sqlcommand block")
 		}
-		s, err := NewSQLCommandSink(conn, sink.SQLCommand.SQL, sink.SQLCommand.Substitutions)
-		return s, false, err
+		return NewSQLCommandSink(conn, sink.SQLCommand.SQL, sink.SQLCommand.Substitutions)
 
 	case "clickhouse":
 		if sink.Clickhouse == nil {
-			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: clickhouse sink requires a clickhouse block")
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: clickhouse sink requires a clickhouse block")
 		}
-		s, err := NewClickhouseSink(*sink.Clickhouse)
-		return s, true, err
+		return NewClickhouseSink(*sink.Clickhouse)
 
 	case "iceberg":
 		if sink.Iceberg == nil {
-			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: iceberg sink requires an iceberg block")
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: iceberg sink requires an iceberg block")
 		}
-		s, err := NewIcebergSink(ctx, sink.Iceberg.CatalogName, sink.Iceberg.TableName)
-		return s, true, err
+		return NewIcebergSink(ctx, sink.Iceberg.CatalogName, sink.Iceberg.TableName)
 
 	default:
-		return nil, false, errs.New(errs.CodeSinkInvalid, "sink: %q not supported", sink.Type)
+		return nil, errs.New(errs.CodeSinkInvalid, "sink: %q not supported", sink.Type)
 	}
 }

--- a/internal/sinks/init.go
+++ b/internal/sinks/init.go
@@ -28,39 +28,72 @@ func (n *NoopSink) Batch() (arrow.Table, error) {
 }
 
 func New(sink config.Sink, conn adbc.Connection) (core.Sink, error) {
+	return NewWithContext(context.Background(), sink, conn)
+}
+
+// NewWithContext builds a sink and wraps it in a retry ladder where one helps.
+//
+// Not every sink is wrapped. The Kafka sink hands records to franz-go, which
+// already retries a produce with its own backoff; a second ladder on top of
+// that one delays the report without improving delivery. The console, noop and
+// sqlcommand sinks reach nothing that can be temporarily unavailable -- the
+// sqlcommand sink writes through the pipeline's own DuckDB connection, and a
+// failure there is not a network blip.
+//
+// That leaves the sinks that cross a network to somebody else's server.
+func NewWithContext(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
+	built, wrap, err := buildSink(ctx, sink, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	policy := RetryPolicyFrom(sink.Retry)
+	if !wrap || !policy.Enabled() {
+		return built, nil
+	}
+	return newRetrying(built, policy), nil
+}
+
+// buildSink constructs the sink and reports whether a retry ladder belongs
+// around it.
+func buildSink(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, bool, error) {
 	switch sink.Type {
 	case "noop":
-		return &NoopSink{}, nil
+		return &NoopSink{}, false, nil
 
 	case "console", "":
 		// The Python engine falls back to console for an unset type.
-		return NewConsoleSink(), nil
+		return NewConsoleSink(), false, nil
 
 	case "kafka":
 		if sink.Kafka == nil {
-			return nil, errs.New(errs.CodeSinkInvalid, "sink: kafka sink requires a kafka block")
+			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: kafka sink requires a kafka block")
 		}
-		return NewKafkaSink(*sink.Kafka)
+		s, err := NewKafkaSink(*sink.Kafka)
+		return s, false, err
 
 	case "sqlcommand":
 		if sink.SQLCommand == nil {
-			return nil, errs.New(errs.CodeSinkInvalid, "sink: sqlcommand sink requires a sqlcommand block")
+			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: sqlcommand sink requires a sqlcommand block")
 		}
-		return NewSQLCommandSink(conn, sink.SQLCommand.SQL, sink.SQLCommand.Substitutions)
+		s, err := NewSQLCommandSink(conn, sink.SQLCommand.SQL, sink.SQLCommand.Substitutions)
+		return s, false, err
 
 	case "clickhouse":
 		if sink.Clickhouse == nil {
-			return nil, errs.New(errs.CodeSinkInvalid, "sink: clickhouse sink requires a clickhouse block")
+			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: clickhouse sink requires a clickhouse block")
 		}
-		return NewClickhouseSink(*sink.Clickhouse)
+		s, err := NewClickhouseSink(*sink.Clickhouse)
+		return s, true, err
 
 	case "iceberg":
 		if sink.Iceberg == nil {
-			return nil, errs.New(errs.CodeSinkInvalid, "sink: iceberg sink requires an iceberg block")
+			return nil, false, errs.New(errs.CodeSinkInvalid, "sink: iceberg sink requires an iceberg block")
 		}
-		return NewIcebergSink(context.Background(), sink.Iceberg.CatalogName, sink.Iceberg.TableName)
+		s, err := NewIcebergSink(ctx, sink.Iceberg.CatalogName, sink.Iceberg.TableName)
+		return s, true, err
 
 	default:
-		return nil, errs.New(errs.CodeSinkInvalid, "sink: %q not supported", sink.Type)
+		return nil, false, errs.New(errs.CodeSinkInvalid, "sink: %q not supported", sink.Type)
 	}
 }

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -50,7 +50,7 @@ func NewKafkaSink(conf config.KafkaSink) (*KafkaSink, error) {
 	return &KafkaSink{client: client, topic: conf.Topic}, nil
 }
 
-func (s *KafkaSink) WriteTable(batch arrow.Table) error {
+func (s *KafkaSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	rows, err := tableRowsAsJSON(batch)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func (s *KafkaSink) WriteTable(batch arrow.Table) error {
 
 // Flush blocks until every buffered record has been acknowledged, so a
 // batch is durable before its source offsets are committed.
-func (s *KafkaSink) Flush() error {
+func (s *KafkaSink) Flush(ctx context.Context) error {
 	if err := s.client.Flush(context.Background()); err != nil {
 		return err
 	}

--- a/internal/sinks/metrics.go
+++ b/internal/sinks/metrics.go
@@ -1,0 +1,43 @@
+package sinks
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// retryCounter builds the callback the retry ladder reports attempts through.
+//
+// A stalled sink has to be visible before its deadline fires. Without this, a
+// pipeline retrying every batch for the full deadline looks the same on a
+// dashboard as one that is merely slow, and the first signal is the pipeline
+// exiting.
+//
+// A nil provider yields a counter that records nothing, so a pipeline started
+// without --metrics needs no branch here.
+func retryCounter(mp metric.MeterProvider, sinkType string) func(attempt int, err error) {
+	if mp == nil {
+		mp = noop.NewMeterProvider()
+	}
+
+	counter, err := mp.Meter("sqlflow").Int64Counter(
+		"sink_retry_count",
+		metric.WithDescription("Number of sink writes retried after a failure"),
+		metric.WithUnit("count"),
+	)
+	if err != nil {
+		// Losing a counter is not worth failing a pipeline over.
+		return func(int, error) {}
+	}
+
+	// Built once: the attribute set is the same for every retry this sink
+	// makes, and rebuilding it per attempt allocates on a path that is already
+	// unhappy.
+	attrs := metric.WithAttributes(attribute.String("sink", sinkType))
+
+	return func(attempt int, err error) {
+		counter.Add(context.Background(), 1, attrs)
+	}
+}

--- a/internal/sinks/metrics_test.go
+++ b/internal/sinks/metrics_test.go
@@ -1,0 +1,102 @@
+package sinks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/zeebo/assert"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// A stalled sink has to be visible before its deadline fires. Without a
+// counter, a pipeline retrying every batch for ten seconds looks identical to
+// one that is merely slow.
+
+// retryAttempts reads the recorded value of sink_retry_count.
+func retryAttempts(t *testing.T, reader sdkmetric.Reader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "sink_retry_count" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("sink_retry_count is %T, want a counter", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+		}
+	}
+	return total
+}
+
+func newMeteredRetry(inner *flakySink, p RetryPolicy) (*retrying, sdkmetric.Reader) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	r, _ := newTestRetry(inner, p)
+	r.onRetry = retryCounter(mp, "clickhouse")
+	return r, reader
+}
+
+// Two failures then a success is two retries, counted before the batch lands.
+func TestMetrics_CountsEveryRetry(t *testing.T) {
+	inner := &flakySink{failures: 2, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+	r, reader := newMeteredRetry(inner, testPolicy())
+
+	assert.NoError(t, r.Flush(context.Background()))
+
+	assert.Equal(t, int64(2), retryAttempts(t, reader))
+}
+
+// A sink that works records nothing, so a nonzero counter always means the
+// destination is struggling.
+func TestMetrics_SuccessCountsNoRetries(t *testing.T) {
+	inner := &flakySink{}
+	r, reader := newMeteredRetry(inner, testPolicy())
+
+	assert.NoError(t, r.Flush(context.Background()))
+
+	assert.Equal(t, int64(0), retryAttempts(t, reader))
+}
+
+// A rejected write is not retried, so it must not inflate the retry counter.
+func TestMetrics_NonRetryableCountsNoRetries(t *testing.T) {
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkWriteFailed, "no such column")}
+	r, reader := newMeteredRetry(inner, testPolicy())
+
+	assert.Error(t, r.Flush(context.Background()))
+
+	assert.Equal(t, int64(0), retryAttempts(t, reader))
+}
+
+// An exhausted ladder counts every retry it made, which is one fewer than the
+// attempts: the last attempt is not followed by another.
+func TestMetrics_ExhaustedLadderCountsItsRetries(t *testing.T) {
+	p := testPolicy()
+	p.MaxAttempts = 4
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+	r, reader := newMeteredRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+
+	assert.Equal(t, int64(3), retryAttempts(t, reader))
+}
+
+// A nil provider must not panic. A pipeline started without --metrics still
+// retries.
+func TestMetrics_NilProviderIsSafe(t *testing.T) {
+	inner := &flakySink{failures: 1, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+	r, _ := newTestRetry(inner, testPolicy())
+	r.onRetry = retryCounter(nil, "clickhouse")
+
+	assert.NoError(t, r.Flush(context.Background()))
+}

--- a/internal/sinks/policy.go
+++ b/internal/sinks/policy.go
@@ -1,0 +1,52 @@
+package sinks
+
+import (
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/config"
+)
+
+// Retry defaults. Deliberately short: the point is to absorb a hiccup, not to
+// wait out an outage. A destination that is still refusing after a few seconds
+// is better reported, because the exit code says "retryable" and a supervisor
+// restarts the pipeline anyway.
+//
+// Retrying is on by default. Before this, one refused connection killed the
+// process, which cost a cold start, a group rejoin and a rebalance to recover
+// from a blip. That default was the defect, not a safe baseline.
+const (
+	DefaultRetryMaxAttempts    = 4
+	DefaultRetryInitialBackoff = 100 * time.Millisecond
+	DefaultRetryMaxBackoff     = 2 * time.Second
+	DefaultRetryDeadline       = 10 * time.Second
+)
+
+// RetryPolicyFrom resolves a config block into a policy, filling in defaults
+// for anything the user left out.
+func RetryPolicyFrom(c *config.SinkRetry) RetryPolicy {
+	p := RetryPolicy{
+		MaxAttempts:    DefaultRetryMaxAttempts,
+		InitialBackoff: DefaultRetryInitialBackoff,
+		MaxBackoff:     DefaultRetryMaxBackoff,
+		Deadline:       DefaultRetryDeadline,
+	}
+	if c == nil {
+		return p
+	}
+	if c.MaxAttempts > 0 {
+		p.MaxAttempts = c.MaxAttempts
+	}
+	if c.InitialBackoffMS > 0 {
+		p.InitialBackoff = time.Duration(c.InitialBackoffMS) * time.Millisecond
+	}
+	if c.MaxBackoffMS > 0 {
+		p.MaxBackoff = time.Duration(c.MaxBackoffMS) * time.Millisecond
+	}
+	if c.DeadlineSeconds > 0 {
+		p.Deadline = time.Duration(c.DeadlineSeconds) * time.Second
+	}
+	return p
+}
+
+// Enabled reports whether the policy will ever make a second attempt.
+func (p RetryPolicy) Enabled() bool { return p.MaxAttempts > 1 }

--- a/internal/sinks/probe.go
+++ b/internal/sinks/probe.go
@@ -1,0 +1,55 @@
+package sinks
+
+import (
+	"context"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/errs"
+)
+
+// Prober is implemented by a sink that can check its destination before the
+// first batch arrives.
+//
+// Without it a sink only discovers its destination when a batch reaches it.
+// clickhouse.Open validates options and never dials, so a pipeline whose DSN
+// names a host that does not resolve starts normally, logs "consumer loop
+// starting", and runs. With a long flush interval the failure appears minutes
+// later, and a supervisor calls the pipeline healthy for all of them.
+type Prober interface {
+	Probe(ctx context.Context) error
+}
+
+// probe checks a sink's destination if it can be checked, and classifies what
+// comes back.
+//
+// It dials once and does not retry. An unreachable destination exits with a
+// retryable code, so the supervisor's restart is already the retry; a ladder
+// here would only delay the report. Nothing has been consumed yet, so there is
+// nothing to lose by failing fast.
+func probe(ctx context.Context, s core.Sink) error {
+	p, ok := s.(Prober)
+	if !ok {
+		// Console, noop and sqlcommand reach nothing that can be absent.
+		return nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return errs.Wrap(errs.CodeSinkInternal, err, "sink: probe cancelled")
+	}
+
+	err := p.Probe(ctx)
+	if err == nil {
+		return nil
+	}
+
+	// A server that answered and refused is the user's to fix: a wrong
+	// password or a missing database does not resolve on a restart. Reporting
+	// it as unreachable would have a supervisor retry a pipeline that cannot
+	// start.
+	if !isUnreachable(err) {
+		return errs.Wrap(errs.CodeSinkInvalid, err,
+			"sink: the destination refused the connection at startup")
+	}
+	return errs.Wrap(errs.CodeSinkUnreachable, err,
+		"sink: the destination could not be reached at startup")
+}

--- a/internal/sinks/probe_test.go
+++ b/internal/sinks/probe_test.go
@@ -1,0 +1,100 @@
+package sinks
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/zeebo/assert"
+)
+
+// A sink that never dials looks healthy until the first batch reaches it.
+// With a long flush interval that is minutes of a pipeline a supervisor calls
+// running while nothing can leave it.
+
+type probeSink struct {
+	err    error
+	probes int
+}
+
+func (s *probeSink) WriteTable(ctx context.Context, b arrow.Table) error { return nil }
+func (s *probeSink) Flush(ctx context.Context) error                     { return nil }
+func (s *probeSink) Batch() (arrow.Table, error)                         { return nil, nil }
+
+func (s *probeSink) Probe(ctx context.Context) error {
+	s.probes++
+	return s.err
+}
+
+func TestProbe_ReachableSinkStarts(t *testing.T) {
+	s := &probeSink{}
+
+	assert.NoError(t, probe(context.Background(), s))
+	assert.Equal(t, 1, s.probes)
+}
+
+// A destination that is not there fails the start with the code whose exit
+// status tells a supervisor the dependency may come back.
+func TestProbe_UnreachableSinkFailsTheStart(t *testing.T) {
+	s := &probeSink{err: syscall.ECONNREFUSED}
+
+	err := probe(context.Background(), s)
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeSinkUnreachable, errs.CodeOf(err))
+	assert.Equal(t, errs.ExitSinkUnreachable, errs.ExitCode(err))
+	// Retryable: the server may come back, unlike a bad DSN.
+	assert.That(t, errs.Retryable(errs.ExitCode(err)))
+}
+
+// A server that answers and refuses is the user's to fix. Reporting it as
+// unreachable would have a supervisor retry a pipeline that cannot start.
+func TestProbe_AuthFailureIsAUserError(t *testing.T) {
+	s := &probeSink{err: errors.New("code: 516, message: Authentication failed")}
+
+	err := probe(context.Background(), s)
+
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeSinkInvalid, errs.CodeOf(err))
+	assert.That(t, !errs.Retryable(errs.ExitCode(err)))
+}
+
+// A sink with nothing to dial is not probed and must not fail the start.
+func TestProbe_SinksWithNothingToDialAreSkipped(t *testing.T) {
+	for _, s := range []config.Sink{
+		{Type: "noop"},
+		{Type: "console"},
+		{Type: ""},
+	} {
+		built, err := NewWithContext(context.Background(), s, nil)
+		assert.NoError(t, err)
+		assert.That(t, built != nil)
+	}
+}
+
+// The probe dials once and does not retry.
+//
+// A retryable exit code already means the supervisor restarts the pipeline,
+// so the restart is the retry. A ladder here would only delay the report of a
+// destination that is genuinely down, and it would run before the pipeline has
+// consumed anything, where there is nothing to lose by failing fast.
+func TestProbe_DialsOnceAndDoesNotRetry(t *testing.T) {
+	s := &probeSink{err: syscall.ECONNREFUSED}
+
+	assert.Error(t, probe(context.Background(), s))
+	assert.Equal(t, 1, s.probes)
+}
+
+// A cancelled context stops the start rather than dialing anyway.
+func TestProbe_RespectsACancelledContext(t *testing.T) {
+	s := &probeSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.Error(t, probe(ctx, s))
+	assert.Equal(t, 0, s.probes)
+}

--- a/internal/sinks/retry.go
+++ b/internal/sinks/retry.go
@@ -1,0 +1,131 @@
+package sinks
+
+import (
+	"context"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/errs"
+)
+
+// RetryPolicy bounds how long a sink keeps trying a destination that is not
+// answering.
+//
+// Deadline bounds the whole ladder rather than one attempt, and it is the
+// field that matters most. The retry runs inside the pipeline's open state
+// transaction, and DuckDB's now() returns that transaction's start time, so a
+// ladder that outlives the flush interval freezes the window clock -- the bug
+// #158 fixed, reached by a second route.
+type RetryPolicy struct {
+	MaxAttempts    int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	Deadline       time.Duration
+}
+
+// retrying wraps a sink whose destination may be temporarily unavailable.
+//
+// It is a decorator rather than a change to each sink because the sinks do not
+// want it uniformly: the Kafka sink hands records to franz-go, which already
+// retries with its own backoff, and a second ladder on top of that one is
+// worse than none. New decides which sinks get wrapped.
+type retrying struct {
+	inner  core.Sink
+	policy RetryPolicy
+
+	// sleep waits, or reports why it stopped. Injected so the tests assert the
+	// backoff ladder without taking it.
+	sleep func(ctx context.Context, d time.Duration) error
+
+	// onRetry reports an attempt that failed and will be tried again, so a
+	// stalled sink is visible before the deadline fires.
+	onRetry func(attempt int, err error)
+}
+
+func newRetrying(inner core.Sink, policy RetryPolicy) *retrying {
+	return &retrying{
+		inner:   inner,
+		policy:  policy,
+		sleep:   sleepCtx,
+		onRetry: func(int, error) {},
+	}
+}
+
+// sleepCtx waits for d, or returns early when the context ends. Returning the
+// context's error is what stops a ladder on SIGTERM instead of letting it
+// outlive the drain.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (r *retrying) Batch() (arrow.Table, error) { return r.inner.Batch() }
+
+// WriteTable is not retried. It buffers into the sink rather than reaching the
+// destination, so there is nothing here for a backoff to wait on.
+func (r *retrying) WriteTable(ctx context.Context, batch arrow.Table) error {
+	return r.inner.WriteTable(ctx, batch)
+}
+
+func (r *retrying) Flush(ctx context.Context) error {
+	deadline := time.Now().Add(r.policy.Deadline)
+	backoff := r.policy.InitialBackoff
+
+	var err error
+	for attempt := 1; attempt <= r.policy.MaxAttempts; attempt++ {
+		err = r.inner.Flush(ctx)
+		if err == nil {
+			return nil
+		}
+		if !retryable(err) {
+			return err
+		}
+		if attempt == r.policy.MaxAttempts {
+			break
+		}
+
+		// Checked before sleeping rather than after, so a ladder that would
+		// wake past the deadline stops now instead of overrunning it.
+		if time.Now().Add(backoff).After(deadline) {
+			break
+		}
+
+		r.onRetry(attempt, err)
+		if sleepErr := r.sleep(ctx, backoff); sleepErr != nil {
+			return err
+		}
+
+		backoff *= 2
+		if backoff > r.policy.MaxBackoff {
+			backoff = r.policy.MaxBackoff
+		}
+	}
+
+	// The ladder ran out. Report the destination as unreachable so the exit
+	// code says "the dependency may come back" rather than "we have a bug".
+	return errs.Wrap(errs.CodeSinkUnreachable, err,
+		"sink still failing after %d attempts", r.policy.MaxAttempts)
+}
+
+// retryable reports whether another attempt could plausibly succeed.
+//
+// A rejected write and a bad configuration fail identically every time, so
+// retrying them only delays the report past the deadline. Everything else is
+// retried, including errors carrying no code: a driver's timeout or reset
+// arrives unclassified, and those are exactly the failures this exists for.
+// The deadline bounds the cost of guessing wrong.
+func retryable(err error) bool {
+	switch errs.CodeOf(err) {
+	case errs.CodeSinkWriteFailed, errs.CodeSinkInvalid, errs.CodeConfigInvalid:
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/sinks/retry.go
+++ b/internal/sinks/retry.go
@@ -38,6 +38,11 @@ type retrying struct {
 	// backoff ladder without taking it.
 	sleep func(ctx context.Context, d time.Duration) error
 
+	// now reads the clock the deadline is measured against. Injected alongside
+	// sleep: a test that fakes one and not the other measures a deadline
+	// against a clock that never advances, and the deadline never binds.
+	now func() time.Time
+
 	// onRetry reports an attempt that failed and will be tried again, so a
 	// stalled sink is visible before the deadline fires.
 	onRetry func(attempt int, err error)
@@ -48,6 +53,7 @@ func newRetrying(inner core.Sink, policy RetryPolicy) *retrying {
 		inner:   inner,
 		policy:  policy,
 		sleep:   sleepCtx,
+		now:     time.Now,
 		onRetry: func(int, error) {},
 	}
 }
@@ -75,43 +81,83 @@ func (r *retrying) WriteTable(ctx context.Context, batch arrow.Table) error {
 }
 
 func (r *retrying) Flush(ctx context.Context) error {
-	deadline := time.Now().Add(r.policy.Deadline)
-	backoff := r.policy.InitialBackoff
+	// A policy bounds how many times the write is retried. It never licenses
+	// skipping the write: max_attempts of 0 must still deliver the batch, or
+	// the caller is told a flush happened that never did.
+	maxAttempts := r.policy.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
 
-	var err error
-	for attempt := 1; attempt <= r.policy.MaxAttempts; attempt++ {
-		err = r.inner.Flush(ctx)
+	maxBackoff := r.policy.MaxBackoff
+	if maxBackoff < 0 {
+		maxBackoff = 0
+	}
+	// Clamped before the first sleep, not after it. Applying the cap only on
+	// the way round the loop lets the first wait exceed the ceiling the
+	// operator set.
+	backoff := clamp(r.policy.InitialBackoff, maxBackoff)
+	deadline := r.now().Add(r.policy.Deadline)
+
+	for attempt := 1; ; attempt++ {
+		err := r.inner.Flush(ctx)
 		if err == nil {
 			return nil
 		}
+		// A rejected write or a bad config keeps its own code. Rewriting it as
+		// unreachable would tell a supervisor to retry a pipeline that cannot
+		// succeed.
 		if !retryable(err) {
 			return err
 		}
-		if attempt == r.policy.MaxAttempts {
-			break
+
+		if attempt >= maxAttempts {
+			return errs.Wrap(errs.CodeSinkUnreachable, err,
+				"sink still failing after %d attempts", attempt)
 		}
 
-		// Checked before sleeping rather than after, so a ladder that would
-		// wake past the deadline stops now instead of overrunning it.
-		if time.Now().Add(backoff).After(deadline) {
-			break
+		// Checked before sleeping, so a ladder that would wake past the
+		// deadline stops now instead of overrunning it. The clock, not the sum
+		// of the backoffs: a flush attempt that blocks on a TCP timeout spends
+		// the deadline too.
+		if r.now().Add(backoff).After(deadline) {
+			return errs.Wrap(errs.CodeSinkUnreachable, err,
+				"sink still failing after %d attempts, %s retry deadline reached",
+				attempt, r.policy.Deadline)
 		}
 
 		r.onRetry(attempt, err)
 		if sleepErr := r.sleep(ctx, backoff); sleepErr != nil {
+			// The context ended. Report the sink's failure rather than the
+			// cancellation: the sink is why this batch did not land.
 			return err
 		}
 
-		backoff *= 2
-		if backoff > r.policy.MaxBackoff {
-			backoff = r.policy.MaxBackoff
-		}
+		backoff = grow(backoff, maxBackoff)
 	}
+}
 
-	// The ladder ran out. Report the destination as unreachable so the exit
-	// code says "the dependency may come back" rather than "we have a bug".
-	return errs.Wrap(errs.CodeSinkUnreachable, err,
-		"sink still failing after %d attempts", r.policy.MaxAttempts)
+// clamp keeps a backoff inside [0, max]. A negative duration would make
+// time.Timer fire immediately and turn the ladder into a spin.
+func clamp(d, max time.Duration) time.Duration {
+	if d < 0 {
+		d = 0
+	}
+	if d > max {
+		d = max
+	}
+	return d
+}
+
+// grow doubles a backoff, stopping at max. The overflow check matters because
+// doubling past the int64 ceiling wraps negative, which clamp would then read
+// as zero and spin on.
+func grow(d, max time.Duration) time.Duration {
+	next := d * 2
+	if next < d {
+		next = max
+	}
+	return clamp(next, max)
 }
 
 // retryable reports whether another attempt could plausibly succeed.

--- a/internal/sinks/retry_bounds_test.go
+++ b/internal/sinks/retry_bounds_test.go
@@ -1,0 +1,338 @@
+package sinks
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/zeebo/assert"
+)
+
+// Every bound of RetryPolicy, including the degenerate values a config can
+// produce. A retry ladder sits between a batch and its destination, so a bound
+// that misbehaves either drops the batch or spins on it.
+
+func alwaysFails() *flakySink {
+	return &flakySink{failures: 1 << 30, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+}
+
+// --- MaxAttempts -----------------------------------------------------------
+
+// The batch must reach the sink even under a nonsense policy. Skipping the
+// flush loses the batch, and the caller is told it succeeded.
+func TestBounds_MaxAttemptsZeroStillFlushesOnce(t *testing.T) {
+	inner := &flakySink{}
+	p := testPolicy()
+	p.MaxAttempts = 0
+	r, _ := newTestRetry(inner, p)
+
+	err := r.Flush(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, inner.attempts)
+}
+
+func TestBounds_MaxAttemptsNegativeStillFlushesOnce(t *testing.T) {
+	inner := &flakySink{}
+	p := testPolicy()
+	p.MaxAttempts = -3
+	r, _ := newTestRetry(inner, p)
+
+	assert.NoError(t, r.Flush(context.Background()))
+	assert.Equal(t, 1, inner.attempts)
+}
+
+// A failure under a zero policy still has to be reported, not swallowed.
+func TestBounds_MaxAttemptsZeroReportsTheFailure(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 0
+	r, _ := newTestRetry(inner, p)
+
+	err := r.Flush(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, inner.attempts)
+}
+
+func TestBounds_MaxAttemptsOneMakesExactlyOneAttempt(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 1
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+	assert.Equal(t, 1, inner.attempts)
+	assert.Equal(t, 0, len(*slept))
+}
+
+func TestBounds_MaxAttemptsTwoSleepsExactlyOnce(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 2
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+	assert.Equal(t, 2, inner.attempts)
+	assert.Equal(t, 1, len(*slept))
+}
+
+// The ladder sleeps between attempts, never after the last one.
+func TestBounds_NeverSleepsAfterTheFinalAttempt(t *testing.T) {
+	for attempts := 1; attempts <= 6; attempts++ {
+		inner := alwaysFails()
+		p := testPolicy()
+		p.MaxAttempts = attempts
+		r, slept := newTestRetry(inner, p)
+
+		assert.Error(t, r.Flush(context.Background()))
+		if inner.attempts != attempts {
+			t.Errorf("max_attempts %d: made %d attempts", attempts, inner.attempts)
+		}
+		if len(*slept) != attempts-1 {
+			t.Errorf("max_attempts %d: slept %d times, want %d",
+				attempts, len(*slept), attempts-1)
+		}
+	}
+}
+
+// --- Backoff ---------------------------------------------------------------
+
+// A cap below the initial backoff must bind on the first sleep. Applying it
+// only after the first sleep lets one wait exceed the cap the operator set.
+func TestBounds_InitialBackoffAboveTheCapIsCapped(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 3
+	p.InitialBackoff = 5 * time.Second
+	p.MaxBackoff = 100 * time.Millisecond
+	p.Deadline = time.Hour
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+
+	for i, d := range *slept {
+		if d > p.MaxBackoff {
+			t.Errorf("sleep %d was %v, above the %v cap", i, d, p.MaxBackoff)
+		}
+	}
+}
+
+// Zero backoff means retry immediately, which is a legitimate ask. It must
+// stay bounded by MaxAttempts rather than spinning.
+func TestBounds_ZeroBackoffRetriesImmediately(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 4
+	p.InitialBackoff = 0
+	p.MaxBackoff = 0
+	p.Deadline = time.Hour
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+	assert.Equal(t, 4, inner.attempts)
+	for _, d := range *slept {
+		assert.Equal(t, time.Duration(0), d)
+	}
+}
+
+// A negative backoff must not become a negative sleep or an endless one.
+func TestBounds_NegativeBackoffIsTreatedAsZero(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 3
+	p.InitialBackoff = -time.Second
+	p.MaxBackoff = -time.Second
+	p.Deadline = time.Hour
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+	assert.Equal(t, 3, inner.attempts)
+	for i, d := range *slept {
+		if d < 0 {
+			t.Errorf("sleep %d was negative: %v", i, d)
+		}
+	}
+}
+
+// Doubling must not overflow into a negative duration, which would turn a
+// long backoff into a tight loop.
+func TestBounds_HugeBackoffDoesNotOverflow(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 8
+	p.InitialBackoff = time.Duration(1) << 61
+	p.MaxBackoff = time.Duration(1) << 62
+	p.Deadline = time.Hour
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+	for i, d := range *slept {
+		if d < 0 {
+			t.Errorf("sleep %d overflowed to %v", i, d)
+		}
+	}
+}
+
+// --- Deadline --------------------------------------------------------------
+
+// A zero deadline leaves no room to wait, so the ladder makes its one attempt
+// and reports. It must not skip the flush.
+func TestBounds_ZeroDeadlineMakesOneAttempt(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 10
+	p.Deadline = 0
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+	assert.Equal(t, 1, inner.attempts)
+	assert.Equal(t, 0, len(*slept))
+}
+
+func TestBounds_NegativeDeadlineMakesOneAttempt(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 10
+	p.Deadline = -time.Minute
+	r, _ := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+	assert.Equal(t, 1, inner.attempts)
+}
+
+// The deadline bounds the total wait. A ladder that would sleep past it stops
+// rather than overrunning, because it runs inside the state transaction whose
+// clock the window depends on.
+func TestBounds_TotalSleepNeverExceedsTheDeadline(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 50
+	p.InitialBackoff = 10 * time.Millisecond
+	p.MaxBackoff = 10 * time.Millisecond
+	p.Deadline = 55 * time.Millisecond
+	r, slept := newTestRetry(inner, p)
+
+	assert.Error(t, r.Flush(context.Background()))
+
+	var total time.Duration
+	for _, d := range *slept {
+		total += d
+	}
+	if total > p.Deadline {
+		t.Errorf("slept %v in total, past the %v deadline", total, p.Deadline)
+	}
+}
+
+// --- What stopped the ladder ----------------------------------------------
+
+// An operator reading the error has to know whether to raise max_attempts or
+// the deadline. Reporting "after N attempts" when the deadline stopped it
+// early sends them to the wrong knob.
+func TestBounds_ErrorSaysTheDeadlineStoppedIt(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 100
+	p.InitialBackoff = 20 * time.Millisecond
+	p.MaxBackoff = 20 * time.Millisecond
+	p.Deadline = 30 * time.Millisecond
+	r, _ := newTestRetry(inner, p)
+
+	err := r.Flush(context.Background())
+
+	assert.Error(t, err)
+	if strings.Contains(err.Error(), "100 attempts") {
+		t.Errorf("the deadline stopped the ladder but the error blames attempts: %v", err)
+	}
+	assert.That(t, strings.Contains(err.Error(), "deadline"))
+}
+
+func TestBounds_ErrorSaysAttemptsWereExhausted(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 3
+	p.Deadline = time.Hour
+	r, _ := newTestRetry(inner, p)
+
+	err := r.Flush(context.Background())
+
+	assert.Error(t, err)
+	assert.That(t, strings.Contains(err.Error(), "3 attempts"))
+}
+
+// The cause has to survive so an operator sees what the destination said.
+func TestBounds_ExhaustedErrorWrapsTheCause(t *testing.T) {
+	cause := errors.New("dial tcp 10.0.0.1:9000: connect: connection refused")
+	inner := &flakySink{failures: 1 << 30, err: cause}
+	p := testPolicy()
+	p.MaxAttempts = 2
+	r, _ := newTestRetry(inner, p)
+
+	err := r.Flush(context.Background())
+
+	assert.Error(t, err)
+	assert.That(t, errors.Is(err, cause))
+	assert.That(t, strings.Contains(err.Error(), "connection refused"))
+}
+
+// --- Success ---------------------------------------------------------------
+
+// Succeeding on the final attempt is a success, not an exhausted ladder.
+func TestBounds_SuccessOnTheFinalAttempt(t *testing.T) {
+	inner := &flakySink{failures: 3, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+	p := testPolicy()
+	p.MaxAttempts = 4
+	r, _ := newTestRetry(inner, p)
+
+	assert.NoError(t, r.Flush(context.Background()))
+	assert.Equal(t, 4, inner.attempts)
+}
+
+// --- Cancellation ----------------------------------------------------------
+
+// A context cancelled partway through stops the ladder there.
+func TestBounds_CancellationMidLadderStops(t *testing.T) {
+	inner := alwaysFails()
+	p := testPolicy()
+	p.MaxAttempts = 10
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := newRetrying(inner, p)
+	r.sleep = func(ctx context.Context, d time.Duration) error {
+		if inner.attempts >= 3 {
+			cancel()
+		}
+		return ctx.Err()
+	}
+
+	assert.Error(t, r.Flush(ctx))
+	assert.Equal(t, 3, inner.attempts)
+	cancel()
+}
+
+// --- Non-retryable, under every bound --------------------------------------
+
+// A rejected write must stop after one attempt regardless of how generous the
+// policy is.
+func TestBounds_NonRetryableStopsUnderAnyPolicy(t *testing.T) {
+	for _, p := range []RetryPolicy{
+		{MaxAttempts: 0},
+		{MaxAttempts: 1},
+		{MaxAttempts: 100, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, Deadline: time.Hour},
+	} {
+		inner := &flakySink{failures: 1 << 30, err: errs.New(errs.CodeSinkWriteFailed, "no such column")}
+		r, _ := newTestRetry(inner, p)
+
+		err := r.Flush(context.Background())
+
+		assert.Error(t, err)
+		if inner.attempts != 1 {
+			t.Errorf("policy %+v: made %d attempts on a non-retryable error", p, inner.attempts)
+		}
+		// The code is preserved rather than being rewritten as unreachable.
+		assert.Equal(t, errs.CodeSinkWriteFailed, errs.CodeOf(err))
+	}
+}

--- a/internal/sinks/retry_test.go
+++ b/internal/sinks/retry_test.go
@@ -203,37 +203,40 @@ func isRetrying(s core.Sink) bool {
 // Kafka must not be wrapped. franz-go already retries a produce with its own
 // backoff, and a second ladder on top of that one delays the report without
 // improving delivery. The sinks reaching nothing remote gain nothing either.
-func TestNew_WrapsOnlyTheSinksThatCrossANetwork(t *testing.T) {
-	for _, tc := range []struct {
-		sink config.Sink
-		want bool
-	}{
-		{config.Sink{Type: "noop"}, false},
-		{config.Sink{Type: "console"}, false},
-		{config.Sink{Type: ""}, false},
-		{config.Sink{Type: "kafka", Kafka: &config.KafkaSink{
-			Brokers: []string{"localhost:9092"}, Topic: "t"}}, false},
-		{config.Sink{Type: "clickhouse", Clickhouse: &config.ClickhouseSink{
-			DSN: "clickhouse://localhost:8123/db", Table: "t"}}, true},
+func TestRetriesHelp_OnlyForSinksThatCrossANetwork(t *testing.T) {
+	for sinkType, want := range map[string]bool{
+		"clickhouse": true,
+		"iceberg":    true,
+		"kafka":      false,
+		"console":    false,
+		"":           false,
+		"noop":       false,
+		"sqlcommand": false,
 	} {
-		s, err := New(tc.sink, nil)
-		assert.NoError(t, err)
-		if got := isRetrying(s); got != tc.want {
-			t.Errorf("sink %q: wrapped=%v, want %v", tc.sink.Type, got, tc.want)
+		if got := retriesHelp(sinkType); got != want {
+			t.Errorf("sink %q: retriesHelp=%v, want %v", sinkType, got, want)
 		}
+	}
+}
+
+// The sinks that reach nothing remote are built without a ladder. These build
+// for real, so they also prove construction does not dial.
+func TestNew_LocalSinksAreNotWrapped(t *testing.T) {
+	for _, s := range []config.Sink{
+		{Type: "noop"},
+		{Type: "console"},
+		{Type: ""},
+	} {
+		built, err := New(s, nil)
+		assert.NoError(t, err)
+		assert.That(t, !isRetrying(built))
 	}
 }
 
 // max_attempts: 1 is how an operator turns retrying off.
 func TestNew_MaxAttemptsOneDisablesRetrying(t *testing.T) {
-	s, err := New(config.Sink{
-		Type:       "clickhouse",
-		Clickhouse: &config.ClickhouseSink{DSN: "clickhouse://localhost:8123/db", Table: "t"},
-		Retry:      &config.SinkRetry{MaxAttempts: 1},
-	}, nil)
-
-	assert.NoError(t, err)
-	assert.That(t, !isRetrying(s))
+	assert.That(t, !RetryPolicyFrom(&config.SinkRetry{MaxAttempts: 1}).Enabled())
+	assert.That(t, RetryPolicyFrom(&config.SinkRetry{MaxAttempts: 2}).Enabled())
 }
 
 // An omitted block takes the defaults rather than turning retrying off. One

--- a/internal/sinks/retry_test.go
+++ b/internal/sinks/retry_test.go
@@ -1,0 +1,247 @@
+package sinks
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/zeebo/assert"
+)
+
+// flakySink fails a set number of times, then succeeds. It records how many
+// attempts it saw so a test can assert the ladder ran the expected length.
+type flakySink struct {
+	failures int
+	err      error
+	attempts int
+}
+
+func (s *flakySink) WriteTable(ctx context.Context, batch arrow.Table) error { return nil }
+func (s *flakySink) Batch() (arrow.Table, error)                             { return nil, nil }
+
+func (s *flakySink) Flush(ctx context.Context) error {
+	s.attempts++
+	if s.attempts <= s.failures {
+		return s.err
+	}
+	return nil
+}
+
+// testPolicy retries quickly so the tests do not sleep. The sleeps are
+// recorded rather than taken.
+func testPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxAttempts:    5,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+		Deadline:       time.Minute,
+	}
+}
+
+// newTestRetry wraps inner and captures the backoffs instead of sleeping.
+func newTestRetry(inner *flakySink, p RetryPolicy) (*retrying, *[]time.Duration) {
+	var slept []time.Duration
+	r := newRetrying(inner, p)
+	r.sleep = func(ctx context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		return ctx.Err()
+	}
+	return r, &slept
+}
+
+// An unreachable sink is the case retry exists for: the destination may come
+// back, and a restart to recover from a 50ms hiccup costs a cold start and a
+// group rejoin.
+func TestRetry_RetriesAnUnreachableSink(t *testing.T) {
+	inner := &flakySink{failures: 2, err: errs.New(errs.CodeSinkUnreachable, "connection refused")}
+	r, slept := newTestRetry(inner, testPolicy())
+
+	assert.NoError(t, r.Flush(context.Background()))
+
+	assert.Equal(t, 3, inner.attempts)
+	assert.Equal(t, 2, len(*slept))
+}
+
+// A rejected write fails the same way every attempt. Retrying a schema
+// mismatch burns the deadline and reports the failure minutes late.
+func TestRetry_DoesNotRetryARejectedWrite(t *testing.T) {
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkWriteFailed, "no such column")}
+	r, slept := newTestRetry(inner, testPolicy())
+
+	err := r.Flush(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, inner.attempts)
+	assert.Equal(t, 0, len(*slept))
+	assert.Equal(t, errs.CodeSinkWriteFailed, errs.CodeOf(err))
+}
+
+// A misconfigured sink is the user's to fix. No number of attempts helps.
+func TestRetry_DoesNotRetryAConfigError(t *testing.T) {
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkInvalid, "table is required")}
+	r, _ := newTestRetry(inner, testPolicy())
+
+	err := r.Flush(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, inner.attempts)
+	assert.Equal(t, errs.CodeSinkInvalid, errs.CodeOf(err))
+}
+
+// Exhausting the ladder reports the destination as unreachable, which maps to
+// a retryable exit code so a supervisor restarts rather than giving up.
+func TestRetry_ExhaustedAttemptsReportUnreachable(t *testing.T) {
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "connection refused")}
+	r, _ := newTestRetry(inner, testPolicy())
+
+	err := r.Flush(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, 5, inner.attempts)
+	assert.Equal(t, errs.CodeSinkUnreachable, errs.CodeOf(err))
+	assert.Equal(t, errs.ExitSinkUnreachable, errs.ExitCode(err))
+}
+
+// Backoff grows and then stops growing. An unbounded ladder sleeps past the
+// flush interval and freezes the window clock.
+func TestRetry_BackoffGrowsAndIsCapped(t *testing.T) {
+	p := testPolicy()
+	p.MaxAttempts = 6
+	p.InitialBackoff = 10 * time.Millisecond
+	p.MaxBackoff = 40 * time.Millisecond
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+	r, slept := newTestRetry(inner, p)
+
+	r.Flush(context.Background())
+
+	assert.DeepEqual(t, []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		40 * time.Millisecond,
+		40 * time.Millisecond,
+	}, *slept)
+}
+
+// The reason the interface carries a context. A SIGTERM mid-ladder must stop
+// the retries, or the graceful drain waits out the whole deadline.
+func TestRetry_CancellationStopsTheLadder(t *testing.T) {
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+	r := newRetrying(inner, testPolicy())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := r.Flush(ctx)
+
+	assert.Error(t, err)
+	// One attempt was made before the context was consulted; the ladder does
+	// not continue past a cancelled context.
+	assert.Equal(t, 1, inner.attempts)
+}
+
+// A sink that works costs nothing.
+func TestRetry_SuccessDoesNotSleep(t *testing.T) {
+	inner := &flakySink{failures: 0}
+	r, slept := newTestRetry(inner, testPolicy())
+
+	assert.NoError(t, r.Flush(context.Background()))
+
+	assert.Equal(t, 1, inner.attempts)
+	assert.Equal(t, 0, len(*slept))
+}
+
+// The deadline bounds the whole ladder, not each attempt. It is what keeps a
+// retry from outliving the flush interval.
+func TestRetry_DeadlineStopsTheLadder(t *testing.T) {
+	p := testPolicy()
+	p.MaxAttempts = 100
+	p.Deadline = 25 * time.Millisecond
+	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "refused")}
+	r := newRetrying(inner, p)
+
+	start := time.Now()
+	err := r.Flush(context.Background())
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.That(t, inner.attempts < 100)
+	assert.That(t, elapsed < 2*time.Second)
+}
+
+// An uncoded error is not evidence the destination is reachable or not.
+// Retrying it is the safer default: the alternative fails a pipeline on a
+// driver error nobody classified yet.
+func TestRetry_RetriesAnUncodedError(t *testing.T) {
+	inner := &flakySink{failures: 1, err: errors.New("i/o timeout")}
+	r, _ := newTestRetry(inner, testPolicy())
+
+	assert.NoError(t, r.Flush(context.Background()))
+	assert.Equal(t, 2, inner.attempts)
+}
+
+func isRetrying(s core.Sink) bool {
+	_, ok := s.(*retrying)
+	return ok
+}
+
+// Kafka must not be wrapped. franz-go already retries a produce with its own
+// backoff, and a second ladder on top of that one delays the report without
+// improving delivery. The sinks reaching nothing remote gain nothing either.
+func TestNew_WrapsOnlyTheSinksThatCrossANetwork(t *testing.T) {
+	for _, tc := range []struct {
+		sink config.Sink
+		want bool
+	}{
+		{config.Sink{Type: "noop"}, false},
+		{config.Sink{Type: "console"}, false},
+		{config.Sink{Type: ""}, false},
+		{config.Sink{Type: "kafka", Kafka: &config.KafkaSink{
+			Brokers: []string{"localhost:9092"}, Topic: "t"}}, false},
+		{config.Sink{Type: "clickhouse", Clickhouse: &config.ClickhouseSink{
+			DSN: "clickhouse://localhost:8123/db", Table: "t"}}, true},
+	} {
+		s, err := New(tc.sink, nil)
+		assert.NoError(t, err)
+		if got := isRetrying(s); got != tc.want {
+			t.Errorf("sink %q: wrapped=%v, want %v", tc.sink.Type, got, tc.want)
+		}
+	}
+}
+
+// max_attempts: 1 is how an operator turns retrying off.
+func TestNew_MaxAttemptsOneDisablesRetrying(t *testing.T) {
+	s, err := New(config.Sink{
+		Type:       "clickhouse",
+		Clickhouse: &config.ClickhouseSink{DSN: "clickhouse://localhost:8123/db", Table: "t"},
+		Retry:      &config.SinkRetry{MaxAttempts: 1},
+	}, nil)
+
+	assert.NoError(t, err)
+	assert.That(t, !isRetrying(s))
+}
+
+// An omitted block takes the defaults rather than turning retrying off. One
+// refused connection killing the process was the defect, not the baseline.
+func TestRetryPolicyFrom_DefaultsAreOn(t *testing.T) {
+	p := RetryPolicyFrom(nil)
+
+	assert.That(t, p.Enabled())
+	assert.Equal(t, DefaultRetryMaxAttempts, p.MaxAttempts)
+	assert.Equal(t, DefaultRetryDeadline, p.Deadline)
+}
+
+func TestRetryPolicyFrom_OverridesOnlyWhatIsSet(t *testing.T) {
+	p := RetryPolicyFrom(&config.SinkRetry{MaxAttempts: 9, DeadlineSeconds: 3})
+
+	assert.Equal(t, 9, p.MaxAttempts)
+	assert.Equal(t, 3*time.Second, p.Deadline)
+	// Untouched fields keep their defaults.
+	assert.Equal(t, DefaultRetryInitialBackoff, p.InitialBackoff)
+	assert.Equal(t, DefaultRetryMaxBackoff, p.MaxBackoff)
+}

--- a/internal/sinks/retry_test.go
+++ b/internal/sinks/retry_test.go
@@ -44,11 +44,21 @@ func testPolicy() RetryPolicy {
 }
 
 // newTestRetry wraps inner and captures the backoffs instead of sleeping.
+//
+// The fake sleep advances a virtual clock by exactly what it was asked to
+// wait, and the policy's deadline is measured against that same clock. Faking
+// only the sleep would leave the deadline measured against a wall clock that
+// never moves, so it could never bind and every deadline test would pass
+// whatever the code did.
 func newTestRetry(inner *flakySink, p RetryPolicy) (*retrying, *[]time.Duration) {
 	var slept []time.Duration
+	clock := time.Now()
+
 	r := newRetrying(inner, p)
+	r.now = func() time.Time { return clock }
 	r.sleep = func(ctx context.Context, d time.Duration) error {
 		slept = append(slept, d)
+		clock = clock.Add(d)
 		return ctx.Err()
 	}
 	return r, &slept

--- a/internal/sinks/sqlcommand.go
+++ b/internal/sinks/sqlcommand.go
@@ -37,7 +37,7 @@ func NewSQLCommandSink(conn adbc.Connection, sql string, substitutions []config.
 	return &SQLCommandSink{conn: conn, sql: sql, substitutions: substitutions}, nil
 }
 
-func (s *SQLCommandSink) WriteTable(batch arrow.Table) error {
+func (s *SQLCommandSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -56,7 +56,7 @@ func (s *SQLCommandSink) Batch() (arrow.Table, error) {
 	return s.tables[len(s.tables)-1], nil
 }
 
-func (s *SQLCommandSink) Flush() error {
+func (s *SQLCommandSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	tables := s.tables
 	s.tables = nil
@@ -71,7 +71,6 @@ func (s *SQLCommandSink) Flush() error {
 		}
 	}()
 
-	ctx := context.Background()
 	if err := s.materialize(ctx, tables); err != nil {
 		return err
 	}

--- a/sqlflow/static/schemas/config.json
+++ b/sqlflow/static/schemas/config.json
@@ -182,6 +182,37 @@
                         "type": "object",
                         "description": "Console output sink configuration.",
                         "properties": {}
+                      },
+                      "retry": {
+                        "type": "object",
+                        "description": "Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.",
+                        "properties": {
+                          "max_attempts": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 4,
+                            "description": "Total attempts, including the first. 1 disables retrying."
+                          },
+                          "initial_backoff_ms": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 100,
+                            "description": "Wait before the first retry. Doubles each attempt."
+                          },
+                          "max_backoff_ms": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 2000,
+                            "description": "Ceiling on the backoff."
+                          },
+                          "deadline_seconds": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 10,
+                            "description": "Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on."
+                          }
+                        },
+                        "additionalProperties": false
                       }
                     },
                     "required": [
@@ -536,6 +567,37 @@
               "type": "object",
               "description": "Console output sink configuration.",
               "properties": {}
+            },
+            "retry": {
+              "type": "object",
+              "description": "Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.",
+              "properties": {
+                "max_attempts": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 4,
+                  "description": "Total attempts, including the first. 1 disables retrying."
+                },
+                "initial_backoff_ms": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 100,
+                  "description": "Wait before the first retry. Doubles each attempt."
+                },
+                "max_backoff_ms": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 2000,
+                  "description": "Ceiling on the backoff."
+                },
+                "deadline_seconds": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 10,
+                  "description": "Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on."
+                }
+              },
+              "additionalProperties": false
             }
           },
           "required": [
@@ -678,6 +740,37 @@
                   "type": "object",
                   "description": "Console output sink configuration.",
                   "properties": {}
+                },
+                "retry": {
+                  "type": "object",
+                  "description": "Bounds how long this sink keeps trying a destination that is not answering. Omit to accept the defaults; set max_attempts to 1 to turn retrying off. The kafka sink ignores this: franz-go already retries a produce with its own backoff.",
+                  "properties": {
+                    "max_attempts": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "default": 4,
+                      "description": "Total attempts, including the first. 1 disables retrying."
+                    },
+                    "initial_backoff_ms": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 100,
+                      "description": "Wait before the first retry. Doubles each attempt."
+                    },
+                    "max_backoff_ms": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 2000,
+                      "description": "Ceiling on the backoff."
+                    },
+                    "deadline_seconds": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "default": 10,
+                      "description": "Bounds the whole ladder, not one attempt. Keep it below pipeline.flush_interval_seconds: the retry runs inside the open state transaction, whose clock the window depends on."
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [


### PR DESCRIPTION
Closes #110.

## Defect

Every sink failure was fatal. `internal/core/turbine.go` rolled back the state transaction and returned, which exited the process.

Correctness survived. Offsets did not advance and the batch replayed. Availability did not: a 50ms ClickHouse hiccup cost a full restart, a cold start, a group rejoin and a rebalance.

A sink also never checked its destination. `clickhouse.Open` validates options and never dials, so a pipeline whose DSN names a host that does not resolve started normally, logged `consumer loop starting`, and ran. The failure appeared only when the first batch reached the sink, which with a long flush interval is minutes later. A supervisor called the pipeline healthy for all of them.

## Fix

`sinks.New` wraps a sink in a bounded retry ladder and dials its destination once before the pipeline consumes anything.

```yaml
sink:
  type: clickhouse
  retry:
    max_attempts: 4          # including the first; 1 disables retrying
    initial_backoff_ms: 100  # doubles each attempt
    max_backoff_ms: 2000
    deadline_seconds: 10     # bounds the whole ladder, not one attempt
```

Retrying is on by default. One refused connection killing the process was the defect rather than a safe baseline.

### Which errors retry

The taxonomy decides. A rejected write and a bad configuration fail identically every attempt, so retrying them only delays the report past the deadline.

Everything else retries, including errors carrying no code. A driver's timeout or reset arrives unclassified, and those are the failures this exists for. The deadline bounds the cost of guessing wrong.

### The classification the ladder depends on

The ladder could not have worked against a real ClickHouse. The sink coded every failure from `PrepareBatch` as `system.sink.write_failed`, and `PrepareBatch` dials, so a refused connection was classified as the one thing retry deliberately does not retry.

`isUnreachable` now separates a network failure from a server rejection: refused, reset, unreachable, broken pipe, EOF, DNS, `net.OpError`, any `net.Error` timeout, and deadline exceeded.

Verified against a live server. Pointing the sink at a database that does not exist reports `user.sink.invalid` rather than unreachable, and is not retried.

### Which sinks are wrapped

Only the ones crossing a network to somebody else's server: ClickHouse and Iceberg.

Kafka is not. It hands records to franz-go, which already retries a produce with its own backoff, and a second ladder on top of that one delays the report without improving delivery. Console, noop and sqlcommand reach nothing that can be temporarily unavailable; sqlcommand writes through the pipeline's own DuckDB connection.

The decision is a function of the sink type alone, so it is testable without building a sink, which would dial.

### The startup probe

Sinks that can check their destination implement `Prober`. It dials once and does not retry: an unreachable destination exits with a retryable code, so the supervisor's restart is already the retry, and nothing has been consumed yet.

A server that answers and refuses is the user's to fix. A wrong password does not resolve on a restart, so that reports `user.sink.invalid` and exits terminal.

`config validate` still works offline. Only the `run` path builds sinks.

### The interface takes a context

A retry ladder has to be interruptible. Without a context it outlives the SIGTERM that asked the pipeline to stop, and the drain #159 added waits out the full retry deadline before it can finish.

Three sinks were manufacturing their own `context.Background()` inside `Flush` -- clickhouse, iceberg and sqlcommand -- which is the same cancellation gap one layer down. Those are gone, so the caller's context now reaches the driver.

### Observability

`sink_retry_count{sink}` makes a stalled sink visible before its deadline fires. Without it, a pipeline retrying every batch looks the same on a dashboard as one that is merely slow, and the first signal is the process exiting.

## Five bounds defects

An exhaustive pass over every bound of `RetryPolicy` found five, each reachable from a config file.

| Bound | Defect |
| --- | --- |
| `max_attempts: 0` or less | The sink was **never called**. The ladder returned a fabricated "still failing after 0 attempts" wrapping a nil cause. |
| First backoff | Ignored `max_backoff_ms`. Measured: a 5s sleep under a 100ms cap. |
| Negative backoff | Became a negative sleep, which `time.Timer` fires immediately, turning the ladder into a spin. Measured: -1s and -2s. |
| Doubling | Could overflow int64 and wrap negative, which the clamp then read as zero and spun on. |
| Exhausted error | Blamed `max_attempts` even when the deadline stopped the ladder early. Measured: "after 100 attempts" on a ladder that made three. |

A policy bounds how often a write is retried. It never licenses skipping the write, so `MaxAttempts` floors at 1.

A sixth failure was the test harness rather than the code. The fake sleep did not advance a clock, and the deadline is measured against one, so no deadline test could bind. The harness now advances a virtual clock by exactly what it was asked to wait. Verified by mutation: pushing the deadline an hour out fails all four deadline tests.

Deliberate: the deadline is measured against the clock rather than the sum of the backoffs, so a flush attempt blocking on a TCP timeout spends the deadline too.

## Evidence

57 tests in the sinks package.

- **Ladder**: retries an unreachable sink, stops on a rejected write, backoff doubles and caps, deadline bounds the whole ladder, a cancelled context stops it after the attempt in flight.
- **Bounds**: `max_attempts` at -3, 0, 1, 2 and 1..6; backoff zero, negative, above the cap, and near the int64 ceiling; deadline zero, negative, and shorter than one backoff; which bound stopped the ladder; cause preservation; success on the final attempt; cancellation mid-ladder; a non-retryable error under every policy shape.
- **Classification**: eleven network error shapes against three server rejections.
- **Probe**: reachable, unreachable, auth failure, sinks with nothing to dial, dialing exactly once, cancelled context.
- **Metric**: a retried flush, a clean one, a non-retryable failure, an exhausted ladder, a nil provider.

Full Go suite: 14 packages, 0 failures. `go vet` and `gofmt` clean.

## Config schema

`retry` is in the schema, so a typo inside it is reported rather than ignored: the sink objects set no `additionalProperties`, so an unknown key had been passing validation silently.

The schema is edited in `sqlflow/static` and copied to `internal/cli/schemas`, which is the direction `TestEmbeddedSchemaMatchesPython` enforces.

## Not in this change

The deadline-versus-`flush_interval_seconds` rule. The retry runs inside the pipeline's open state transaction, and DuckDB's `now()` returns that transaction's start time, so a ladder outliving the flush interval freezes the window clock -- the bug #158 fixed, reached by a second route.

It belongs in `validate` rather than a runtime clamp, so the user is told their deadline is too long instead of having it silently shortened. It is a cross-field rule that JSON Schema cannot express, so it needs Go validation alongside #169.

## What breaks if this is wrong

A pipeline retries a failure no attempt can fix and reports it a deadline late, keeps dying on a blip it could have absorbed, or starts healthy against a destination that was never there.
