### PR TITLE
fix: the windowed Postgres example wedges on its first duplicate

### DIFF
--- a/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
@@ -51,9 +51,18 @@ tables:
         sink:
           type: sqlcommand
           sqlcommand:
+            # ON CONFLICT is what keeps at-least-once delivery survivable. The
+            # manager deletes a window only after the sink accepts it, so a
+            # crash between the two republishes that window on the next poll.
+            # Against the target table's primary key on (bucket, lang), a bare
+            # INSERT fails that republish -- and because the failed flush also
+            # blocks the delete, every later poll collects the same rows and
+            # fails the same way. One duplicate stops the pipeline publishing
+            # anything, ever again.
             sql: |
               INSERT INTO pg.posts_per_minute_by_lang (bucket, lang, posts)
               SELECT bucket, lang, posts FROM sqlflow_sink_batch
+              ON CONFLICT (bucket, lang) DO UPDATE SET posts = EXCLUDED.posts
 
 pipeline:
   name: bluesky-posts-per-minute-by-lang


### PR DESCRIPTION
## Defect

The tumbling-window Postgres example stops publishing permanently the first time a window is republished.

The manager deletes a closed window only after the sink accepts it. That ordering is what makes delivery at-least-once: a crash between the write and the delete republishes the window on the next poll. The example's target table has a primary key on `(bucket, lang)`, and the sink's insert had no conflict clause, so that republish fails.

The failure is not one bad poll. A failed flush also blocks the delete, so the next poll collects the same rows and fails the same way, every 10 seconds, indefinitely. The window table grows without bound and no later window is ever written.

Reproduced at the SQL level against the example's own table definition:

```
INSERT 0 1
ERROR:  duplicate key value violates unique constraint "..._pkey"
DETAIL:  Key (bucket, lang)=(2026-09-06 12:00:00+00, en) already exists.
```

## Fix

The insert ends in `ON CONFLICT (bucket, lang) DO UPDATE SET posts = EXCLUDED.posts`, with a comment explaining why the clause is load-bearing rather than decorative.

`DO UPDATE` rather than `DO NOTHING`: a straggler can upsert into the still-present window row between the failed write and the retry, so the republished count is the more complete one.

## Verification

DuckDB's Postgres extension does support `ON CONFLICT ... DO UPDATE` against a remote table — confirmed before relying on it, by running both inserts through the extension and reading the row back.

Then end to end, with the fixed config against Postgres 16:

1. Started the pipeline.
2. Seeded the target table with a colliding row for a bucket about to publish, `posts = 999999`.
3. The manager published that bucket.

Result: `posts = 1484`, the real count, zero errors logged, and the pipeline carried on to publish further windows. Before the fix that same collision raises the duplicate-key error above and wedges the manager.

## Docs

The turbolytics.io tutorial and blog post that use this config describe the duplicate as harmless. Both are being corrected alongside this change.