### PR TITLE
fix: spell San Francisco correctly in the sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker exec -it kafka1 kafka-console-consumer --bootstrap-server=kafka1:9092 --t
 The consumer prints one row per city:
 
 ```
-{"city":"San Fransisco","city_count":177}
+{"city":"San Francisco","city_count":177}
 {"city":"New York","city_count":236}
 {"city":"Miami","city_count":203}
 {"city":"Baltimore","city_count":180}

--- a/sqlflow/fixtures/__init__.py
+++ b/sqlflow/fixtures/__init__.py
@@ -23,7 +23,7 @@ event = {
 }
 
 cities = [
-    'San Fransisco',
+    'San Francisco',
     'Baltimore',
     'New York',
     'Miami',


### PR DESCRIPTION
`sqlflow/fixtures/__init__.py` spelled the city `'San Fransisco'` in its `cities` list, while the template `event` dict twelve lines above spells it `"San Francisco"`. Same file, same concept, two spellings — the list one is a typo.

It is not confined to test data. `cmd/publish-test-data.py` drives the quickstart in both the README and the getting-started docs, so the misspelling is in the first output a new user sees:

```
{"city":"San Fransisco","city_count":177}
```

Fixed in the fixture and in the README's example output. Nothing asserts on the string — I grepped the tree before changing it — and the full Go suite passes, 14 packages.

Found while reviewing the turbolytics.io quickstart against a live run.