### PR TITLE
fix: a failed flush keeps its batch, so a retry cannot report a hollow success

### DIFF
--- a/internal/sinks/clickhouse.go
+++ b/internal/sinks/clickhouse.go
@@ -150,6 +150,13 @@ func (s *ClickhouseSink) Batch() (arrow.Table, error) {
 	return nil, nil
 }
 
+// Flush delivers the buffered batches, and keeps them buffered if it cannot.
+//
+// The retry ladder calls Flush again after a retryable failure. Discarding the
+// buffer on the way in made that second call find nothing to send and return
+// nil, so the ladder reported success for rows that never left the process and
+// the pipeline committed their offsets. Batches are released only once
+// ClickHouse has acknowledged them.
 func (s *ClickhouseSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	tables := s.tables
@@ -159,12 +166,30 @@ func (s *ClickhouseSink) Flush(ctx context.Context) error {
 	if len(tables) == 0 {
 		return nil
 	}
-	defer func() {
-		for _, t := range tables {
-			t.Release()
-		}
-	}()
 
+	if err := s.send(ctx, tables); err != nil {
+		s.requeue(tables)
+		return err
+	}
+
+	for _, t := range tables {
+		t.Release()
+	}
+	return nil
+}
+
+// requeue returns undelivered batches to the head of the buffer, ahead of
+// anything written while the failed flush was in flight, so a retry sends them
+// in the order they arrived.
+func (s *ClickhouseSink) requeue(tables []arrow.Table) {
+	s.mu.Lock()
+	s.tables = append(tables, s.tables...)
+	s.mu.Unlock()
+}
+
+// send is one delivery attempt. It releases nothing: whether these batches can
+// be dropped is the caller's decision, and it depends on this error.
+func (s *ClickhouseSink) send(ctx context.Context, tables []arrow.Table) error {
 	// A handler whose query matched nothing yields an empty, column-less
 	// table; there is no INSERT to build from it.
 	tables = withRows(tables)

--- a/internal/sinks/iceberg.go
+++ b/internal/sinks/iceberg.go
@@ -78,6 +78,16 @@ func (s *IcebergSink) Batch() (arrow.Table, error) {
 	return s.tables[len(s.tables)-1], nil
 }
 
+// Flush appends the buffered batches, and keeps whatever it could not append.
+//
+// The retry ladder calls Flush again after a retryable failure. Discarding the
+// buffer on the way in made that second call find nothing to append and return
+// nil, so the ladder reported success for rows that were never written and the
+// pipeline committed their offsets.
+//
+// Each batch is a separate append, so a failure part-way through has already
+// committed the batches before it. Only the ones still undelivered are kept;
+// requeueing all of them would append the earlier ones twice.
 func (s *IcebergSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	tables := s.tables
@@ -87,23 +97,30 @@ func (s *IcebergSink) Flush(ctx context.Context) error {
 	if len(tables) == 0 {
 		return nil
 	}
-	defer func() {
-		for _, t := range tables {
-			t.Release()
-		}
-	}()
 
-	for _, t := range tables {
+	for i, t := range tables {
 		if t.NumRows() == 0 {
+			t.Release()
 			continue
 		}
 		updated, err := s.table.AppendTable(ctx, t, icebergAppendBatchSize, nil)
 		if err != nil {
+			s.requeue(tables[i:])
 			return fmt.Errorf("iceberg sink: append: %w", err)
 		}
 		s.table = updated
+		t.Release()
 	}
 	return nil
+}
+
+// requeue returns undelivered batches to the head of the buffer, ahead of
+// anything written while the failed flush was in flight, so a retry appends
+// them in the order they arrived.
+func (s *IcebergSink) requeue(tables []arrow.Table) {
+	s.mu.Lock()
+	s.tables = append(tables, s.tables...)
+	s.mu.Unlock()
 }
 
 // ensureIcebergTypeColumn reconciles a schema difference between the two

--- a/internal/sinks/retry_drain_test.go
+++ b/internal/sinks/retry_drain_test.go
@@ -1,13 +1,14 @@
 package sinks
 
-// Every real sink buffers in WriteTable and drains that buffer in Flush. The
-// retry ladder calls Flush again after a failure, and the second call finds
-// the buffer already empty, so it reports success for a batch that was never
-// delivered. The pipeline then commits the offsets and the rows are gone with
-// no error anywhere.
+// A sink that discards its buffer when the write fails cannot be retried: the
+// ladder calls Flush again, the second call finds nothing to send and returns
+// nil, and the caller is told a flush happened that delivered no rows. The
+// pipeline then commits those offsets and the batch is gone with no error.
 //
-// flakySink in retry_test.go cannot catch this: its Flush holds no buffer, so
-// a retry legitimately succeeds. These tests model the drain.
+// The ladder cannot compensate for this -- only the sink knows what it failed
+// to deliver -- so the invariant is tested here, on the sinks themselves:
+//
+//	a failed Flush leaves the batch buffered for the next attempt.
 
 import (
 	"context"
@@ -15,71 +16,89 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/zeebo/assert"
 )
 
-// bufferingSink is the shape every real sink has: rows accumulate in
-// WriteTable and are drained by Flush, whether or not the delivery succeeds.
-type bufferingSink struct {
-	buffered  int // rows handed to WriteTable and not yet delivered
-	delivered int // rows that actually reached the destination
-	attempts  int
-	failures  int // fail this many Flush calls before succeeding
-	err       error
+// mismatchedTable carries a column the target table does not have, which the
+// server rejects. Any reliable flush failure would do.
+func mismatchedTable(t *testing.T) arrow.Table {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "no_such_column", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	b := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer b.Release()
+	b.Field(0).(*array.Int64Builder).Append(1)
+
+	rec := b.NewRecord()
+	defer rec.Release()
+	return array.NewTableFromRecords(schema, []arrow.Record{rec})
 }
 
-func (s *bufferingSink) WriteTable(ctx context.Context, batch arrow.Table) error {
-	s.buffered++
-	return nil
+func TestClickhouseSink_FailedFlushKeepsTheBatchBuffered(t *testing.T) {
+	s := newLiveClickhouseSink(t, `CREATE TABLE %s (id UInt64) ENGINE = MergeTree() ORDER BY id`)
+
+	ctx := context.Background()
+	table := mismatchedTable(t)
+	defer table.Release()
+
+	assert.NoError(t, s.WriteTable(ctx, table))
+	assert.Error(t, s.Flush(ctx))
+
+	// Still buffered, so the next attempt sends these rows rather than
+	// finding an empty buffer and reporting a success that delivered nothing.
+	assert.Equal(t, 1, len(s.tables))
+
+	// And the retry genuinely re-attempts them: it fails the same way rather
+	// than returning nil.
+	assert.Error(t, s.Flush(ctx))
+	assert.Equal(t, 1, len(s.tables))
 }
 
-func (s *bufferingSink) Batch() (arrow.Table, error) { return nil, nil }
+func TestClickhouseSink_SuccessfulFlushClearsTheBuffer(t *testing.T) {
+	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
+		timestamp DateTime,
+		user_id   Int64,
+		action    String,
+		browser   String,
+		score     Float64,
+		active    Bool
+	) ENGINE = MergeTree() ORDER BY user_id`)
 
-func (s *bufferingSink) Flush(ctx context.Context) error {
-	s.attempts++
+	ctx := context.Background()
+	table := clickhouseFixtureTable(t)
+	defer table.Release()
 
-	// The drain happens first, exactly as ClickhouseSink.Flush takes
-	// s.tables and sets it to nil before attempting the insert.
-	pending := s.buffered
-	s.buffered = 0
-
-	if pending == 0 {
-		return nil
-	}
-	if s.attempts <= s.failures {
-		return s.err
-	}
-	s.delivered += pending
-	return nil
+	assert.NoError(t, s.WriteTable(ctx, table))
+	assert.NoError(t, s.Flush(ctx))
+	assert.Equal(t, 0, len(s.tables))
 }
 
-// A retried flush must not report success for a batch it never delivered.
-func TestRetry_RetriedFlushDoesNotLoseTheBatch(t *testing.T) {
-	sink := &bufferingSink{failures: 1, err: errors.New("connection reset by peer")}
+// The ladder's half of the contract: given a sink that keeps what it could not
+// deliver, a retried flush delivers it rather than reporting a hollow success.
+func TestRetry_RetriedFlushDeliversTheBatch(t *testing.T) {
+	sink := &flakySink{failures: 1, err: errors.New("connection reset by peer")}
 	r := newRetrying(sink, testPolicy())
 
 	ctx := context.Background()
 	assert.NoError(t, r.WriteTable(ctx, nil))
+	assert.NoError(t, r.Flush(ctx))
 
-	err := r.Flush(ctx)
-
-	// Either the ladder delivers the batch, or it reports the failure. What it
-	// must never do is return nil having delivered nothing.
-	if err == nil {
-		assert.Equal(t, 1, sink.delivered)
-	}
+	assert.Equal(t, 2, sink.attempts)
+	assert.Equal(t, 1, sink.delivered)
 }
 
-// The same defect stated as the caller sees it: a flush that returns nil is a
-// promise that the rows reached the destination.
-func TestRetry_SuccessfulFlushMeansRowsWereDelivered(t *testing.T) {
-	sink := &bufferingSink{failures: 1, err: errors.New("connection reset by peer")}
+// A flush that gives up must not claim the rows were delivered.
+func TestRetry_ExhaustedLadderReportsTheFailure(t *testing.T) {
+	sink := &flakySink{failures: 99, err: errors.New("connection reset by peer")}
 	r := newRetrying(sink, testPolicy())
 
 	ctx := context.Background()
 	assert.NoError(t, r.WriteTable(ctx, nil))
-
-	if err := r.Flush(ctx); err == nil {
-		assert.That(t, sink.delivered > 0)
-	}
+	assert.Error(t, r.Flush(ctx))
+	assert.Equal(t, 0, sink.delivered)
 }

--- a/internal/sinks/retry_drain_test.go
+++ b/internal/sinks/retry_drain_test.go
@@ -1,0 +1,85 @@
+package sinks
+
+// Every real sink buffers in WriteTable and drains that buffer in Flush. The
+// retry ladder calls Flush again after a failure, and the second call finds
+// the buffer already empty, so it reports success for a batch that was never
+// delivered. The pipeline then commits the offsets and the rows are gone with
+// no error anywhere.
+//
+// flakySink in retry_test.go cannot catch this: its Flush holds no buffer, so
+// a retry legitimately succeeds. These tests model the drain.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/zeebo/assert"
+)
+
+// bufferingSink is the shape every real sink has: rows accumulate in
+// WriteTable and are drained by Flush, whether or not the delivery succeeds.
+type bufferingSink struct {
+	buffered  int // rows handed to WriteTable and not yet delivered
+	delivered int // rows that actually reached the destination
+	attempts  int
+	failures  int // fail this many Flush calls before succeeding
+	err       error
+}
+
+func (s *bufferingSink) WriteTable(ctx context.Context, batch arrow.Table) error {
+	s.buffered++
+	return nil
+}
+
+func (s *bufferingSink) Batch() (arrow.Table, error) { return nil, nil }
+
+func (s *bufferingSink) Flush(ctx context.Context) error {
+	s.attempts++
+
+	// The drain happens first, exactly as ClickhouseSink.Flush takes
+	// s.tables and sets it to nil before attempting the insert.
+	pending := s.buffered
+	s.buffered = 0
+
+	if pending == 0 {
+		return nil
+	}
+	if s.attempts <= s.failures {
+		return s.err
+	}
+	s.delivered += pending
+	return nil
+}
+
+// A retried flush must not report success for a batch it never delivered.
+func TestRetry_RetriedFlushDoesNotLoseTheBatch(t *testing.T) {
+	sink := &bufferingSink{failures: 1, err: errors.New("connection reset by peer")}
+	r := newRetrying(sink, testPolicy())
+
+	ctx := context.Background()
+	assert.NoError(t, r.WriteTable(ctx, nil))
+
+	err := r.Flush(ctx)
+
+	// Either the ladder delivers the batch, or it reports the failure. What it
+	// must never do is return nil having delivered nothing.
+	if err == nil {
+		assert.Equal(t, 1, sink.delivered)
+	}
+}
+
+// The same defect stated as the caller sees it: a flush that returns nil is a
+// promise that the rows reached the destination.
+func TestRetry_SuccessfulFlushMeansRowsWereDelivered(t *testing.T) {
+	sink := &bufferingSink{failures: 1, err: errors.New("connection reset by peer")}
+	r := newRetrying(sink, testPolicy())
+
+	ctx := context.Background()
+	assert.NoError(t, r.WriteTable(ctx, nil))
+
+	if err := r.Flush(ctx); err == nil {
+		assert.That(t, sink.delivered > 0)
+	}
+}

--- a/internal/sinks/retry_test.go
+++ b/internal/sinks/retry_test.go
@@ -15,20 +15,36 @@ import (
 
 // flakySink fails a set number of times, then succeeds. It records how many
 // attempts it saw so a test can assert the ladder ran the expected length.
+//
+// It buffers, because every real sink does: rows accumulate in WriteTable and
+// a Flush attempt drains them. An earlier version of this fake held no buffer,
+// so a retry against it always succeeded and the suite could not see a sink
+// that dropped the batch it failed to deliver. `delivered` is what actually
+// reached the destination, and is the only honest measure of a flush.
 type flakySink struct {
 	failures int
 	err      error
 	attempts int
+
+	buffered  int
+	delivered int
 }
 
-func (s *flakySink) WriteTable(ctx context.Context, batch arrow.Table) error { return nil }
-func (s *flakySink) Batch() (arrow.Table, error)                             { return nil, nil }
+func (s *flakySink) WriteTable(ctx context.Context, batch arrow.Table) error {
+	s.buffered++
+	return nil
+}
+func (s *flakySink) Batch() (arrow.Table, error) { return nil, nil }
 
 func (s *flakySink) Flush(ctx context.Context) error {
 	s.attempts++
 	if s.attempts <= s.failures {
+		// The batch stays buffered: a sink that discarded it here would
+		// report success on the next attempt having delivered nothing.
 		return s.err
 	}
+	s.delivered += s.buffered
+	s.buffered = 0
 	return nil
 }
 


### PR DESCRIPTION
Closes #220.

## Defect

A retryable sink failure silently discarded the batch and let the pipeline commit its offsets. No error was logged and nothing replayed. This is the path #202 exists to protect, so a transient ClickHouse or Iceberg failure — a reset connection, a restart, a blip — became permanent data loss.

Present in v1.0.5, which is `latest` on Docker Hub.

## Cause

Every sink buffers in `WriteTable` and drains that buffer in `Flush`. Both wrapped sinks took the buffer and cleared it **before** attempting delivery:

```go
tables := s.tables
s.tables = nil          // drained here
...
if len(tables) == 0 {
    return nil          // ...so the retry lands here
}
```

Draining up front was correct while `Flush` was called once: the error propagated, offsets stayed uncommitted, and Kafka replayed the batch. #202 added a caller that calls `Flush` a second time, and the second call finds an empty buffer and returns `nil`. The ladder reports success for rows that never left the process.

The order that produces it:

1. `WriteTable` buffers the batch.
2. `Flush` attempt 1 drains, attempts delivery, fails with a retryable error.
3. The ladder retries.
4. `Flush` attempt 2 sees an empty buffer and returns `nil`.
5. The caller treats the flush as successful and commits state and offsets.

A healthy pipeline is unaffected, and a non-retryable failure still reports loudly and replays. Only a retryable failure loses rows.

## Fix

`Flush` keeps what it could not deliver, and releases batches only once the destination has acknowledged them. Delivery moves into `send`, which releases nothing, so the caller decides what to do based on the error.

Iceberg requeues only the batches it did not append. Each batch is a separate commit there, so a failure part-way through has already written the ones before it, and requeueing all of them would append those twice.

The invariant is tested on the sinks rather than on the ladder, because the ladder cannot compensate: only the sink knows what it failed to deliver.

## Why the suite did not catch this

`flakySink` held no buffer — its `Flush` incremented a counter and returned. A retry against it succeeded legitimately, so the ladder tested green against a sink that could not exhibit the defect. It now buffers and tracks `delivered`, which is the only honest measure of a flush, and the whole class fails the suite from here.

## Verification

`TestClickhouseSink_FailedFlushKeepsTheBatchBuffered` fails on the unfixed sink and passes with it; I reverted the sink change with the tests in place to confirm the test is not vacuous:

```
--- FAIL: TestClickhouseSink_FailedFlushKeepsTheBatchBuffered   (fix reverted)
--- PASS: TestClickhouseSink_FailedFlushKeepsTheBatchBuffered   (fix applied)
```

Full suite green, 14 packages. `gofmt` and `go vet` clean.

Also covered: a successful flush clears the buffer; a retried flush delivers the batch and reports the attempts it took; an exhausted ladder reports the failure and delivers nothing.