### PR TITLE
build: release-image refuses a HEAD that is not on origin/main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,13 @@ release-image:
 	@test -z "$$(git status --porcelain)" || { \
 		echo "release-image: working tree is dirty, so $(VERSION) would not be reproducible" >&2; \
 		echo "               commit or stash, then re-run" >&2; exit 1; }
+	@# A clean, tagged HEAD is not enough: v1.0.5 was first tagged and published
+	@# from a feature branch, so the image shipped unmerged commits and lacked
+	@# the fixes its own tag message described. The release must be on main.
+	@git fetch -q origin main && git merge-base --is-ancestor HEAD origin/main || { \
+		echo "release-image: HEAD is not on origin/main, so $(VERSION) would ship unmerged commits" >&2; \
+		echo "               git checkout main && git pull --ff-only origin main, then tag and re-run" >&2; \
+		exit 1; }
 	@git describe --exact-match --tags HEAD >/dev/null 2>&1 || { \
 		echo "release-image: HEAD is not tagged (VERSION=$(VERSION))" >&2; \
 		echo "               tag the release first: git tag -a vX.Y.Z -m ... && git push origin vX.Y.Z" >&2; \


### PR DESCRIPTION
## Problem

`make release-image` checks for a clean tree and an exact tag on HEAD, and nothing else. Both passed today on a feature branch: v1.0.5 was tagged and published from `feat/error-taxonomy` at 0c045cc, so the image on Docker Hub carried seven unmerged commits and lacked #174 and #217, the two fixes its own tag message described. `latest` pointed at it.

## Fix

A third guard, between the clean-tree check and the tag check, fetches `origin/main` and requires HEAD to be an ancestor of it:

```
git fetch -q origin main && git merge-base --is-ancestor HEAD origin/main
```

It runs before the tag check because being on the wrong branch is the more fundamental error, and it is the one to report first.

## Verification

From a worktree whose HEAD is one commit past main:

```
release-image: HEAD is not on origin/main, so v1.0.5-1-g612ac65 would ship unmerged commits
               git checkout main && git pull --ff-only origin main, then tag and re-run
make: *** [release-image] Error 1
```

No docker invocation is reached. The check itself against the two commits from the incident: 658a451 (main) is allowed, 0c045cc (the feature branch head v1.0.5 was first cut from) is refused.