### PR TITLE
CI: run every Go package, drop the Python engine's tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,6 @@
 name: CI
 on: [push]
 jobs:
-  ci:
-    name: CI
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.11
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.dev.txt ]; then pip install -r requirements.dev.txt; fi
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-      - name: Test Unit
-        run: |
-          mkdir /tmp/sqlflow
-          mkdir /tmp/sqlflow/resultscache
-          make test-unit
-
-      - name: Test Integration
-        run: |
-          make test-integration
-
   # The Go engine (sqlflow). Unit tests only: anything that needs a Kafka broker
   # stays out of CI and runs from the dev stack.
   go:
@@ -66,8 +39,11 @@ jobs:
             exit 1
           fi
 
+      # ./... rather than ./internal/...: the narrower form covers 16 of the 17
+      # packages, and the 17th has no tests today. That makes the gap silent
+      # rather than absent -- the first test added under cmd/ would not run.
       - name: Test Unit
-        run: go test ./internal/...
+        run: go test ./...
 
   # Functional tests against the built image: entrypoint, CLI surface, the
   # baked-in libduckdb, and a real pipeline through Kafka. The Go job above


### PR DESCRIPTION
Two changes to what CI covers.

## `go test ./internal/...` becomes `go test ./...`

The narrower form covers 16 of the 17 packages. The 17th, `cmd/sqlflow`, has no test files, so nothing is missed today -- which makes the gap silent rather than absent. The first test added under `cmd/` would not run, and nobody would see that.

## The Python job goes

The `CI` job ran the Python engine's unit and integration suites. That engine is not shipped: the Dockerfile builds the Go binary and sets `ENTRYPOINT /usr/local/bin/sqlflow`, and the README documents `make sqlflow` and `docker run`. The suite covers the Python handlers, sinks, sources, managers and pipeline -- code no user runs -- and gated every Go pull request on it for 1m42s.

It does not guard the config spec either. Nothing under `tests/` or `sqlflow/` reads `sqlflow/static/schemas/config.json`. The only guard on that file is the Go test comparing the two copies byte for byte, which this change does not touch.

## What stays

The Python package itself. `tests/release` imports `settings`, `KafkaFaker` and `read_all_kafka_messages` from it as harness for the image tests, so the `Image` job keeps its Python setup.

Removing the engine is a follow-up branch that builds on this one.

## What breaks if this is wrong

A regression in the Python engine goes unnoticed. That is the intent: it is not the shipped artifact.
