### PR TITLE
Invariant matrix: the foundation, and its first proven cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ SQLFlow is a stream processing engine that lets you define pipelines with just S
 - Sinks: Kafka, ClickHouse, Iceberg, the console, or anything DuckDB can `COPY` to (PostgreSQL, S3, parquet, MotherDuck, DuckLake).
 - Built on [DuckDB](https://duckdb.org/) and [Apache Arrow](https://arrow.apache.org/): ~900k messages/sec on a laptop, in about a quarter GiB of memory.
 - One Go binary, one Docker image, one YAML file per pipeline. No cluster.
+- [Coverage and invariant matrix](docs/coverage/matrix.md): what is tested, and
+  separately, what is *proven* — regenerated from the suites on every push.
 
 # Quick Start (Getting Started in 5 Minutes)
 
@@ -990,11 +992,9 @@ make test-image     # build the image and run tests/release against it
 which builds the environment from `uv.lock` on first use. There is no
 `pip install` step, and no dependency is resolved at install time.
 
-`docs/coverage/matrix.md` is the coverage matrix: one table per feature, and
-one per invariant family. Features say what sqlflow does; invariants say what
-every integration must hold whatever it does, and `internal/conformance`
-proves them. A new sink or source supplies a subject in its package's
-`conformance_test.go` and inherits the whole contract.
+[**Coverage and invariant matrix**](docs/coverage/matrix.md) — what is tested,
+and separately, what is proven. It is generated from the suites on every push
+and gates the merge.
 
 `make test-go` and `make test-image` are what CI runs on every push.
 Kafka-backed integration tests are deliberately excluded from `test-go`; they

--- a/README.md
+++ b/README.md
@@ -990,6 +990,12 @@ make test-image     # build the image and run tests/release against it
 which builds the environment from `uv.lock` on first use. There is no
 `pip install` step, and no dependency is resolved at install time.
 
+`docs/coverage/matrix.md` is the coverage matrix: one table per feature, and
+one per invariant family. Features say what sqlflow does; invariants say what
+every integration must hold whatever it does, and `internal/conformance`
+proves them. A new sink or source supplies a subject in its package's
+`conformance_test.go` and inherits the whole contract.
+
 `make test-go` and `make test-image` are what CI runs on every push.
 Kafka-backed integration tests are deliberately excluded from `test-go`; they
 run from the dev stack. Backing services for local development:

--- a/docs/coverage/features.yml
+++ b/docs/coverage/features.yml
@@ -32,6 +32,9 @@
 # test named TestSinkClickhouse* or any Python test named test_sink_clickhouse*.
 # Names are matched against this registry rather than parsed, so a name that
 # matches nothing is reported rather than silently inventing a feature.
+#
+# Invariants -- what every integration must hold, whatever it does -- are a
+# second axis. See invariants.yml and integrations.yml beside this file.
 
 features:
   # --- Sources ------------------------------------------------------------
@@ -171,3 +174,14 @@ features:
   - id: cli.version
     description: The shipped binary reports the version it was built from.
     requires: [release]
+
+  # --- The gate itself ----------------------------------------------------
+  # These are not shipped, and they are declared anyway: a wrong gate is worse
+  # than no gate, so losing its tests must show up here like any other gap.
+  - id: tooling.conformance
+    description: The harness proves the declared invariants for any integration.
+    requires: [unit]
+
+  - id: tooling.coverage
+    description: Tests attribute to features and invariants, and the registries match the code.
+    requires: [unit]

--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -75,6 +75,10 @@ integrations:
     implements: [Sink]
     feature: sink.console
     exempt:
+      - invariant: sink.write.buffers_only
+        reason: >
+          discards every row by design, so there is no destination for a
+          write to reach and nothing a read-back could show
       - invariant: sink.flush.keeps_batch
         reason: discards every row by design; it exists for benchmarking
       - invariant: sink.flush.no_hollow_success

--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -1,0 +1,145 @@
+# Every integration sqlflow can construct, and what each one claims.
+#
+# One entry per case in sinks.buildSink, sources.New and handlers.New. A test
+# in each of those packages holds Kinds() equal to the ids here, so a new case
+# without an entry fails `go test -short` in seconds. An integration the
+# engine can build and this file does not name has no invariant cells at all,
+# which is the sink.iceberg failure: nothing written down, so nothing can be
+# missing.
+#
+# `implements` lists the interfaces the integration satisfies beyond its
+# kind's base contract. Prober means the sink checks its destination before
+# the first batch arrives.
+#
+# `exempt` names invariants that cannot apply, each with a reason. An
+# exemption is one of two statements that must agree: the harness skips what
+# it cannot exercise, and this file excuses it. Either one alone leaves the
+# cell missing.
+#
+# `feature` ties the entry to features.yml.
+
+integrations:
+  # --- Sinks ---------------------------------------------------------------
+  - id: sink.kafka
+    kind: sink
+    implements: [Sink]
+    feature: sink.kafka
+    exempt: []
+
+  - id: sink.clickhouse
+    kind: sink
+    implements: [Sink, Prober]
+    feature: sink.clickhouse
+    exempt: []
+
+  - id: sink.iceberg
+    kind: sink
+    implements: [Sink, Prober]
+    feature: sink.iceberg
+    exempt: []
+
+  - id: sink.sqlcommand
+    kind: sink
+    implements: [Sink]
+    feature: sink.sqlcommand
+    exempt:
+      - invariant: sink.flush.keeps_batch
+        reason: >
+          writes through the pipeline's own DuckDB connection, so a failure is
+          not a network blip. retriesHelp already excludes it.
+      - invariant: sink.flush.honours_context
+        reason: nothing to wait on that a context could cut short
+      - invariant: sink.error.classifies
+        reason: no network, so nothing to classify as unreachable
+      - invariant: sink.probe.fails_start
+        reason: nothing to dial
+
+  - id: sink.console
+    kind: sink
+    implements: [Sink]
+    feature: sink.console
+    exempt:
+      - invariant: sink.flush.keeps_batch
+        reason: >
+          stdout cannot be temporarily unavailable. retriesHelp already
+          excludes it.
+      - invariant: sink.flush.honours_context
+        reason: nothing to wait on that a context could cut short
+      - invariant: sink.error.classifies
+        reason: no network, so nothing to classify as unreachable
+      - invariant: sink.probe.fails_start
+        reason: nothing to dial
+
+  - id: sink.noop
+    kind: sink
+    implements: [Sink]
+    feature: sink.console
+    exempt:
+      - invariant: sink.flush.keeps_batch
+        reason: discards every row by design; it exists for benchmarking
+      - invariant: sink.flush.no_hollow_success
+        reason: discards every row by design
+      - invariant: sink.flush.preserves_order
+        reason: discards every row by design
+      - invariant: sink.flush.honours_context
+        reason: nothing to wait on
+      - invariant: sink.batch.reports_buffer
+        reason: buffers nothing by design
+      - invariant: sink.error.classifies
+        reason: never fails
+      - invariant: sink.probe.fails_start
+        reason: nothing to dial
+
+  # --- Sources ---------------------------------------------------------------
+  - id: source.kafka
+    kind: source
+    implements: [Source, MarkCommitter]
+    feature: source.kafka
+    exempt: []
+
+  - id: source.websocket
+    kind: source
+    implements: [Source]
+    feature: source.websocket
+    exempt:
+      - invariant: source.commit.only_processed
+        reason: no replayable position; at-most-once by construction
+      - invariant: source.resume.from_committed
+        reason: no replayable position; at-most-once by construction
+      - invariant: source.marks.never_regress
+        reason: no marks
+      - invariant: source.commit.on_revoke
+        reason: no partitions to revoke
+
+  - id: source.webhook
+    kind: source
+    implements: [Source]
+    feature: source.webhook
+    exempt:
+      - invariant: source.commit.only_processed
+        reason: no replayable position; at-most-once by construction
+      - invariant: source.resume.from_committed
+        reason: no replayable position; at-most-once by construction
+      - invariant: source.marks.never_regress
+        reason: no marks
+      - invariant: source.commit.on_revoke
+        reason: no partitions to revoke
+
+  # --- Handlers --------------------------------------------------------------
+  - id: handler.structured
+    kind: handler
+    implements: [Handler]
+    feature: handler.structured
+    exempt: []
+
+  - id: handler.inferred_mem
+    kind: handler
+    implements: [Handler, MetadataWriter]
+    feature: handler.inferred_mem
+    exempt: []
+
+  - id: handler.inferred_disk
+    kind: handler
+    implements: [Handler]
+    feature: handler.inferred_disk
+    exempt: []

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -1,0 +1,264 @@
+# The invariants every integration must hold, and the evidence each requires.
+#
+# This file is declared, not derived, for the reason features.yml gives: the
+# failure it catches is an integration with no evidence at all. Seven of these
+# have been violated and fixed since v1.0.4, and each of those rows names the
+# fix.
+#
+# `applies_to` is the interface the invariant is a property of. Every
+# integration of that kind must prove it, or be exempt in integrations.yml
+# with a reason.
+#
+# `verified_by` says how evidence attaches:
+#
+#   harness    internal/conformance emits COVERS invariant=... integration=...
+#   typetable  the generated type round-trip emits the same marker per type
+#   named      a test named Test<Invariant>_* attributes by prefix
+#
+# `requires` lists the levels evidence must exist at. Every entry is empty in
+# this revision: the matrix reports, and nothing fails. An invariant is
+# enforced by filling one in, which is legal only once every non-exempt
+# integration has a subject.
+#
+# `tracked_by` marks an invariant the code does not yet satisfy. It renders as
+# declared-unenforced until that issue lands.
+
+invariants:
+  # --- Resilience: the sink contract ---------------------------------------
+  - id: sink.write.buffers_only
+    family: resilience
+    applies_to: sink
+    claim: WriteTable does not reach the destination. Only Flush does.
+    verified_by: harness
+    requires: []
+
+  - id: sink.flush.keeps_batch
+    family: resilience
+    applies_to: sink
+    claim: >
+      A failed Flush leaves every undelivered row buffered. The next Flush
+      re-attempts them.
+    verified_by: harness
+    requires: []
+    violated_once: ["#221"]
+
+  - id: sink.flush.no_hollow_success
+    family: resilience
+    applies_to: sink
+    claim: >
+      Flush returns nil only when every row since the last success was
+      acknowledged by the destination.
+    verified_by: harness
+    requires: []
+    violated_once: ["#221"]
+
+  - id: sink.flush.preserves_order
+    family: resilience
+    applies_to: sink
+    claim: Rows reach the destination in WriteTable order, across a retry.
+    verified_by: harness
+    requires: []
+
+  - id: sink.flush.honours_context
+    family: resilience
+    applies_to: sink
+    claim: Flush returns ctx.Err() when the context ends. Rows stay buffered.
+    verified_by: harness
+    requires: []
+    violated_once: ["#219"]
+
+  - id: sink.flush.empty_is_noop
+    family: resilience
+    applies_to: sink
+    claim: Flush with nothing buffered returns nil and touches nothing.
+    verified_by: harness
+    requires: []
+
+  - id: sink.batch.reports_buffer
+    family: resilience
+    applies_to: sink
+    claim: Batch returns what is buffered, and nil when nothing is.
+    verified_by: harness
+    requires: []
+
+  - id: sink.error.classifies
+    family: resilience
+    applies_to: sink
+    claim: >
+      The sink's errors classify as unreachable or rejected, so the retry
+      ladder retries the right ones.
+    verified_by: harness
+    requires: []
+
+  - id: sink.probe.fails_start
+    family: resilience
+    applies_to: sink
+    claim: >
+      A Prober whose destination is unreachable fails the start once, without
+      retrying.
+    verified_by: harness
+    requires: []
+
+  # --- Checkpoint: the pipeline and source contract ------------------------
+  - id: pipeline.commit.after_flush
+    family: checkpoint
+    applies_to: pipeline
+    claim: Offsets and state commit only after Flush returned nil.
+    verified_by: named
+    requires: []
+
+  - id: pipeline.commit.nothing_on_failure
+    family: checkpoint
+    applies_to: pipeline
+    claim: A failed flush commits nothing. Not offsets, not state.
+    verified_by: named
+    requires: []
+
+  - id: pipeline.state.with_offsets
+    family: checkpoint
+    applies_to: pipeline
+    claim: Window state and the offsets that produced it commit atomically.
+    verified_by: named
+    requires: []
+
+  - id: source.commit.only_processed
+    family: checkpoint
+    applies_to: source
+    claim: >
+      A source commits the marks the pipeline processed, never what it
+      fetched.
+    verified_by: harness
+    requires: []
+    violated_once: ["#154"]
+
+  - id: source.resume.from_committed
+    family: checkpoint
+    applies_to: source
+    claim: >
+      Restart resumes at the committed position. No gap, and no replay before
+      it.
+    verified_by: harness
+    requires: []
+
+  - id: source.marks.never_regress
+    family: checkpoint
+    applies_to: source
+    claim: A committed position never moves backwards.
+    verified_by: harness
+    requires: []
+
+  - id: source.commit.on_revoke
+    family: checkpoint
+    applies_to: source
+    claim: >
+      Marks commit when a partition is revoked, before the rebalance
+      completes.
+    verified_by: harness
+    requires: []
+    tracked_by: "#183"
+
+  # --- Types: per integration, from its declared table ---------------------
+  - id: type.roundtrip
+    family: types
+    applies_to: sink
+    claim: >
+      Every declared Arrow type reads back with the declared outcome: exact,
+      coerced by the stated rule, or unsupported with a coded error.
+    verified_by: typetable
+    requires: []
+    violated_once: ["#147", "#150", "#151"]
+
+  - id: type.null
+    family: types
+    applies_to: sink
+    claim: A null in every declared type reads back as declared.
+    verified_by: typetable
+    requires: []
+
+  - id: type.timestamp.instant
+    family: types
+    applies_to: sink
+    claim: >
+      A timestamp reads back as the same instant. Zone-less is UTC, and the
+      host zone never leaks into the type.
+    verified_by: typetable
+    requires: []
+    violated_once: ["#153"]
+
+  - id: type.nested
+    family: types
+    applies_to: sink
+    claim: >
+      list, struct, list-of-struct and list-of-list read back, or are declared
+      unsupported. Never silently flattened.
+    verified_by: typetable
+    requires: []
+
+  - id: type.string.fidelity
+    family: types
+    applies_to: sink
+    claim: Unicode, escapes and the empty string round-trip byte for byte.
+    verified_by: typetable
+    requires: []
+    violated_once: ["#149"]
+
+  - id: type.undeclared.fails_loud
+    family: types
+    applies_to: sink
+    claim: >
+      An Arrow type absent from the table fails the batch with a coded error.
+      Never coerced silently.
+    verified_by: typetable
+    requires: []
+
+  # --- Lifecycle -----------------------------------------------------------
+  - id: lifecycle.drain.on_cancel
+    family: lifecycle
+    applies_to: pipeline
+    claim: Cancel or SIGTERM flushes the buffered batch, then commits.
+    verified_by: named
+    requires: []
+
+  - id: lifecycle.drain.bounded
+    family: lifecycle
+    applies_to: pipeline
+    claim: The drain finishes or fails inside its deadline.
+    verified_by: named
+    requires: []
+    tracked_by: "#161"
+
+  - id: lifecycle.close.idempotent
+    family: lifecycle
+    applies_to: sink
+    claim: Close twice is safe.
+    verified_by: harness
+    requires: []
+
+  - id: pipeline.batch.timeout
+    family: lifecycle
+    applies_to: pipeline
+    claim: >
+      A batch whose query exceeds the timeout fails the batch, not the
+      process.
+    verified_by: named
+    requires: []
+    tracked_by: "#163"
+
+  # --- Error policy --------------------------------------------------------
+  - id: error.dlq.carries_provenance
+    family: errors
+    applies_to: pipeline
+    claim: A DLQ record carries the payload, offset, partition and reason.
+    verified_by: named
+    requires: []
+    tracked_by: "#166"
+
+  - id: error.bad_record.threshold
+    family: errors
+    applies_to: pipeline
+    claim: >
+      N bad records in a window fail the pipeline rather than discarding
+      forever.
+    verified_by: named
+    requires: []
+    tracked_by: "#166"

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "features": [
     {
       "id": "source.kafka",
@@ -1238,5 +1238,1821 @@
     "integration": [],
     "release": []
   },
-  "unknown_markers": []
+  "unknown_markers": [],
+  "invariants": [
+    {
+      "id": "sink.write.buffers_only",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "WriteTable does not reach the destination. Only Flush does.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "sink.flush.keeps_batch",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "exempt",
+            "reason": "writes through the pipeline's own DuckDB connection, so a failure is not a network blip. retriesHelp already excludes it.\n"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "writes through the pipeline's own DuckDB connection, so a failure is not a network blip. retriesHelp already excludes it.\n"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "writes through the pipeline's own DuckDB connection, so a failure is not a network blip. retriesHelp already excludes it.\n"
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "exempt",
+            "reason": "stdout cannot be temporarily unavailable. retriesHelp already excludes it.\n"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "stdout cannot be temporarily unavailable. retriesHelp already excludes it.\n"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "stdout cannot be temporarily unavailable. retriesHelp already excludes it.\n"
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "discards every row by design; it exists for benchmarking"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "discards every row by design; it exists for benchmarking"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "discards every row by design; it exists for benchmarking"
+          }
+        }
+      },
+      "violated_once": [
+        "#221"
+      ]
+    },
+    {
+      "id": "sink.flush.no_hollow_success",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "Flush returns nil only when every row since the last success was acknowledged by the destination.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "discards every row by design"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "discards every row by design"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "discards every row by design"
+          }
+        }
+      },
+      "violated_once": [
+        "#221"
+      ]
+    },
+    {
+      "id": "sink.flush.preserves_order",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "Rows reach the destination in WriteTable order, across a retry.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "discards every row by design"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "discards every row by design"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "discards every row by design"
+          }
+        }
+      }
+    },
+    {
+      "id": "sink.flush.honours_context",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "Flush returns ctx.Err() when the context ends. Rows stay buffered.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "exempt",
+            "reason": "nothing to wait on that a context could cut short"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "nothing to wait on that a context could cut short"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "nothing to wait on that a context could cut short"
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "exempt",
+            "reason": "nothing to wait on that a context could cut short"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "nothing to wait on that a context could cut short"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "nothing to wait on that a context could cut short"
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "nothing to wait on"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "nothing to wait on"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "nothing to wait on"
+          }
+        }
+      },
+      "violated_once": [
+        "#219"
+      ]
+    },
+    {
+      "id": "sink.flush.empty_is_noop",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "Flush with nothing buffered returns nil and touches nothing.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "sink.batch.reports_buffer",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "Batch returns what is buffered, and nil when nothing is.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "buffers nothing by design"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "buffers nothing by design"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "buffers nothing by design"
+          }
+        }
+      }
+    },
+    {
+      "id": "sink.error.classifies",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no network, so nothing to classify as unreachable"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no network, so nothing to classify as unreachable"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no network, so nothing to classify as unreachable"
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no network, so nothing to classify as unreachable"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no network, so nothing to classify as unreachable"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no network, so nothing to classify as unreachable"
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "never fails"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "never fails"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "never fails"
+          }
+        }
+      }
+    },
+    {
+      "id": "sink.probe.fails_start",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "A Prober whose destination is unreachable fails the start once, without retrying.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "nothing to dial"
+          }
+        }
+      }
+    },
+    {
+      "id": "pipeline.commit.after_flush",
+      "family": "checkpoint",
+      "applies_to": "pipeline",
+      "claim": "Offsets and state commit only after Flush returned nil.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {}
+    },
+    {
+      "id": "pipeline.commit.nothing_on_failure",
+      "family": "checkpoint",
+      "applies_to": "pipeline",
+      "claim": "A failed flush commits nothing. Not offsets, not state.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {}
+    },
+    {
+      "id": "pipeline.state.with_offsets",
+      "family": "checkpoint",
+      "applies_to": "pipeline",
+      "claim": "Window state and the offsets that produced it commit atomically.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {}
+    },
+    {
+      "id": "source.commit.only_processed",
+      "family": "checkpoint",
+      "applies_to": "source",
+      "claim": "A source commits the marks the pipeline processed, never what it fetched.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "source.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "source.websocket": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          }
+        },
+        "source.webhook": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          }
+        }
+      },
+      "violated_once": [
+        "#154"
+      ]
+    },
+    {
+      "id": "source.resume.from_committed",
+      "family": "checkpoint",
+      "applies_to": "source",
+      "claim": "Restart resumes at the committed position. No gap, and no replay before it.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "source.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "source.websocket": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          }
+        },
+        "source.webhook": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no replayable position; at-most-once by construction"
+          }
+        }
+      }
+    },
+    {
+      "id": "source.marks.never_regress",
+      "family": "checkpoint",
+      "applies_to": "source",
+      "claim": "A committed position never moves backwards.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "source.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "source.websocket": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no marks"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no marks"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no marks"
+          }
+        },
+        "source.webhook": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no marks"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no marks"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no marks"
+          }
+        }
+      }
+    },
+    {
+      "id": "source.commit.on_revoke",
+      "family": "checkpoint",
+      "applies_to": "source",
+      "claim": "Marks commit when a partition is revoked, before the rebalance completes.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "source.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "source.websocket": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no partitions to revoke"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no partitions to revoke"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no partitions to revoke"
+          }
+        },
+        "source.webhook": {
+          "unit": {
+            "status": "exempt",
+            "reason": "no partitions to revoke"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "no partitions to revoke"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "no partitions to revoke"
+          }
+        }
+      },
+      "tracked_by": "#183"
+    },
+    {
+      "id": "type.roundtrip",
+      "family": "types",
+      "applies_to": "sink",
+      "claim": "Every declared Arrow type reads back with the declared outcome: exact, coerced by the stated rule, or unsupported with a coded error.",
+      "verified_by": "typetable",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
+      "violated_once": [
+        "#147",
+        "#150",
+        "#151"
+      ]
+    },
+    {
+      "id": "type.null",
+      "family": "types",
+      "applies_to": "sink",
+      "claim": "A null in every declared type reads back as declared.",
+      "verified_by": "typetable",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "type.timestamp.instant",
+      "family": "types",
+      "applies_to": "sink",
+      "claim": "A timestamp reads back as the same instant. Zone-less is UTC, and the host zone never leaks into the type.",
+      "verified_by": "typetable",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
+      "violated_once": [
+        "#153"
+      ]
+    },
+    {
+      "id": "type.nested",
+      "family": "types",
+      "applies_to": "sink",
+      "claim": "list, struct, list-of-struct and list-of-list read back, or are declared unsupported. Never silently flattened.",
+      "verified_by": "typetable",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "type.string.fidelity",
+      "family": "types",
+      "applies_to": "sink",
+      "claim": "Unicode, escapes and the empty string round-trip byte for byte.",
+      "verified_by": "typetable",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
+      "violated_once": [
+        "#149"
+      ]
+    },
+    {
+      "id": "type.undeclared.fails_loud",
+      "family": "types",
+      "applies_to": "sink",
+      "claim": "An Arrow type absent from the table fails the batch with a coded error. Never coerced silently.",
+      "verified_by": "typetable",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "lifecycle.drain.on_cancel",
+      "family": "lifecycle",
+      "applies_to": "pipeline",
+      "claim": "Cancel or SIGTERM flushes the buffered batch, then commits.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {}
+    },
+    {
+      "id": "lifecycle.drain.bounded",
+      "family": "lifecycle",
+      "applies_to": "pipeline",
+      "claim": "The drain finishes or fails inside its deadline.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {},
+      "tracked_by": "#161"
+    },
+    {
+      "id": "lifecycle.close.idempotent",
+      "family": "lifecycle",
+      "applies_to": "sink",
+      "claim": "Close twice is safe.",
+      "verified_by": "harness",
+      "requires": [],
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "pipeline.batch.timeout",
+      "family": "lifecycle",
+      "applies_to": "pipeline",
+      "claim": "A batch whose query exceeds the timeout fails the batch, not the process.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {},
+      "tracked_by": "#163"
+    },
+    {
+      "id": "error.dlq.carries_provenance",
+      "family": "errors",
+      "applies_to": "pipeline",
+      "claim": "A DLQ record carries the payload, offset, partition and reason.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {},
+      "tracked_by": "#166"
+    },
+    {
+      "id": "error.bad_record.threshold",
+      "family": "errors",
+      "applies_to": "pipeline",
+      "claim": "N bad records in a window fail the pipeline rather than discarding forever.",
+      "verified_by": "named",
+      "requires": [],
+      "integrations": {},
+      "tracked_by": "#166"
+    }
+  ],
+  "invariant_gaps": [],
+  "unknown_invariant_markers": []
 }

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -178,6 +178,7 @@
         "unit": {
           "status": "covered",
           "tests": [
+            "TestIntegrationSinkClickhouse_Conformance",
             "TestSinkClickhouse_BatchIsNil",
             "TestSinkClickhouse_EmptyTableIsNoop",
             "TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered",
@@ -195,6 +196,7 @@
             "TestSinkClickhouse_SuccessfulFlushClearsTheBuffer"
           ],
           "skipped": [
+            "TestIntegrationSinkClickhouse_Conformance",
             "TestSinkClickhouse_BatchIsNil",
             "TestSinkClickhouse_EmptyTableIsNoop",
             "TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered",
@@ -207,7 +209,12 @@
           ]
         },
         "integration": {
-          "status": "not_required"
+          "status": "covered",
+          "tests": [
+            "TestIntegrationSinkClickhouse_Conformance",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.keeps_batch",
+            "TestIntegrationSinkClickhouse_Conformance/sink.write.buffers_only"
+          ]
         },
         "release": {
           "status": "covered",
@@ -1230,6 +1237,74 @@
           ]
         }
       }
+    },
+    {
+      "id": "tooling.conformance",
+      "description": "The harness proves the declared invariants for any integration.",
+      "requires": [
+        "unit"
+      ],
+      "levels": {
+        "unit": {
+          "status": "covered",
+          "tests": [
+            "TestToolingConformanceDescribe_NamesTheRowsItFound",
+            "TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink",
+            "TestToolingConformanceSinks_ACorrectSinkPasses",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.keeps_batch",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.write.buffers_only",
+            "TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly",
+            "TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught",
+            "TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught",
+            "TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught",
+            "TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught",
+            "TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker",
+            "TestToolingConformanceSinks_ASubjectMissingReadBackIsRejected",
+            "TestToolingConformanceSinks_ASubjectWithBreakAndNoHealIsRejected",
+            "TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped",
+            "TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected",
+            "TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants"
+          ]
+        },
+        "integration": {
+          "status": "not_required"
+        },
+        "release": {
+          "status": "not_required"
+        }
+      }
+    },
+    {
+      "id": "tooling.coverage",
+      "description": "Tests attribute to features and invariants, and the registries match the code.",
+      "requires": [
+        "unit"
+      ],
+      "levels": {
+        "unit": {
+          "status": "covered",
+          "tests": [
+            "TestToolingCoverageCovers_EmitsOneLinePerFeature",
+            "TestToolingCoverageHandlerRegistry_EveryConfigTypeHasABuilder",
+            "TestToolingCoverageHandlerRegistry_MatchesTheConstructorSwitch",
+            "TestToolingCoverageInvariant_DoesNotLookLikeAFeatureMarker",
+            "TestToolingCoverageInvariant_EmitsTheStructuredMarker",
+            "TestToolingCoverageRegistry_ListsHandlers",
+            "TestToolingCoverageRegistry_ListsSinksByBareName",
+            "TestToolingCoverageRegistry_ListsSources",
+            "TestToolingCoverageRegistry_RejectsAKindNothingConstructs",
+            "TestToolingCoverageRegistry_RejectsAnUnknownKind",
+            "TestToolingCoverageSinkRegistry_MatchesTheConstructorSwitch",
+            "TestToolingCoverageSourceRegistry_MatchesTheConstructorSwitch"
+          ]
+        },
+        "integration": {
+          "status": "not_required"
+        },
+        "release": {
+          "status": "not_required"
+        }
+      }
     }
   ],
   "gaps": [],
@@ -1238,7 +1313,12 @@
     "integration": [],
     "release": []
   },
-  "unknown_markers": [],
+  "unknown_markers": [
+    {
+      "test": "TestToolingConformanceSinks_ACorrectSinkPasses",
+      "feature": "sink.noop"
+    }
+  ],
   "invariants": [
     {
       "id": "sink.write.buffers_only",
@@ -1268,8 +1348,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.write.buffers_only"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1320,16 +1402,16 @@
         },
         "sink.noop": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "discards every row by design, so there is no destination for a write to reach and nothing a read-back could show\n"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "discards every row by design, so there is no destination for a write to reach and nothing a read-back could show\n"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "discards every row by design, so there is no destination for a write to reach and nothing a read-back could show\n"
           }
         }
       }
@@ -1362,8 +1444,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.keeps_batch"
+            ]
           },
           "release": {
             "status": "missing",

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -55,7 +55,35 @@ names every one of them.
 | `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 16 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
-**33 features declared, 33 fully covered, 0 gap(s).**
+**33 features declared. 33 have at least one passing test attributed at every level they require, so 0 gap(s).**
+
+That sentence counts attribution, not proof. A feature is green here when
+a test named for it ran and passed; it says nothing about whether the
+integration behind it keeps a batch it could not deliver, or commits
+offsets only after a flush. Those are invariants, they are counted
+separately below, and the two numbers are not interchangeable.
+
+**28 invariants declared. Of 108 (invariant, integration) cells: 2 proven, 82 missing, 0 skipped, 0 failing, 24 exempt. 0 gap(s), because no invariant requires a level yet.**
+
+A further 8 invariants attach to the pipeline rather than
+to any one integration. Nothing collects evidence for them yet, so
+they show no cells at all, which is worse than missing rather than
+better.
+
+## Why invariants, and not the test count
+
+`sink.retry` carries 71 attributed tests, more than anything
+else in the `sink` layer. `sink.flush.no_hollow_success`, an invariant
+of that same layer, is proven on 0 of the 5
+integrations it applies to.
+
+Those two numbers are the argument. Tests accumulate around the
+code that was written; an invariant is the claim that code exists
+to uphold. A suite can exercise a retry ladder in every direction
+and never ask whether the sink underneath keeps the rows the
+ladder re-sends -- and if it does not, every one of those tests
+passes while the pipeline loses data. The feature table calls that
+covered. This one does not.
 
 ## Covered only by another test's marker
 
@@ -102,10 +130,10 @@ invariant's `requires` is filled in, and none is yet.
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ❌ missing | ✅ i | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. | ❌ missing | ✅ i | ❌ missing | — exempt | — exempt | — exempt |
-| `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
+| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. *(violated once: #221)* | ❌ missing | ✅ i | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. *(violated once: #221)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
 | `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 | `sink.batch.reports_buffer` | Batch returns what is buffered, and nil when nothing is. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
@@ -115,38 +143,65 @@ invariant's `requires` is filled in, and none is yet.
 
 | Invariant | Claim | `source.kafka` | `source.websocket` | `source.webhook` |
 | --- | --- | --- | --- | --- |
-| `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | · | · | · |
-| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | · | · | · |
-| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | · | · | · |
-| `source.commit.only_processed` | A source commits the marks the pipeline processed, never what it fetched. | ❌ missing | — exempt | — exempt |
+| `source.commit.only_processed` | A source commits the marks the pipeline processed, never what it fetched. *(violated once: #154)* | ❌ missing | — exempt | — exempt |
 | `source.resume.from_committed` | Restart resumes at the committed position. No gap, and no replay before it. | ❌ missing | — exempt | — exempt |
 | `source.marks.never_regress` | A committed position never moves backwards. | ❌ missing | — exempt | — exempt |
 | `source.commit.on_revoke` | Marks commit when a partition is revoked, before the rebalance completes. *(declared, tracked by #183)* | ❌ missing | — exempt | — exempt |
+
+These checkpoint invariants are properties of the pipeline, not
+of any one integration, so they have no column. **No evidence is
+collected for them yet**: `verified_by: named` is declared and
+not wired, so an empty cell here means unmeasured, not passing.
+The feature table above may show the same ground as covered,
+and where the two disagree this one is the weaker claim.
+
+| Invariant | Claim | Evidence |
+| --- | --- | --- |
+| `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | ❌ none collected (`named`) |
+| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | ❌ none collected (`named`) |
+| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | ❌ none collected (`named`) |
 
 ## Invariants: types
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `type.roundtrip` | Every declared Arrow type reads back with the declared outcome: exact, coerced by the stated rule, or unsupported with a coded error. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.roundtrip` | Every declared Arrow type reads back with the declared outcome: exact, coerced by the stated rule, or unsupported with a coded error. *(violated once: #147, #150, #151)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 | `type.null` | A null in every declared type reads back as declared. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
-| `type.timestamp.instant` | A timestamp reads back as the same instant. Zone-less is UTC, and the host zone never leaks into the type. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.timestamp.instant` | A timestamp reads back as the same instant. Zone-less is UTC, and the host zone never leaks into the type. *(violated once: #153)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 | `type.nested` | list, struct, list-of-struct and list-of-list read back, or are declared unsupported. Never silently flattened. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
-| `type.string.fidelity` | Unicode, escapes and the empty string round-trip byte for byte. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.string.fidelity` | Unicode, escapes and the empty string round-trip byte for byte. *(violated once: #149)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 | `type.undeclared.fails_loud` | An Arrow type absent from the table fails the batch with a coded error. Never coerced silently. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 
 ## Invariants: lifecycle
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | · | · | · | · | · | · |
-| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | · | · | · | · | · | · |
 | `lifecycle.close.idempotent` | Close twice is safe. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
-| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | · | · | · | · | · | · |
+
+These lifecycle invariants are properties of the pipeline, not
+of any one integration, so they have no column. **No evidence is
+collected for them yet**: `verified_by: named` is declared and
+not wired, so an empty cell here means unmeasured, not passing.
+The feature table above may show the same ground as covered,
+and where the two disagree this one is the weaker claim.
+
+| Invariant | Claim | Evidence |
+| --- | --- | --- |
+| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | ❌ none collected (`named`) |
+| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ none collected (`named`) |
+| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ none collected (`named`) |
 
 ## Invariants: errors
 
-| Invariant | Claim | Verified by |
+These errors invariants are properties of the pipeline, not
+of any one integration, so they have no column. **No evidence is
+collected for them yet**: `verified_by: named` is declared and
+not wired, so an empty cell here means unmeasured, not passing.
+The feature table above may show the same ground as covered,
+and where the two disagree this one is the weaker claim.
+
+| Invariant | Claim | Evidence |
 | --- | --- | --- |
-| `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | named |
-| `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | named |
+| `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | ❌ none collected (`named`) |
+| `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | ❌ none collected (`named`) |
 

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -25,7 +25,7 @@ names every one of them.
 | `source.webhook` | Accepts records over HTTP, with optional HMAC signature checks. | ✅ | — | — | 15 |
 | `source.websocket` | Consumes a websocket stream, reconnecting on drop. | ✅ | — | ✅ | 6 |
 | `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | — | ✅ | 7 |
-| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | — | ✅ | 16 |
+| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 20 |
 | `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 13 |
 | `sink.parquet` | Writes result batches as parquet files to a local path. | — | — | ✅ | 1 |
 | `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 10 |
@@ -52,8 +52,10 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 16 |
+| `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
-**31 features declared, 31 fully covered, 0 gap(s).**
+**33 features declared, 33 fully covered, 0 gap(s).**
 
 ## Covered only by another test's marker
 
@@ -72,6 +74,10 @@ that deserves its own test.
 - `config.templating` (release) — via `test_config_validation_accepts_a_shipped_example`
 - `cli.dev_invoke` (release) — via `test_handler_inferred_mem_invoke_renders_rows`
 
+## Markers naming an unknown feature
+
+- `TestToolingConformanceSinks_ACorrectSinkPasses` marks `sink.noop`
+
 
 # Invariant matrix
 
@@ -84,16 +90,19 @@ harness in `internal/conformance`, which emits a marker naming both
 ids -- a harness test's name says nothing, because the same code runs
 for every integration.
 
-**exempt** carries its reason in the JSON. **missing** means no
-evidence. Nothing here fails the build until an invariant's `requires`
-is filled in, and none is yet.
+A covered cell names the levels that proved it: `u` unit, `i`
+integration, `r` release. That is the question the matrix exists to
+answer -- proven with a fake, or against the real thing, or in the
+shipped image. **exempt** carries its reason in the JSON, and
+**missing** means no evidence. Nothing here fails the build until an
+invariant's `requires` is filled in, and none is yet.
 
 ## Invariants: resilience
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
-| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ❌ missing | ✅ i | ❌ missing | ❌ missing | ❌ missing | — exempt |
+| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. | ❌ missing | ✅ i | ❌ missing | — exempt | — exempt | — exempt |
 | `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -72,3 +72,72 @@ that deserves its own test.
 - `config.templating` (release) — via `test_config_validation_accepts_a_shipped_example`
 - `cli.dev_invoke` (release) — via `test_handler_inferred_mem_invoke_renders_rows`
 
+
+# Invariant matrix
+
+Generated from `docs/coverage/matrix.json` by `make coverage-matrix`.
+Do not edit by hand.
+
+Invariants are declared in `docs/coverage/invariants.yml`, integrations
+in `docs/coverage/integrations.yml`. A cell is proven by the conformance
+harness in `internal/conformance`, which emits a marker naming both
+ids -- a harness test's name says nothing, because the same code runs
+for every integration.
+
+**exempt** carries its reason in the JSON. **missing** means no
+evidence. Nothing here fails the build until an invariant's `requires`
+is filled in, and none is yet.
+
+## Invariants: resilience
+
+| Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
+| `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
+| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `sink.batch.reports_buffer` | Batch returns what is buffered, and nil when nothing is. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
+| `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+
+## Invariants: checkpoint
+
+| Invariant | Claim | `source.kafka` | `source.websocket` | `source.webhook` |
+| --- | --- | --- | --- | --- |
+| `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | · | · | · |
+| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | · | · | · |
+| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | · | · | · |
+| `source.commit.only_processed` | A source commits the marks the pipeline processed, never what it fetched. | ❌ missing | — exempt | — exempt |
+| `source.resume.from_committed` | Restart resumes at the committed position. No gap, and no replay before it. | ❌ missing | — exempt | — exempt |
+| `source.marks.never_regress` | A committed position never moves backwards. | ❌ missing | — exempt | — exempt |
+| `source.commit.on_revoke` | Marks commit when a partition is revoked, before the rebalance completes. *(declared, tracked by #183)* | ❌ missing | — exempt | — exempt |
+
+## Invariants: types
+
+| Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `type.roundtrip` | Every declared Arrow type reads back with the declared outcome: exact, coerced by the stated rule, or unsupported with a coded error. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.null` | A null in every declared type reads back as declared. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.timestamp.instant` | A timestamp reads back as the same instant. Zone-less is UTC, and the host zone never leaks into the type. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.nested` | list, struct, list-of-struct and list-of-list read back, or are declared unsupported. Never silently flattened. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.string.fidelity` | Unicode, escapes and the empty string round-trip byte for byte. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `type.undeclared.fails_loud` | An Arrow type absent from the table fails the batch with a coded error. Never coerced silently. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+
+## Invariants: lifecycle
+
+| Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | · | · | · | · | · | · |
+| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | · | · | · | · | · | · |
+| `lifecycle.close.idempotent` | Close twice is safe. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | · | · | · | · | · | · |
+
+## Invariants: errors
+
+| Invariant | Claim | Verified by |
+| --- | --- | --- |
+| `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | named |
+| `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | named |
+

--- a/docs/superpowers/plans/2026-09-06-invariant-matrix-foundation.md
+++ b/docs/superpowers/plans/2026-09-06-invariant-matrix-foundation.md
@@ -1,0 +1,2438 @@
+# Invariant Matrix Foundation (PR 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Declare every invariant and every integration in two registries, verify one invariant (`sink.flush.keeps_batch`) for one integration (ClickHouse) through a reusable conformance harness behind toxiproxy, and render the result as a second axis of the coverage matrix. Nothing is enforced yet; the build stays green.
+
+**Architecture:** Two declared YAML registries beside `features.yml`. A Go package `internal/conformance` that knows the invariants and drives any sink through a `SinkSubject` (constructor, break, heal, read-back). Evidence is emitted as a structured `COVERS invariant=… integration=…` log line, which `scripts/coverage_matrix.py` parses into an invariant × integration × level table. The integration-level fault is a toxiproxy `timeout` toxic between the sink and a ClickHouse container.
+
+**Tech Stack:** Go 1.25, `github.com/zeebo/assert`, testcontainers-go v0.44.0 (`modules/clickhouse`, `modules/toxiproxy`), `github.com/Shopify/toxiproxy/v2/client` v2.12.0, `gopkg.in/yaml.v3`, Python 3.11 via `uv run --locked`, pytest 7.4.3, PyYAML 6.0.1.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-invariant-matrix-design.md`
+
+## Global Constraints
+
+- All prose (commit messages, comments, YAML comments, docs) follows Google Technical Writing One; see `CLAUDE.md`. Comments explain why, not what.
+- Commit messages name the defect, the fix, and the evidence, and state what breaks if the change is wrong. No attribution trailers.
+- Python runs through `uv run --locked`; never bare `python3` or `pytest`.
+- Go tests use `github.com/zeebo/assert`, never `testify`.
+- Integration tests are named `TestIntegration<Feature>_<Behaviour>`. `-short` must skip them before any container starts. They must never skip for any other reason.
+- Every invariant in `invariants.yml` carries `requires: []` in this PR. Enforcement is PR 3.
+- No `types:` blocks in `integrations.yml` in this PR.
+- Container images are pinned: `clickhouse/clickhouse-server:26.8`, `ghcr.io/shopify/toxiproxy:2.12.0`.
+- `internal/conformance` must not import `internal/sinks`, `internal/kafka`, `internal/webhook` or `internal/websocket`. Those packages' tests import it, and Go forbids the cycle.
+- `docs/coverage/matrix.json` and `matrix.md` are regenerated, never edited by hand.
+
+---
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `internal/coverage/coverage.go` | Modify. Add `Invariant(t, invariant, integration)`: the structured marker. |
+| `docs/coverage/invariants.yml` | Create. The contract: every invariant from the spec, `requires: []`. |
+| `docs/coverage/integrations.yml` | Create. The surface: every constructor case, `implements`, `exempt`. |
+| `scripts/coverage_matrix.py` | Modify. Parse structured markers; load and validate registries; build and render the invariant axis; skip marker-carrying tests in the unattributed report. |
+| `tests/tooling/test_coverage_matrix.py` | Modify. Tests for each generator change. |
+| `internal/sinks/init.go` | Modify. `buildSink` becomes a lookup in a `builders` map; `Kinds()` returns its keys. |
+| `internal/sources/init.go` | Modify. Same shape: `builders` map, `Kinds()`. |
+| `internal/handlers/init.go` | Modify. Same shape: `builders` map, `Kinds()`. |
+| `internal/coverage/registry.go` | Create. Loads `integrations.yml` for the agreement tests. Lives in `coverage` so it imports nothing under `internal/` that imports it back. |
+| `internal/sinks/registry_test.go`, `internal/sources/registry_test.go`, `internal/handlers/registry_test.go` | Create. `Kinds()` equals the registry's ids of that kind. |
+| `internal/conformance/conformance.go` | Create. `Row`, `SinkSubject`, `Sinks`. |
+| `internal/conformance/conformance_test.go` | Create. The harness against an in-memory sink that keeps its batch, and one that drops it. |
+| `internal/conformance/proxy.go` | Create. `Proxy`: a toxiproxy container in front of an upstream, with `Break` and `Heal`. |
+| `internal/sinks/conformance_test.go` | Create. `TestIntegrationSinkClickhouse_Conformance`: ClickHouse container + proxy + the subject. |
+| `docs/coverage/matrix.json`, `docs/coverage/matrix.md` | Regenerated. |
+| `go.mod`, `go.sum` | Three new requirements. |
+
+---
+
+### Task 1: The structured marker, in Go and in the parser
+
+**Files:**
+- Modify: `internal/coverage/coverage.go`
+- Modify: `scripts/coverage_matrix.py:93-127` (`COVERS`, `parse_go`)
+- Modify: `scripts/coverage_matrix.py:130-143` (`parse_pytest`)
+- Test: `tests/tooling/test_coverage_matrix.py`
+
+**Interfaces:**
+- Produces: `coverage.Invariant(t *testing.T, invariant, integration string)` — logs `COVERS invariant=<id> integration=<id>`.
+- Produces: `parse_go(path) -> (results, covers, invariants)` where `invariants` is `{test_name: [(invariant_id, integration_id), ...]}`. `parse_pytest` returns the same triple; its third element is always `{}` in this PR.
+
+- [ ] **Step 1: Write the failing parser test**
+
+Append to `tests/tooling/test_coverage_matrix.py`, after `test_parse_go_ignores_package_level_events`:
+
+```python
+def test_parse_go_reads_structured_invariant_markers(tmp_path):
+    """The harness emits one line per (invariant, integration). Both ids are
+    carried; the parser must not collapse them into the feature list."""
+    path = write(tmp_path, "go.json", "\n".join([
+        json.dumps({"Action": "output", "Test": "TestA",
+                    "Output": "    x.go:1: COVERS invariant=sink.flush.keeps_batch integration=sink.clickhouse\n"}),
+        json.dumps({"Action": "output", "Test": "TestA",
+                    "Output": "    x.go:2: COVERS sink.clickhouse\n"}),
+        json.dumps({"Action": "pass", "Test": "TestA"}),
+    ]))
+    results, covers, invariants = cm.parse_go(path)
+
+    assert results == {"TestA": cm.PASS}
+    assert covers == {"TestA": ["sink.clickhouse"]}
+    assert invariants == {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}
+
+
+def test_parse_pytest_returns_an_empty_invariant_map(tmp_path):
+    path = write(tmp_path, "pytest.json", json.dumps({"tests": [
+        {"nodeid": "test_a", "outcome": "passed", "covers": []},
+    ]}))
+    results, covers, invariants = cm.parse_pytest(path)
+    assert invariants == {}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run --locked pytest tests/tooling/test_coverage_matrix.py -k "structured_invariant or empty_invariant_map" -v`
+Expected: FAIL — `ValueError: not enough values to unpack (expected 3, got 2)`.
+
+- [ ] **Step 3: Change the parsers**
+
+In `scripts/coverage_matrix.py`, replace the `COVERS` regex and `parse_go` (lines 93–127) with:
+
+```python
+# A plain marker names an extra feature. A structured one names an invariant
+# and the integration it was proven on; the harness emits those, and a test
+# name cannot carry two ids.
+COVERS = re.compile(r"COVERS ([a-z0-9_.]+)(?:\s|$)")
+COVERS_INVARIANT = re.compile(
+    r"COVERS invariant=([a-z0-9_.]+) integration=([a-z0-9_.]+)")
+
+
+def parse_go(path):
+    """Read `go test -json` into ({test: outcome}, {test: [features]},
+    {test: [(invariant, integration)]}).
+
+    Markers come from coverage.Covers and coverage.Invariant, which write to
+    the test log. `go test -json` carries that as an output event, so both are
+    read from ordinary suite output with no plugin and no build tag.
+    """
+    results, covers, invariants = {}, {}, {}
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name, action = event.get("Test"), event.get("Action")
+            if not name:
+                continue
+            if action == "output":
+                out = event.get("Output", "")
+                structured = COVERS_INVARIANT.findall(out)
+                if structured:
+                    invariants.setdefault(name, []).extend(structured)
+                    continue
+                found = COVERS.findall(out)
+                if found:
+                    covers.setdefault(name, []).extend(found)
+            # Subtests report their own outcome; the parent aggregates them.
+            elif action == "pass":
+                results.setdefault(name, PASS)
+            elif action == "skip":
+                results[name] = SKIP if results.get(name) != PASS else PASS
+            elif action == "fail":
+                results[name] = FAIL
+    return results, covers, invariants
+```
+
+The `continue` after a structured match matters: `COVERS invariant=...` would otherwise also match the plain pattern and record `invariant` as a feature.
+
+Change `parse_pytest`'s last line from `return results, covers` to `return results, covers, {}`.
+
+Update the two call sites in `main()` (lines 395–403):
+
+```python
+    go_results, go_covers, go_invariants = (
+        parse_go(args.go) if args.go and os.path.exists(args.go) else ({}, {}, {}))
+    it_results, it_covers, it_invariants = (
+        parse_go(args.go_integration)
+        if args.go_integration and os.path.exists(args.go_integration)
+        else ({}, {}, {}))
+    py_results, py_covers, py_invariants = (
+        parse_pytest(args.pytest)
+        if args.pytest and os.path.exists(args.pytest) else ({}, {}, {}))
+```
+
+The three `*_invariants` values are unused until Task 3. Update the two existing parser tests (`test_parse_go_reads_outcomes_and_markers`, `test_parse_pytest_reads_outcomes_and_markers`) to unpack three values: `results, covers, _ = cm.parse_go(path)`.
+
+- [ ] **Step 4: Run the whole tooling suite**
+
+Run: `uv run --locked pytest tests/tooling -q`
+Expected: 46 passed.
+
+- [ ] **Step 5: Write the failing Go test for the marker**
+
+Create `internal/coverage/coverage_test.go`:
+
+```go
+package coverage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zeebo/assert"
+)
+
+// The generator parses this line with a fixed regex. A format drift here is a
+// silent loss of every invariant cell, so the exact bytes are pinned.
+func TestCoverageInvariant_EmitsTheStructuredMarker(t *testing.T) {
+	var got string
+	rec := &recorder{t: t, sink: &got}
+	Invariant(rec, "sink.flush.keeps_batch", "sink.clickhouse")
+	assert.True(t, strings.HasSuffix(got,
+		"COVERS invariant=sink.flush.keeps_batch integration=sink.clickhouse"))
+}
+
+// recorder captures Logf so the test can read what Invariant wrote.
+type recorder struct {
+	testing.TB
+	t    *testing.T
+	sink *string
+}
+
+func (r *recorder) Helper() {}
+func (r *recorder) Logf(format string, args ...any) {
+	*r.sink = strings.TrimSpace(sprintf(format, args...))
+}
+```
+
+`Invariant` must therefore take `testing.TB`, not `*testing.T`, so a recorder can stand in. Add the `sprintf` helper as `fmt.Sprintf` via an import of `fmt` in the test file.
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `go test ./internal/coverage/ -run TestCoverageInvariant -v`
+Expected: FAIL — `undefined: Invariant`.
+
+- [ ] **Step 7: Add `Invariant`**
+
+In `internal/coverage/coverage.go`, change `Covers` to take `testing.TB` and add:
+
+```go
+// Invariant records that this test proved one invariant for one integration.
+//
+// The line carries both ids. A test name can attribute to one feature by
+// prefix, but an invariant is proven per integration, and the harness that
+// proves it runs the same code for every integration; only the marker knows
+// which one this run was.
+func Invariant(t testing.TB, invariant, integration string) {
+	t.Helper()
+	t.Logf("COVERS invariant=%s integration=%s", invariant, integration)
+}
+```
+
+- [ ] **Step 8: Run the Go tests**
+
+Run: `go test ./internal/coverage/ -v`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/coverage/ scripts/coverage_matrix.py tests/tooling/test_coverage_matrix.py
+git commit -m "coverage: a structured marker carries an invariant and the integration it was proven on
+
+A feature attributes by test name. An invariant cannot: the harness that
+proves it runs the same code for every integration, so the name says
+nothing about which one this run was. coverage.Invariant writes both ids
+to the test log, and the generator reads them back as a third result.
+
+If the format drifts, every invariant cell goes missing at once, so the
+exact bytes are pinned by a test on each side."
+```
+
+---
+
+### Task 2: The two registries, loaded and validated
+
+**Files:**
+- Create: `docs/coverage/invariants.yml`
+- Create: `docs/coverage/integrations.yml`
+- Modify: `scripts/coverage_matrix.py:37-56` (paths, `load_features`)
+- Test: `tests/tooling/test_coverage_matrix.py`
+
+**Interfaces:**
+- Produces: `load_invariants() -> list[dict]`, `load_integrations() -> list[dict]`, and `validate_registries(invariants, integrations, features) -> list[str]` returning human-readable problems, empty when the registries are consistent.
+
+- [ ] **Step 1: Write `invariants.yml`**
+
+```yaml
+# The invariants every integration must hold, and the evidence each one
+# requires.
+#
+# This file is declared, not derived, for the reason features.yml gives: the
+# failure it catches is an integration with no evidence at all. Seven of these
+# have been violated and fixed since v1.0.4; each row names the fix.
+#
+# `applies_to` is the interface the invariant is a property of. Every
+# integration of that kind must prove it, or be exempt in integrations.yml
+# with a reason.
+#
+# `verified_by` says how evidence attaches:
+#   harness    internal/conformance emits COVERS invariant=… integration=…
+#   typetable  the generated type round-trip emits the same marker per type
+#   named      a test named Test<Invariant>_* attributes by prefix
+#
+# `requires` lists the levels evidence must exist at. Every entry is empty in
+# this revision: the matrix reports, and nothing fails. An invariant is
+# enforced by filling it in, which is legal only once every non-exempt
+# integration has a subject.
+#
+# `tracked_by` marks an invariant the code does not yet satisfy. It renders as
+# declared-unenforced until the issue lands.
+
+invariants:
+  # --- Resilience: the sink contract -------------------------------------
+  - id: sink.write.buffers_only
+    family: resilience
+    applies_to: sink
+    claim: WriteTable does not reach the destination. Only Flush does.
+    verified_by: harness
+    requires: []
+
+  - id: sink.flush.keeps_batch
+    family: resilience
+    applies_to: sink
+    claim: >
+      A failed Flush leaves every undelivered row buffered. The next Flush
+      re-attempts them.
+    verified_by: harness
+    requires: []
+    violated_once: ["#221"]
+
+  - id: sink.flush.no_hollow_success
+    family: resilience
+    applies_to: sink
+    claim: >
+      Flush returns nil only when every row since the last success was
+      acknowledged by the destination.
+    verified_by: harness
+    requires: []
+    violated_once: ["#221"]
+
+  - id: sink.flush.preserves_order
+    family: resilience
+    applies_to: sink
+    claim: Rows reach the destination in WriteTable order, across a retry.
+    verified_by: harness
+    requires: []
+
+  - id: sink.flush.honours_context
+    family: resilience
+    applies_to: sink
+    claim: Flush returns ctx.Err() when the context ends. Rows stay buffered.
+    verified_by: harness
+    requires: []
+    violated_once: ["#219"]
+
+  - id: sink.flush.empty_is_noop
+    family: resilience
+    applies_to: sink
+    claim: Flush with nothing buffered returns nil and touches nothing.
+    verified_by: harness
+    requires: []
+
+  - id: sink.batch.reports_buffer
+    family: resilience
+    applies_to: sink
+    claim: Batch() returns what is buffered, and nil when nothing is.
+    verified_by: harness
+    requires: []
+
+  - id: sink.error.classifies
+    family: resilience
+    applies_to: sink
+    claim: >
+      The sink's errors classify as unreachable or rejected, so the retry
+      ladder retries the right ones.
+    verified_by: harness
+    requires: []
+
+  - id: sink.probe.fails_start
+    family: resilience
+    applies_to: sink
+    claim: >
+      A Prober whose destination is unreachable fails the start once, without
+      retrying.
+    verified_by: harness
+    requires: []
+
+  # --- Checkpoint: the pipeline and source contract ----------------------
+  - id: pipeline.commit.after_flush
+    family: checkpoint
+    applies_to: pipeline
+    claim: Offsets and state commit only after Flush returned nil.
+    verified_by: named
+    requires: []
+
+  - id: pipeline.commit.nothing_on_failure
+    family: checkpoint
+    applies_to: pipeline
+    claim: A failed flush commits nothing. Not offsets, not state.
+    verified_by: named
+    requires: []
+
+  - id: pipeline.state.with_offsets
+    family: checkpoint
+    applies_to: pipeline
+    claim: Window state and the offsets that produced it commit atomically.
+    verified_by: named
+    requires: []
+
+  - id: source.commit.only_processed
+    family: checkpoint
+    applies_to: source
+    claim: >
+      A source commits the marks the pipeline processed, never what it
+      fetched.
+    verified_by: harness
+    requires: []
+    violated_once: ["#154"]
+
+  - id: source.resume.from_committed
+    family: checkpoint
+    applies_to: source
+    claim: >
+      Restart resumes at the committed position. No gap, no replay before
+      it.
+    verified_by: harness
+    requires: []
+
+  - id: source.marks.never_regress
+    family: checkpoint
+    applies_to: source
+    claim: A committed position never moves backwards.
+    verified_by: harness
+    requires: []
+
+  - id: source.commit.on_revoke
+    family: checkpoint
+    applies_to: source
+    claim: >
+      Marks commit when a partition is revoked, before the rebalance
+      completes.
+    verified_by: harness
+    requires: []
+    tracked_by: "#183"
+
+  # --- Types: per integration, from its declared table -------------------
+  - id: type.roundtrip
+    family: types
+    applies_to: sink
+    claim: >
+      Every declared Arrow type reads back with the declared outcome: exact,
+      coerced by the stated rule, or unsupported with a coded error.
+    verified_by: typetable
+    requires: []
+    violated_once: ["#147", "#150", "#151"]
+
+  - id: type.null
+    family: types
+    applies_to: sink
+    claim: A null in every declared type reads back as declared.
+    verified_by: typetable
+    requires: []
+
+  - id: type.timestamp.instant
+    family: types
+    applies_to: sink
+    claim: >
+      A timestamp reads back as the same instant. Zone-less is UTC. The host
+      zone never leaks into the type.
+    verified_by: typetable
+    requires: []
+    violated_once: ["#153"]
+
+  - id: type.nested
+    family: types
+    applies_to: sink
+    claim: >
+      list, struct, list-of-struct and list-of-list read back or are
+      declared unsupported. Never silently flattened.
+    verified_by: typetable
+    requires: []
+
+  - id: type.string.fidelity
+    family: types
+    applies_to: sink
+    claim: Unicode, escapes and the empty string round-trip byte for byte.
+    verified_by: typetable
+    requires: []
+    violated_once: ["#149"]
+
+  - id: type.undeclared.fails_loud
+    family: types
+    applies_to: sink
+    claim: >
+      An Arrow type absent from the table fails the batch with a coded
+      error. Never coerced silently.
+    verified_by: typetable
+    requires: []
+
+  # --- Lifecycle ---------------------------------------------------------
+  - id: lifecycle.drain.on_cancel
+    family: lifecycle
+    applies_to: pipeline
+    claim: Cancel or SIGTERM flushes the buffered batch, then commits.
+    verified_by: named
+    requires: []
+
+  - id: lifecycle.drain.bounded
+    family: lifecycle
+    applies_to: pipeline
+    claim: The drain finishes or fails inside its deadline.
+    verified_by: named
+    requires: []
+    tracked_by: "#161"
+
+  - id: lifecycle.close.idempotent
+    family: lifecycle
+    applies_to: sink
+    claim: Close twice is safe.
+    verified_by: harness
+    requires: []
+
+  # --- Error policy: declared, tracked ------------------------------------
+  - id: error.dlq.carries_provenance
+    family: errors
+    applies_to: pipeline
+    claim: A DLQ record carries the payload, offset, partition and reason.
+    verified_by: named
+    requires: []
+    tracked_by: "#166"
+
+  - id: error.bad_record.threshold
+    family: errors
+    applies_to: pipeline
+    claim: N bad records in a window fail the pipeline rather than discard forever.
+    verified_by: named
+    requires: []
+    tracked_by: "#166"
+
+  - id: pipeline.batch.timeout
+    family: lifecycle
+    applies_to: pipeline
+    claim: A batch whose query exceeds the timeout fails the batch, not the process.
+    verified_by: named
+    requires: []
+    tracked_by: "#163"
+```
+
+- [ ] **Step 2: Write `integrations.yml`**
+
+```yaml
+# Every integration sqlflow can construct, and what each one claims.
+#
+# One entry per case in sinks.buildSink, sources.New and handlers.New. A test
+# in each package holds Kinds() equal to the ids here, so a new case without
+# an entry fails `go test -short` in seconds.
+#
+# `implements` lists the interfaces the integration satisfies beyond its
+# kind's base contract. `Prober` means the sink checks its destination before
+# the first batch.
+#
+# `exempt` names invariants that cannot apply, each with a reason. An
+# exemption is one of two statements that must agree: the harness skips what
+# it cannot exercise, and the registry excuses it. Either alone leaves the
+# cell missing.
+#
+# `feature` ties the entry to features.yml.
+
+integrations:
+  # --- Sinks ---------------------------------------------------------------
+  - id: sink.kafka
+    kind: sink
+    implements: [Sink]
+    feature: sink.kafka
+    exempt: []
+
+  - id: sink.clickhouse
+    kind: sink
+    implements: [Sink, Prober]
+    feature: sink.clickhouse
+    exempt: []
+
+  - id: sink.iceberg
+    kind: sink
+    implements: [Sink, Prober]
+    feature: sink.iceberg
+    exempt: []
+
+  - id: sink.sqlcommand
+    kind: sink
+    implements: [Sink]
+    feature: sink.sqlcommand
+    exempt:
+      - invariant: sink.flush.keeps_batch
+        reason: writes through the pipeline's own DuckDB connection; a failure is not a network blip. retriesHelp already excludes it.
+      - invariant: sink.flush.honours_context
+        reason: same
+      - invariant: sink.error.classifies
+        reason: same
+      - invariant: sink.probe.fails_start
+        reason: nothing to dial
+
+  - id: sink.console
+    kind: sink
+    implements: [Sink]
+    feature: sink.console
+    exempt:
+      - invariant: sink.flush.keeps_batch
+        reason: stdout cannot be temporarily unavailable. retriesHelp already excludes it.
+      - invariant: sink.flush.honours_context
+        reason: same
+      - invariant: sink.error.classifies
+        reason: same
+      - invariant: sink.probe.fails_start
+        reason: nothing to dial
+
+  - id: sink.noop
+    kind: sink
+    implements: [Sink]
+    feature: sink.console
+    exempt:
+      - invariant: sink.flush.keeps_batch
+        reason: discards by design
+      - invariant: sink.flush.no_hollow_success
+        reason: discards by design
+      - invariant: sink.flush.preserves_order
+        reason: discards by design
+      - invariant: sink.flush.honours_context
+        reason: nothing to wait on
+      - invariant: sink.batch.reports_buffer
+        reason: buffers nothing by design
+      - invariant: sink.error.classifies
+        reason: never fails
+      - invariant: sink.probe.fails_start
+        reason: nothing to dial
+
+  # --- Sources -------------------------------------------------------------
+  - id: source.kafka
+    kind: source
+    implements: [Source, MarkCommitter]
+    feature: source.kafka
+    exempt: []
+
+  - id: source.websocket
+    kind: source
+    implements: [Source]
+    feature: source.websocket
+    exempt:
+      - invariant: source.commit.only_processed
+        reason: no replayable position; at-most-once by construction
+      - invariant: source.resume.from_committed
+        reason: same
+      - invariant: source.marks.never_regress
+        reason: same
+      - invariant: source.commit.on_revoke
+        reason: no partitions
+
+  - id: source.webhook
+    kind: source
+    implements: [Source]
+    feature: source.webhook
+    exempt:
+      - invariant: source.commit.only_processed
+        reason: no replayable position; at-most-once by construction
+      - invariant: source.resume.from_committed
+        reason: same
+      - invariant: source.marks.never_regress
+        reason: same
+      - invariant: source.commit.on_revoke
+        reason: no partitions
+
+  # --- Handlers ------------------------------------------------------------
+  - id: handler.structured
+    kind: handler
+    implements: [Handler]
+    feature: handler.structured
+    exempt: []
+
+  - id: handler.inferred_mem
+    kind: handler
+    implements: [Handler, MetadataWriter]
+    feature: handler.inferred_mem
+    exempt: []
+
+  - id: handler.inferred_disk
+    kind: handler
+    implements: [Handler]
+    feature: handler.inferred_disk
+    exempt: []
+```
+
+`sink.noop` maps to `feature: sink.console` because `features.yml` declares no noop feature and noop is a benchmarking stand-in; the generator only requires that `feature` names a declared feature.
+
+- [ ] **Step 3: Write the failing loader and validator tests**
+
+Append to `tests/tooling/test_coverage_matrix.py`:
+
+```python
+# --- Registries ------------------------------------------------------------
+
+INVARIANTS = [
+    {"id": "sink.flush.keeps_batch", "family": "resilience", "applies_to": "sink",
+     "claim": "kept", "verified_by": "harness", "requires": []},
+    {"id": "source.commit.only_processed", "family": "checkpoint",
+     "applies_to": "source", "claim": "c", "verified_by": "harness", "requires": []},
+]
+
+INTEGRATIONS = [
+    {"id": "sink.clickhouse", "kind": "sink", "implements": ["Sink"],
+     "feature": "sink.clickhouse", "exempt": []},
+    {"id": "sink.console", "kind": "sink", "implements": ["Sink"],
+     "feature": "sink.console",
+     "exempt": [{"invariant": "sink.flush.keeps_batch", "reason": "stdout"}]},
+    {"id": "source.kafka", "kind": "source", "implements": ["Source"],
+     "feature": "source.kafka", "exempt": []},
+]
+
+
+def test_the_committed_registries_load_and_validate():
+    """The real files, not fixtures: a typo in either fails here before it
+    can fail in CI."""
+    invariants = cm.load_invariants()
+    integrations = cm.load_integrations()
+    features = cm.load_features()
+    assert cm.validate_registries(invariants, integrations, features) == []
+    assert len(invariants) >= 20
+    assert {i["kind"] for i in integrations} == {"sink", "source", "handler"}
+
+
+def test_every_committed_invariant_is_unenforced_in_this_revision():
+    """PR 1 reports and fails nothing. Flipping a `requires` is PR 3."""
+    for inv in cm.load_invariants():
+        assert inv["requires"] == [], inv["id"]
+
+
+def test_validate_rejects_an_exemption_naming_no_invariant():
+    bad = [dict(INTEGRATIONS[1], exempt=[
+        {"invariant": "sink.flush.nonexistent", "reason": "r"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("sink.flush.nonexistent" in p for p in problems)
+
+
+def test_validate_rejects_an_exemption_without_a_reason():
+    bad = [dict(INTEGRATIONS[1], exempt=[
+        {"invariant": "sink.flush.keeps_batch"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("reason" in p for p in problems)
+
+
+def test_validate_rejects_an_exemption_from_an_invariant_of_another_kind():
+    """A sink cannot be exempt from a source invariant; that is a typo."""
+    bad = [dict(INTEGRATIONS[0], exempt=[
+        {"invariant": "source.commit.only_processed", "reason": "r"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("applies_to" in p for p in problems)
+
+
+def test_validate_rejects_an_integration_naming_no_feature():
+    bad = [dict(INTEGRATIONS[0], feature="sink.nonexistent")]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("sink.nonexistent" in p for p in problems)
+
+
+def test_validate_rejects_a_duplicate_invariant_id():
+    problems = cm.validate_registries(INVARIANTS + [INVARIANTS[0]], INTEGRATIONS, FEATURES)
+    assert any("duplicate" in p for p in problems)
+
+
+def test_validate_rejects_a_requires_level_that_does_not_exist():
+    bad = [dict(INVARIANTS[0], requires=["nightly"])]
+    problems = cm.validate_registries(bad, INTEGRATIONS, FEATURES)
+    assert any("nightly" in p for p in problems)
+```
+
+- [ ] **Step 4: Run them to verify they fail**
+
+Run: `uv run --locked pytest tests/tooling/test_coverage_matrix.py -k "registr or validate or unenforced" -v`
+Expected: FAIL — `AttributeError: module 'coverage_matrix' has no attribute 'load_invariants'`.
+
+- [ ] **Step 5: Add the loaders and the validator**
+
+In `scripts/coverage_matrix.py`, after `REGISTRY = ...` (line 38):
+
+```python
+INVARIANTS = os.path.join(REPO, "docs", "coverage", "invariants.yml")
+INTEGRATIONS = os.path.join(REPO, "docs", "coverage", "integrations.yml")
+
+FAMILIES = ("resilience", "checkpoint", "types", "lifecycle", "errors")
+KINDS = ("sink", "source", "handler", "pipeline")
+VERIFIERS = ("harness", "typetable", "named")
+```
+
+After `load_features` (line 56):
+
+```python
+def load_invariants():
+    with open(INVARIANTS) as fh:
+        return yaml.safe_load(fh)["invariants"]
+
+
+def load_integrations():
+    with open(INTEGRATIONS) as fh:
+        return yaml.safe_load(fh)["integrations"]
+
+
+def validate_registries(invariants, integrations, features):
+    """Every problem a human can fix, as one line each. Empty when consistent.
+
+    Checked before any test result is read: a registry error is a typo, and a
+    typo that reached the matrix would read as a missing cell, which is the
+    signal the matrix exists to carry. It must not be spendable on typos.
+    """
+    problems = []
+    by_id = {}
+    for inv in invariants:
+        if inv["id"] in by_id:
+            problems.append(f"invariants.yml: duplicate id {inv['id']}")
+        by_id[inv["id"]] = inv
+        for key in ("family", "applies_to", "claim", "verified_by", "requires"):
+            if key not in inv:
+                problems.append(f"invariants.yml: {inv['id']} has no {key}")
+        if inv.get("family") not in FAMILIES:
+            problems.append(f"invariants.yml: {inv['id']} family {inv.get('family')!r} is not one of {FAMILIES}")
+        if inv.get("applies_to") not in KINDS:
+            problems.append(f"invariants.yml: {inv['id']} applies_to {inv.get('applies_to')!r} is not one of {KINDS}")
+        if inv.get("verified_by") not in VERIFIERS:
+            problems.append(f"invariants.yml: {inv['id']} verified_by {inv.get('verified_by')!r} is not one of {VERIFIERS}")
+        for lvl in inv.get("requires", []):
+            if lvl not in LEVELS:
+                problems.append(f"invariants.yml: {inv['id']} requires {lvl!r}, which is not a level")
+
+    feature_ids = {f["id"] for f in features}
+    seen = set()
+    for integ in integrations:
+        if integ["id"] in seen:
+            problems.append(f"integrations.yml: duplicate id {integ['id']}")
+        seen.add(integ["id"])
+        if integ.get("kind") not in ("sink", "source", "handler"):
+            problems.append(f"integrations.yml: {integ['id']} kind {integ.get('kind')!r} is not sink, source or handler")
+        if integ.get("feature") not in feature_ids:
+            problems.append(f"integrations.yml: {integ['id']} names feature {integ.get('feature')!r}, which features.yml does not declare")
+        for ex in integ.get("exempt", []):
+            inv = by_id.get(ex.get("invariant"))
+            if inv is None:
+                problems.append(f"integrations.yml: {integ['id']} is exempt from {ex.get('invariant')!r}, which invariants.yml does not declare")
+                continue
+            if not ex.get("reason"):
+                problems.append(f"integrations.yml: {integ['id']} exemption from {inv['id']} has no reason")
+            if inv["applies_to"] != integ.get("kind"):
+                problems.append(f"integrations.yml: {integ['id']} is a {integ.get('kind')} but {inv['id']} applies_to {inv['applies_to']}")
+    return problems
+```
+
+- [ ] **Step 6: Run the tooling suite**
+
+Run: `uv run --locked pytest tests/tooling -q`
+Expected: 54 passed. If `test_the_committed_registries_load_and_validate` fails, the message names the YAML line to fix; fix the YAML, not the validator.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/coverage/invariants.yml docs/coverage/integrations.yml scripts/coverage_matrix.py tests/tooling/test_coverage_matrix.py
+git commit -m "coverage: declare every invariant and every integration
+
+Two registries beside features.yml. invariants.yml is the contract: 28
+claims, each grounded in a test that exists, a defect that was fixed, or
+an issue that is open. integrations.yml is the surface: every constructor
+case, what it implements, and what it is exempt from with a reason.
+
+Every requires is empty. This revision reports and fails nothing; an
+invariant is enforced by filling one in, which is legal only once every
+non-exempt integration has a subject.
+
+The generator validates both before reading a single test result. A typo
+that reached the matrix would read as a missing cell, and that signal
+must not be spendable on typos. Nine tests pin the rules."
+```
+
+---
+
+### Task 3: The invariant axis in the matrix
+
+**Files:**
+- Modify: `scripts/coverage_matrix.py` (`build`, `snapshot`, `render`, `main`)
+- Test: `tests/tooling/test_coverage_matrix.py`
+
+**Interfaces:**
+- Consumes: `parse_go` triple from Task 1; `load_invariants`, `load_integrations`, `validate_registries` from Task 2.
+- Produces: `build_invariants(invariants, integrations, evidence) -> dict` where `evidence` is `{level: {test: [(invariant, integration)]}}` merged with outcomes, and the snapshot gains `"invariants": [...]` and `"invariant_gaps": [...]`. `render` gains one table per family.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/tooling/test_coverage_matrix.py`:
+
+```python
+# --- The invariant axis ----------------------------------------------------
+
+def inv_snap(evidence=None, results=None, invariants=None, integrations=None):
+    """evidence: {level: {test: [(invariant, integration)]}}
+    results:  {level: {test: outcome}}"""
+    evidence = evidence or {}
+    results = results or {}
+    cells = cm.build_invariants(
+        invariants or INVARIANTS, integrations or INTEGRATIONS,
+        {lvl: results.get(lvl, {}) for lvl in cm.LEVELS},
+        {lvl: evidence.get(lvl, {}) for lvl in cm.LEVELS})
+    return cm.snapshot_invariants(invariants or INVARIANTS, integrations or INTEGRATIONS, cells)
+
+
+def cell(s, invariant, integration, lvl):
+    for inv in s["invariants"]:
+        if inv["id"] == invariant:
+            return inv["integrations"][integration][lvl]
+    raise AssertionError(f"{invariant} not in the snapshot")
+
+
+def test_a_passing_harness_case_covers_the_cell():
+    s = inv_snap(
+        evidence={"integration": {"TestIntegrationSinkClickhouse_Conformance/keeps_batch":
+                                  [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"integration": {"TestIntegrationSinkClickhouse_Conformance/keeps_batch": cm.PASS}},
+    )
+    c = cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "integration")
+    assert c["status"] == "covered"
+    assert c["tests"] == ["TestIntegrationSinkClickhouse_Conformance/keeps_batch"]
+
+
+def test_a_marker_from_a_failing_test_is_not_coverage():
+    """The harness emits the marker only on pass, but a parent test can fail
+    after a subtest passed. The outcome wins."""
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"integration": {"TestX": cm.FAIL}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "integration")["status"] == "failing"
+
+
+def test_a_marker_from_a_skipped_test_is_not_coverage():
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"integration": {"TestX": cm.SKIP}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "integration")["status"] == "skipped"
+
+
+def test_an_integration_with_no_evidence_is_missing():
+    s = inv_snap()
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "integration")["status"] == "missing"
+
+
+def test_an_exempt_integration_renders_exempt_with_its_reason():
+    s = inv_snap()
+    c = cell(s, "sink.flush.keeps_batch", "sink.console", "integration")
+    assert c["status"] == "exempt"
+    assert c["reason"] == "stdout"
+
+
+def test_an_invariant_applies_only_to_its_kind():
+    """source.kafka has no cell under a sink invariant at all."""
+    s = inv_snap()
+    inv = next(i for i in s["invariants"] if i["id"] == "sink.flush.keeps_batch")
+    assert "source.kafka" not in inv["integrations"]
+    assert set(inv["integrations"]) == {"sink.clickhouse", "sink.console"}
+
+
+def test_an_unrequired_level_is_not_a_gap():
+    s = inv_snap()
+    assert s["invariant_gaps"] == []
+
+
+def test_a_required_level_with_no_evidence_is_a_gap():
+    required = [dict(INVARIANTS[0], requires=["integration"])]
+    s = inv_snap(invariants=required)
+    assert {"invariant": "sink.flush.keeps_batch", "integration": "sink.clickhouse",
+            "level": "integration", "status": "missing"} in s["invariant_gaps"]
+    # console is exempt, so it is not a gap even though the level is required
+    assert not any(g["integration"] == "sink.console" for g in s["invariant_gaps"])
+
+
+def test_a_marker_naming_an_unknown_invariant_or_integration_is_reported():
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("sink.flush.bogus", "sink.clickhouse"),
+                                            ("sink.flush.keeps_batch", "sink.bogus")]}},
+        results={"integration": {"TestX": cm.PASS}},
+    )
+    assert {"test": "TestX", "invariant": "sink.flush.bogus", "integration": "sink.clickhouse"} in s["unknown_invariant_markers"]
+    assert {"test": "TestX", "invariant": "sink.flush.keeps_batch", "integration": "sink.bogus"} in s["unknown_invariant_markers"]
+
+
+def test_two_unknown_invariant_markers_do_not_crash_the_snapshot():
+    """Regression guard for the sorted()-over-dicts crash in the feature
+    snapshot: sort by key, never by dict."""
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("a.b.c", "sink.clickhouse")],
+                                  "TestY": [("d.e.f", "sink.clickhouse")]}},
+        results={"integration": {"TestX": cm.PASS, "TestY": cm.PASS}},
+    )
+    assert len(s["unknown_invariant_markers"]) == 2
+
+
+def test_a_tracked_invariant_renders_as_declared_unenforced():
+    tracked = [dict(INVARIANTS[0], tracked_by="#183")]
+    s = inv_snap(invariants=tracked)
+    inv = next(i for i in s["invariants"] if i["id"] == "sink.flush.keeps_batch")
+    assert inv["tracked_by"] == "#183"
+
+
+def test_render_carries_one_table_per_family():
+    s = inv_snap()
+    md = cm.render_invariants(s)
+    assert "## Invariants: resilience" in md
+    assert "## Invariants: checkpoint" in md
+    assert "| `sink.flush.keeps_batch` |" in md
+
+
+def test_render_marks_an_exempt_cell_and_names_the_reason():
+    s = inv_snap()
+    md = cm.render_invariants(s)
+    line = next(l for l in md.splitlines() if "`sink.flush.keeps_batch`" in l)
+    assert "exempt" in line
+
+
+def test_a_test_carrying_any_marker_is_not_unattributed():
+    """Review finding: a marker-attributed test was listed under 'match no
+    declared feature'. The harness attributes by marker only, so its tests
+    would all land there."""
+    s = snap(
+        integration_results={"TestIntegrationSinkClickhouse_Conformance/keeps_batch": cm.PASS},
+        integration_covers={"TestIntegrationSinkClickhouse_Conformance/keeps_batch": ["sink.clickhouse"]},
+    )
+    assert s["unattributed"]["integration"] == []
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `uv run --locked pytest tests/tooling/test_coverage_matrix.py -k "invariant or unattributed or render_carries_one or render_marks" -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'build_invariants'` and the unattributed test asserting `[] == ['TestIntegration...']`.
+
+- [ ] **Step 3: Add `build_invariants` and `snapshot_invariants`**
+
+In `scripts/coverage_matrix.py`, after `build` (line 186):
+
+```python
+def build_invariants(invariants, integrations, results, evidence):
+    """Attribute harness markers to (invariant, integration, level) cells.
+
+    results:  {level: {test: outcome}}
+    evidence: {level: {test: [(invariant, integration)]}}
+
+    A marker is only ever emitted by a passing subtest, but the parent that
+    ran it can still fail or be skipped afterwards, and that verdict is the
+    one `go test` reports. The outcome recorded here is the test's, not the
+    marker's presence.
+    """
+    known_inv = {i["id"] for i in invariants}
+    known_integ = {i["id"] for i in integrations}
+    cells = {}          # (invariant, integration, level) -> [(test, outcome)]
+    unknown = []        # (test, invariant, integration)
+
+    for level in LEVELS:
+        for test, pairs in sorted(evidence.get(level, {}).items()):
+            outcome = results.get(level, {}).get(test, FAIL)
+            for inv, integ in pairs:
+                if inv not in known_inv or integ not in known_integ:
+                    unknown.append((test, inv, integ))
+                    continue
+                cells.setdefault((inv, integ, level), []).append((test, outcome))
+    return {"cells": cells, "unknown": unknown}
+
+
+def snapshot_invariants(invariants, integrations, built):
+    """The invariant half of matrix.json. Same bare-name encoding as the
+    feature half, plus `exempt` cells that carry their reason, so the page
+    can show why a cell is blank without a second lookup."""
+    by_kind = {}
+    for integ in integrations:
+        by_kind.setdefault(integ["kind"], []).append(integ)
+    exemptions = {
+        (ex["invariant"], integ["id"]): ex["reason"]
+        for integ in integrations for ex in integ.get("exempt", [])
+    }
+
+    out = {"invariants": [], "invariant_gaps": [], "unknown_invariant_markers": []}
+    for inv in invariants:
+        required = set(inv.get("requires", []))
+        entry = {
+            "id": inv["id"],
+            "family": inv["family"],
+            "applies_to": inv["applies_to"],
+            "claim": " ".join(inv["claim"].split()),
+            "verified_by": inv["verified_by"],
+            "requires": sorted(required),
+            "integrations": {},
+        }
+        if inv.get("tracked_by"):
+            entry["tracked_by"] = inv["tracked_by"]
+        if inv.get("violated_once"):
+            entry["violated_once"] = list(inv["violated_once"])
+
+        # pipeline invariants have no per-integration cell; they attach to core.
+        subjects = by_kind.get(inv["applies_to"], [])
+        for integ in subjects:
+            levels = {}
+            reason = exemptions.get((inv["id"], integ["id"]))
+            for level in LEVELS:
+                if reason is not None:
+                    levels[level] = {"status": "exempt", "reason": reason}
+                    continue
+                tests = sorted(built["cells"].get((inv["id"], integ["id"], level), []))
+                if level not in required and not tests:
+                    levels[level] = {"status": "not_required"}
+                    continue
+                state = status(tests)
+                c = {"status": state, "tests": [n for n, _ in tests]}
+                for key, members in (
+                    ("skipped", [n for n, o in tests if o == SKIP]),
+                    ("failing", [n for n, o in tests if o == FAIL]),
+                ):
+                    if members:
+                        c[key] = members
+                levels[level] = c
+                if level in required and state != "covered":
+                    out["invariant_gaps"].append({
+                        "invariant": inv["id"], "integration": integ["id"],
+                        "level": level, "status": state})
+            entry["integrations"][integ["id"]] = levels
+        out["invariants"].append(entry)
+
+    out["unknown_invariant_markers"] = [
+        {"test": t, "invariant": i, "integration": g}
+        for t, i, g in sorted(set(built["unknown"]))
+    ]
+    return out
+```
+
+`sorted(set(...))` over tuples is safe; this is the shape the feature snapshot's `unknown_markers` should have used.
+
+- [ ] **Step 4: Add `render_invariants`**
+
+After `render` (line 380):
+
+```python
+INV_MARK = {
+    "covered": "✅",
+    "skipped": "⚠️ skipped",
+    "missing": "❌ missing",
+    "failing": "🔥 failing",
+    "not_required": "·",
+    "exempt": "— exempt",
+}
+
+
+def render_invariants(snap):
+    """One table per family. Columns are the integrations the family's
+    invariants apply to; a cell is the worst status across the levels the
+    invariant requires, or across all levels when it requires none."""
+    lines = [
+        "# Invariant matrix",
+        "",
+        "Generated from `docs/coverage/matrix.json` by `make coverage-matrix`.",
+        "Do not edit by hand.",
+        "",
+        "Invariants are declared in `docs/coverage/invariants.yml`; integrations",
+        "in `docs/coverage/integrations.yml`. A cell is proven by the conformance",
+        "harness (`internal/conformance`), which emits a marker naming both ids.",
+        "An **exempt** cell carries its reason in the JSON. A **missing** cell has",
+        "no evidence. Nothing here fails the build until an invariant's `requires`",
+        "is filled in.",
+        "",
+    ]
+    rank = ["failing", "missing", "skipped", "covered", "exempt", "not_required"]
+
+    def worst(levels, required):
+        consider = required or list(levels)
+        statuses = [levels[l]["status"] for l in consider if l in levels]
+        return min(statuses, key=rank.index) if statuses else "missing"
+
+    families = []
+    for inv in snap["invariants"]:
+        if inv["family"] not in families:
+            families.append(inv["family"])
+
+    for family in families:
+        rows = [i for i in snap["invariants"] if i["family"] == family]
+        columns = []
+        for inv in rows:
+            for integ in inv["integrations"]:
+                if integ not in columns:
+                    columns.append(integ)
+        lines += [f"## Invariants: {family}", ""]
+        if columns:
+            lines.append("| Invariant | Claim | " + " | ".join(f"`{c}`" for c in columns) + " |")
+            lines.append("| --- | --- | " + " | ".join("---" for _ in columns) + " |")
+        else:
+            lines.append("| Invariant | Claim | evidence |")
+            lines.append("| --- | --- | --- |")
+        for inv in rows:
+            claim = inv["claim"]
+            if inv.get("tracked_by"):
+                claim += f" *(declared, tracked by {inv['tracked_by']})*"
+            if columns:
+                cells = " | ".join(
+                    INV_MARK[worst(inv["integrations"][c], inv["requires"])]
+                    if c in inv["integrations"] else "·"
+                    for c in columns)
+                lines.append(f"| `{inv['id']}` | {claim} | {cells} |")
+            else:
+                lines.append(f"| `{inv['id']}` | {claim} | {inv['verified_by']} |")
+        lines.append("")
+
+    if snap["invariant_gaps"]:
+        lines += ["## Invariant gaps", "", "These fail `make coverage-check`.", ""]
+        for g in snap["invariant_gaps"]:
+            lines.append(f"- `{g['invariant']}` on `{g['integration']}` requires **{g['level']}** and is *{g['status']}*.")
+        lines.append("")
+
+    if snap["unknown_invariant_markers"]:
+        lines += ["## Markers naming an unknown invariant or integration", ""]
+        for m in snap["unknown_invariant_markers"]:
+            lines.append(f"- `{m['test']}` marks `{m['invariant']}` on `{m['integration']}`")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+```
+
+- [ ] **Step 5: Exclude marker-carrying tests from the unattributed report**
+
+In `build` (line 170–175), change:
+
+```python
+            feature_id = match(strip_level_prefix(name), prefixes)
+            if feature_id:
+                coverage[feature_id][level].append((name, outcome))
+            else:
+                unmatched[level].append(name)
+```
+
+to:
+
+```python
+            feature_id = match(strip_level_prefix(name), prefixes)
+            if feature_id:
+                coverage[feature_id][level].append((name, outcome))
+            elif not extras.get(name):
+                # A test with a marker is attributed by it. Listing it here
+                # would tell the reader to rename a test that already says
+                # what it covers.
+                unmatched[level].append(name)
+```
+
+- [ ] **Step 6: Wire `main`**
+
+Replace the body of `main()` from `features = load_features()` to the `rendered = render(snap)` line with:
+
+```python
+    features = load_features()
+    invariants = load_invariants()
+    integrations = load_integrations()
+    problems = validate_registries(invariants, integrations, features)
+    if problems:
+        for p in problems:
+            print(p, file=sys.stderr)
+        return 2
+
+    go_results, go_covers, go_invariants = (
+        parse_go(args.go) if args.go and os.path.exists(args.go) else ({}, {}, {}))
+    it_results, it_covers, it_invariants = (
+        parse_go(args.go_integration)
+        if args.go_integration and os.path.exists(args.go_integration)
+        else ({}, {}, {}))
+    py_results, py_covers, py_invariants = (
+        parse_pytest(args.pytest)
+        if args.pytest and os.path.exists(args.pytest) else ({}, {}, {}))
+
+    coverage, secondary, unmatched, unknown = build(
+        features, go_results, py_results, go_covers, py_covers,
+        it_results, it_covers)
+    snap = snapshot(features, coverage, secondary, unmatched, unknown)
+
+    built = build_invariants(
+        invariants, integrations,
+        {"unit": go_results, "integration": it_results, "release": py_results},
+        {"unit": go_invariants, "integration": it_invariants, "release": py_invariants})
+    snap.update(snapshot_invariants(invariants, integrations, built))
+    snap["version"] = 3
+
+    rendered = render(snap) + "\n" + render_invariants(snap)
+```
+
+And extend the gap report at the end of `main`:
+
+```python
+    gaps = snap["gaps"] + snap["invariant_gaps"]
+    if args.check and gaps:
+        print(f"\n{len(gaps)} coverage gap(s):", file=sys.stderr)
+        for gap in snap["gaps"]:
+            print(f"  {gap['feature']}: {gap['level']} is {gap['status']}",
+                  file=sys.stderr)
+        for gap in snap["invariant_gaps"]:
+            print(f"  {gap['invariant']} on {gap['integration']}: "
+                  f"{gap['level']} is {gap['status']}", file=sys.stderr)
+        return 1
+    return 0
+```
+
+Update `test_the_snapshot_declares_its_schema_version` to expect `3` if it asserts on `snapshot(...)` output directly — check: it calls `snap(...)`, which calls `cm.snapshot`, which still writes `2`; `main` bumps to `3`. Leave that test alone and add nothing: the bump is `main`'s, so the committed file reads `3` and the unit snapshot reads `2`. Instead, change `snapshot()` line 231 to `"version": 3` and update the existing test to assert `3`. One number, one place.
+
+- [ ] **Step 7: Run the tooling suite**
+
+Run: `uv run --locked pytest tests/tooling -q`
+Expected: 69 passed.
+
+- [ ] **Step 8: Regenerate against the existing reports and confirm the shape**
+
+Run: `SQLFLOW_CLICKHOUSE_DSN=clickhouse://127.0.0.1:1/default make coverage-write && uv run --locked python -c "import json; m=json.load(open('docs/coverage/matrix.json')); print(m['version'], len(m['invariants']), m['invariant_gaps'], m['unknown_invariant_markers'])"`
+Expected: `3 28 [] []`, and `docs/coverage/matrix.md` ends with the invariant tables, every sink cell `❌ missing` or `— exempt`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/coverage_matrix.py tests/tooling/test_coverage_matrix.py docs/coverage/matrix.json docs/coverage/matrix.md
+git commit -m "coverage: the matrix gains an invariant axis
+
+invariant x integration x level, beside the feature table. A cell is
+proven by a structured marker from a passing test; failing and skipped
+outcomes win over the marker, as they do for features. Exempt cells carry
+their reason. A required level with no evidence is a gap and fails
+--check, exactly as a feature gap does; today no level is required.
+
+Two fixes in passing that the harness depends on. A test carrying a
+marker no longer appears as unattributed, which would have listed every
+harness test under 'match no declared feature'. Unknown markers sort by
+tuple, not by dict, so two of them report rather than crash.
+
+Evidence: 69 tooling tests pass. The regenerated matrix carries 28
+invariants, 0 gaps, and every sink cell missing or exempt.
+
+If the marker parsing is wrong, every invariant cell reads missing. That
+fails toward 'unproven', which is the direction it must fail."
+```
+
+---
+
+### Task 4: `Kinds()` on every constructor, held equal to the registry
+
+**Files:**
+- Create: `internal/coverage/registry.go`
+- Modify: `internal/sinks/init.go:106-145` (`buildSink`)
+- Modify: `internal/sources/init.go:16-98` (`New`)
+- Modify: `internal/handlers/init.go:13-…` (`New`)
+- Test: `internal/coverage/registry_test.go`, `internal/sinks/registry_test.go`, `internal/sources/registry_test.go`, `internal/handlers/registry_test.go`
+
+**Interfaces:**
+- Produces: `coverage.Integrations(kind string) ([]string, error)` — ids of that kind from `integrations.yml`, as the bare type name (`sink.clickhouse` → `clickhouse`).
+- Produces: `sinks.Kinds() []string`, `sources.Kinds() []string`, `handlers.Kinds() []string` — sorted constructor cases.
+
+- [ ] **Step 1: Write the failing registry-reader test**
+
+Create `internal/coverage/registry_test.go`:
+
+```go
+package coverage
+
+import (
+	"testing"
+
+	"github.com/zeebo/assert"
+)
+
+func TestCoverageRegistry_ListsSinksByBareName(t *testing.T) {
+	got, err := Integrations("sink")
+	assert.NoError(t, err)
+	// The registry's ids are prefixed by kind; the constructor switch is
+	// not. The bare name is what both sides can compare.
+	assert.DeepEqual(t, []string{"clickhouse", "console", "iceberg", "kafka", "noop", "sqlcommand"}, got)
+}
+
+func TestCoverageRegistry_RejectsAnUnknownKind(t *testing.T) {
+	_, err := Integrations("router")
+	assert.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./internal/coverage/ -run TestCoverageRegistry -v`
+Expected: FAIL — `undefined: Integrations`.
+
+- [ ] **Step 3: Write the reader**
+
+Create `internal/coverage/registry.go`:
+
+```go
+package coverage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Integrations returns the bare type names integrations.yml declares for one
+// kind, sorted. "sink.clickhouse" is reported as "clickhouse", which is the
+// form the constructor switches use, so a test can hold the two equal.
+//
+// The file is located relative to this source file rather than the working
+// directory, because `go test ./...` runs each package from its own dir.
+func Integrations(kind string) ([]string, error) {
+	switch kind {
+	case "sink", "source", "handler":
+	default:
+		return nil, fmt.Errorf("coverage: %q is not an integration kind", kind)
+	}
+	_, self, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(self), "..", "..", "docs", "coverage", "integrations.yml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("coverage: read %s: %w", path, err)
+	}
+	var doc struct {
+		Integrations []struct {
+			ID   string `yaml:"id"`
+			Kind string `yaml:"kind"`
+		} `yaml:"integrations"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("coverage: parse %s: %w", path, err)
+	}
+	var out []string
+	for _, i := range doc.Integrations {
+		if i.Kind == kind {
+			out = append(out, strings.TrimPrefix(i.ID, kind+"."))
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run it**
+
+Run: `go test ./internal/coverage/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the three failing agreement tests**
+
+Create `internal/sinks/registry_test.go`:
+
+```go
+package sinks
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// A sink the switch can build and the registry does not name has no
+// invariant cells at all, which is the sink.iceberg failure: nothing written
+// down, so nothing can be missing. This fails in the unit pass, in seconds.
+func TestSinkRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+	declared, err := coverage.Integrations("sink")
+	assert.NoError(t, err)
+	assert.DeepEqual(t, declared, Kinds())
+}
+```
+
+Create `internal/sources/registry_test.go` with the same body, package `sources`, `coverage.Integrations("source")`, test name `TestSourceRegistry_MatchesTheConstructorSwitch`.
+
+Create `internal/handlers/registry_test.go` with the same body, package `handlers`, `coverage.Integrations("handler")`, test name `TestHandlerRegistry_MatchesTheConstructorSwitch`.
+
+The handler switch cases are `handlers.StructuredBatch`, `handlers.InferredMemBatch`, `handlers.InferredDiskBatch`; `Kinds()` for handlers must return the registry's form (`structured`, `inferred_mem`, `inferred_disk`). The mapping lives in the `builders` map keys below.
+
+- [ ] **Step 6: Run them to verify they fail**
+
+Run: `go test -short ./internal/sinks/ ./internal/sources/ ./internal/handlers/ -run Registry`
+Expected: FAIL — `undefined: Kinds` in each package.
+
+- [ ] **Step 7: Refactor `buildSink` into a map**
+
+In `internal/sinks/init.go`, replace `buildSink` (lines 106–145) with:
+
+```go
+// builders is the constructor for each sink type. A map rather than a switch
+// so Kinds can list it: the registry test holds the two equal, and a new
+// sink without a registry entry fails the unit pass.
+var builders = map[string]func(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error){
+	"noop": func(context.Context, config.Sink, adbc.Connection) (core.Sink, error) {
+		return &NoopSink{}, nil
+	},
+	"console": func(context.Context, config.Sink, adbc.Connection) (core.Sink, error) {
+		return NewConsoleSink(), nil
+	},
+	"kafka": func(_ context.Context, sink config.Sink, _ adbc.Connection) (core.Sink, error) {
+		if sink.Kafka == nil {
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: kafka sink requires a kafka block")
+		}
+		return NewKafkaSink(*sink.Kafka)
+	},
+	"sqlcommand": func(_ context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
+		if sink.SQLCommand == nil {
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: sqlcommand sink requires a sqlcommand block")
+		}
+		return NewSQLCommandSink(conn, sink.SQLCommand.SQL, sink.SQLCommand.Substitutions)
+	},
+	"clickhouse": func(_ context.Context, sink config.Sink, _ adbc.Connection) (core.Sink, error) {
+		if sink.Clickhouse == nil {
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: clickhouse sink requires a clickhouse block")
+		}
+		return NewClickhouseSink(*sink.Clickhouse)
+	},
+	"iceberg": func(ctx context.Context, sink config.Sink, _ adbc.Connection) (core.Sink, error) {
+		if sink.Iceberg == nil {
+			return nil, errs.New(errs.CodeSinkInvalid, "sink: iceberg sink requires an iceberg block")
+		}
+		return NewIcebergSink(ctx, sink.Iceberg.CatalogName, sink.Iceberg.TableName)
+	},
+}
+
+// Kinds lists every sink type the engine can build, sorted.
+func Kinds() []string {
+	out := make([]string, 0, len(builders))
+	for k := range builders {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// buildSink constructs the sink itself. Whether a retry ladder belongs around
+// it is retriesHelp's decision, not this one's.
+func buildSink(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
+	kind := sink.Type
+	if kind == "" {
+		// The Python engine falls back to console for an unset type.
+		kind = "console"
+	}
+	build, ok := builders[kind]
+	if !ok {
+		return nil, errs.New(errs.CodeSinkInvalid, "sink: %q not supported", sink.Type)
+	}
+	return build(ctx, sink, conn)
+}
+```
+
+Add `"sort"` to the imports.
+
+- [ ] **Step 8: Refactor `sources.New` the same way**
+
+In `internal/sources/init.go`, move each `case` body into a map entry keyed `"kafka"`, `"websocket"`, `"webhook"` with signature `func(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, error)`. Keep every body byte-identical to the case it came from. `New` becomes:
+
+```go
+func New(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, error) {
+	build, ok := builders[c.Type]
+	if !ok {
+		return nil, errs.New(errs.CodeSourceInvalid, "source: %q not supported", c.Type)
+	}
+	return build(c, l, mp)
+}
+
+// Kinds lists every source type the engine can build, sorted.
+func Kinds() []string {
+	out := make([]string, 0, len(builders))
+	for k := range builders {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+```
+
+- [ ] **Step 9: Refactor `handlers.New` the same way**
+
+In `internal/handlers/init.go`, the config carries the Python-era names. Key the map by the registry's bare name and translate once:
+
+```go
+// handlerKinds maps the config's Python-era type names to the registry's.
+var handlerKinds = map[string]string{
+	"handlers.StructuredBatch":   "structured",
+	"handlers.InferredMemBatch":  "inferred_mem",
+	"handlers.InferredDiskBatch": "inferred_disk",
+}
+```
+
+Move each case body into `builders[<bare name>]` with signature `func(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, error)`. `New` looks up `handlerKinds[c.Type]` then `builders[...]`; an unknown type keeps its existing error. `Kinds()` is the same shape as the other two.
+
+- [ ] **Step 10: Run the unit pass for the three packages plus their existing tests**
+
+Run: `go test -short ./internal/sinks/ ./internal/sources/ ./internal/handlers/ ./internal/coverage/`
+Expected: all `ok`. In particular `TestSinkRetry_New*` and the config-driven tests must still pass — the refactor changes no behaviour, and those tests prove it.
+
+- [ ] **Step 11: Run the whole unit pass**
+
+Run: `go build ./... && go vet ./... && go test -short ./...`
+Expected: all `ok`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/coverage/registry.go internal/coverage/registry_test.go internal/sinks/init.go internal/sinks/registry_test.go internal/sources/init.go internal/sources/registry_test.go internal/handlers/init.go internal/handlers/registry_test.go
+git commit -m "integrations: the constructor switches and integrations.yml cannot drift
+
+Each constructor is a map now, and Kinds() lists its keys. A test per
+package holds that list equal to the registry, so a new case without an
+entry fails go test -short in seconds. A sink the engine can build and
+the registry does not name has no invariant cells at all, which is the
+sink.iceberg failure: nothing written down, so nothing can be missing.
+
+No behaviour change. Every existing sink, source and handler test passes
+unchanged, and the unsupported-type errors are the same strings."
+```
+
+---
+
+### Task 5: The harness, proven against an in-memory sink
+
+**Files:**
+- Create: `internal/conformance/conformance.go`
+- Test: `internal/conformance/conformance_test.go`
+
+**Interfaces:**
+- Produces:
+  ```go
+  type Row map[string]any
+  type SinkSubject struct {
+      Integration string
+      New         func(t *testing.T) core.Sink
+      Break       func(t *testing.T)
+      Heal        func(t *testing.T)
+      ReadBack    func(t *testing.T) []Row
+      Table       func(t *testing.T, id int64) arrow.Table   // a one-row table the subject's destination accepts
+  }
+  func Sinks(t *testing.T, s SinkSubject)
+  ```
+  `Table` is the subject's, not the harness's: a ClickHouse table needs columns the DDL declared, and the harness must not know DDL. The harness compares `ReadBack` rows by the `id` key only.
+
+- [ ] **Step 1: Write the failing harness tests**
+
+Create `internal/conformance/conformance_test.go`:
+
+```go
+package conformance
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/zeebo/assert"
+)
+
+// memSink is the smallest sink that honours the contract: it buffers on
+// WriteTable, delivers on Flush, and keeps what it could not deliver.
+type memSink struct {
+	mu        sync.Mutex
+	down      bool
+	buffered  []arrow.Table
+	delivered []int64
+}
+
+func (m *memSink) WriteTable(_ context.Context, t arrow.Table) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t.Retain()
+	m.buffered = append(m.buffered, t)
+	return nil
+}
+
+func (m *memSink) Flush(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.down {
+		return errors.New("destination unreachable")
+	}
+	for _, t := range m.buffered {
+		m.delivered = append(m.delivered, ids(t)...)
+		t.Release()
+	}
+	m.buffered = nil
+	return nil
+}
+
+func (m *memSink) Batch() (arrow.Table, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.buffered) == 0 {
+		return nil, nil
+	}
+	return m.buffered[0], nil
+}
+
+// dropSink is memSink with #221's defect: a failed Flush discards the buffer.
+type dropSink struct{ memSink }
+
+func (d *dropSink) Flush(ctx context.Context) error {
+	d.mu.Lock()
+	down := d.down
+	if down {
+		d.buffered = nil
+	}
+	d.mu.Unlock()
+	return d.memSink.Flush(ctx)
+}
+
+func ids(t arrow.Table) []int64 {
+	var out []int64
+	col := t.Column(0)
+	for _, chunk := range col.Data().Chunks() {
+		arr := chunk.(*array.Int64)
+		for i := 0; i < arr.Len(); i++ {
+			out = append(out, arr.Value(i))
+		}
+	}
+	return out
+}
+
+func oneRow(t *testing.T, id int64) arrow.Table {
+	t.Helper()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	b := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer b.Release()
+	b.Field(0).(*array.Int64Builder).Append(id)
+	rec := b.NewRecord()
+	defer rec.Release()
+	return array.NewTableFromRecords(schema, []arrow.Record{rec})
+}
+
+func subjectFor(sink interface {
+	core.Sink
+	set(down bool)
+	rows() []Row
+}) SinkSubject {
+	return SinkSubject{
+		Integration: "sink.mem",
+		New:         func(*testing.T) core.Sink { return sink },
+		Break:       func(*testing.T) { sink.set(true) },
+		Heal:        func(*testing.T) { sink.set(false) },
+		ReadBack:    func(*testing.T) []Row { return sink.rows() },
+		Table:       oneRow,
+	}
+}
+
+func (m *memSink) set(down bool) { m.mu.Lock(); m.down = down; m.mu.Unlock() }
+func (m *memSink) rows() []Row {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Row, 0, len(m.delivered))
+	for _, id := range m.delivered {
+		out = append(out, Row{"id": id})
+	}
+	return out
+}
+
+func TestConformanceSinks_ACorrectSinkPasses(t *testing.T) {
+	Sinks(t, subjectFor(&memSink{}))
+}
+
+// The harness must catch the defect it exists for. Run it against a sink
+// that drops its buffer and confirm the keeps_batch subtest fails, using a
+// child *testing.T so the failure is observed rather than reported.
+func TestConformanceSinks_ADroppingSinkFailsKeepsBatch(t *testing.T) {
+	var failed bool
+	t.Run("probe", func(inner *testing.T) {
+		inner.Cleanup(func() { failed = inner.Failed() })
+		// Run the harness under a subtest whose failure we can inspect.
+		inner.Run("harness", func(h *testing.T) {
+			Sinks(h, subjectFor(&dropSink{}))
+		})
+	})
+	assert.True(t, failed)
+}
+```
+
+`go test` marks a test failed if any subtest fails, so `inner.Failed()` in `Cleanup` is true when the harness's `keeps_batch` subtest failed. The outer test then passes on `assert.True(t, failed)`, but `go test` still reports the inner `probe/harness/keeps_batch` failure as a failure of the whole test. Avoid that: the dropping-sink case must not use real `t.Run` failure. Replace the second test with a `Check` variant — see Step 3 — so the harness exposes its verdicts as values.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test -short ./internal/conformance/ -v`
+Expected: FAIL — `undefined: SinkSubject`, `undefined: Sinks`, `undefined: Row`.
+
+- [ ] **Step 3: Write the harness**
+
+Create `internal/conformance/conformance.go`:
+
+```go
+// Package conformance proves the invariants every integration must hold.
+//
+// It knows the invariants and nothing about any integration. An integration
+// supplies a subject: how to build it, how to make its destination stop
+// answering, how to bring it back, and how to read what it delivered. The
+// harness runs one sequence and asserts each invariant as its own subtest,
+// so each gets its own marker and its own cell in the matrix.
+//
+// Evidence is emitted, not inferred. A passing subtest logs
+//
+//	COVERS invariant=<id> integration=<id>
+//
+// which the coverage generator reads from `go test -json` output. Test names
+// carry nothing, because the same code proves the same invariant for every
+// integration and only the marker knows which one this run was.
+package conformance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+)
+
+// Row is one delivered row, decoded by the subject through the destination's
+// own reader. The harness compares rows by their "id" value only, because
+// the destination decides what other columns a row has.
+type Row map[string]any
+
+// SinkSubject is what an integration hands the harness.
+type SinkSubject struct {
+	// Integration is the integrations.yml id, e.g. "sink.clickhouse".
+	Integration string
+	// New builds the sink under test. Called once per sequence.
+	New func(t *testing.T) core.Sink
+	// Break makes the destination stop answering. Nil means nothing can
+	// break, and the network-shaped invariants are skipped; the registry
+	// must then exempt the integration, or the cell stays missing.
+	Break func(t *testing.T)
+	// Heal reverses Break.
+	Heal func(t *testing.T)
+	// ReadBack returns every row the destination holds, in delivery order.
+	ReadBack func(t *testing.T) []Row
+	// Table returns a one-row table with an int64 "id" column that the
+	// destination accepts. The subject owns the schema because a ClickHouse
+	// table has the columns its DDL declared, and the harness has no DDL.
+	Table func(t *testing.T, id int64) arrow.Table
+}
+
+// flushTimeout bounds a Flush against a broken destination. A hung
+// connection must return as ctx.Err(), not hang the suite.
+const flushTimeout = 10 * time.Second
+
+// Sinks proves every sink invariant the subject can exercise.
+func Sinks(t *testing.T, s SinkSubject) {
+	t.Helper()
+	if s.Integration == "" {
+		t.Fatal("conformance: SinkSubject.Integration is required")
+	}
+	for _, v := range sinkVerdicts(t, s) {
+		v := v
+		t.Run(v.invariant, func(t *testing.T) {
+			if v.skipped != "" {
+				t.Skip(v.skipped)
+			}
+			if v.failure != "" {
+				t.Fatal(v.failure)
+			}
+			coverage.Invariant(t, v.invariant, s.Integration)
+		})
+	}
+	coverage.Covers(t, s.Integration)
+}
+
+// verdict is one invariant's outcome. Separated from the subtest that
+// reports it so the harness's own tests can assert on a failure without
+// failing.
+type verdict struct {
+	invariant string
+	failure   string // non-empty: the invariant does not hold
+	skipped   string // non-empty: the subject cannot exercise it
+}
+
+// sinkVerdicts runs the sequence once and judges each invariant.
+//
+//  1. WriteTable(A)
+//  2. Break; Flush must fail
+//  3. Heal; Flush must succeed
+//  4. ReadBack must be [A]
+func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
+	t.Helper()
+	const keepsBatch = "sink.flush.keeps_batch"
+
+	if s.Break == nil {
+		return []verdict{{invariant: keepsBatch, skipped: "subject has nothing to break; exempt it in integrations.yml"}}
+	}
+
+	sink := s.New(t)
+	a := s.Table(t, 1)
+	defer a.Release()
+
+	ctx := context.Background()
+	if err := sink.WriteTable(ctx, a); err != nil {
+		t.Fatalf("conformance: WriteTable before any fault: %v", err)
+	}
+
+	s.Break(t)
+	bctx, cancel := context.WithTimeout(ctx, flushTimeout)
+	err := sink.Flush(bctx)
+	cancel()
+	if err == nil {
+		// A flush that "succeeds" into a broken destination proves nothing
+		// about keeping the batch; the fault did not take.
+		t.Fatalf("conformance: Flush succeeded while the destination was broken; Break did not break it")
+	}
+
+	s.Heal(t)
+	if err := sink.Flush(ctx); err != nil {
+		return []verdict{{invariant: keepsBatch,
+			failure: "Flush after Heal failed: " + err.Error() + "; the retry did not deliver"}}
+	}
+
+	got := s.ReadBack(t)
+	if len(got) != 1 || got[0]["id"] != int64(1) {
+		return []verdict{{invariant: keepsBatch,
+			failure: "after a failed Flush and a successful retry the destination holds " +
+				describe(got) + "; want exactly the row that failed"}}
+	}
+	return []verdict{{invariant: keepsBatch}}
+}
+
+func describe(rows []Row) string {
+	if len(rows) == 0 {
+		return "no rows"
+	}
+	ids := ""
+	for i, r := range rows {
+		if i > 0 {
+			ids += ", "
+		}
+		ids += "id=" + itoa(r["id"])
+	}
+	return "rows [" + ids + "]"
+}
+
+func itoa(v any) string {
+	switch n := v.(type) {
+	case int64:
+		return time.Duration(n).String()[:0] + fmtInt(n)
+	default:
+		return "?"
+	}
+}
+```
+
+Replace the last helper with a plain `strconv.FormatInt` — the version above is a placeholder that must not ship:
+
+```go
+import "strconv"
+
+func itoa(v any) string {
+	if n, ok := v.(int64); ok {
+		return strconv.FormatInt(n, 10)
+	}
+	return "?"
+}
+```
+
+Then rewrite the dropping-sink test to use `sinkVerdicts` directly:
+
+```go
+func TestConformanceSinks_ADroppingSinkFailsKeepsBatch(t *testing.T) {
+	vs := sinkVerdicts(t, subjectFor(&dropSink{}))
+	assert.Equal(t, 1, len(vs))
+	assert.Equal(t, "sink.flush.keeps_batch", vs[0].invariant)
+	assert.True(t, vs[0].failure != "")
+	assert.True(t, strings.Contains(vs[0].failure, "no rows"))
+}
+
+func TestConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.T) {
+	s := subjectFor(&memSink{})
+	s.Break, s.Heal = nil, nil
+	vs := sinkVerdicts(t, s)
+	assert.True(t, vs[0].skipped != "")
+}
+```
+
+Add `"strings"` to the test imports.
+
+- [ ] **Step 4: Run the harness tests**
+
+Run: `go test -short ./internal/conformance/ -v`
+Expected: PASS. The `-v` output for `ACorrectSinkPasses` must contain the line `COVERS invariant=sink.flush.keeps_batch integration=sink.mem` — confirm it by eye; Task 1's parser test already pins the format.
+
+- [ ] **Step 5: Confirm the import rule**
+
+Run: `go list -deps ./internal/conformance/ | grep -E 'internal/(sinks|kafka|webhook|websocket)$'`
+Expected: no output. If any prints, the package has the cycle the Global Constraints forbid.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/conformance/
+git commit -m "conformance: one harness proves a sink invariant for any sink
+
+The harness knows the invariant and nothing about the integration. A
+subject supplies New, Break, Heal, ReadBack and a one-row Table; the
+harness writes a row, breaks the destination, sees Flush fail, heals it,
+sees Flush succeed, and reads the row back. That proves
+sink.flush.keeps_batch, and a passing subtest emits the marker the
+matrix reads.
+
+Verdicts are values, separate from the subtests that report them, so
+the harness's own tests can run it against a sink with #221's defect and
+assert that it catches it without failing themselves.
+
+If the sequence is wrong, a sink that drops its batch passes. The
+dropSink test is the guard: it drops, and the verdict names it."
+```
+
+---
+
+### Task 6: `Proxy`: toxiproxy in front of an upstream
+
+**Files:**
+- Create: `internal/conformance/proxy.go`
+- Modify: `go.mod`, `go.sum`
+
+**Interfaces:**
+- Produces:
+  ```go
+  type Proxy struct { Addr string }             // host:port the sink dials
+  func NewProxy(t *testing.T, network *testcontainers.DockerNetwork, upstream string) *Proxy
+  func (p *Proxy) Break(t *testing.T)           // add a timeout toxic: connections hang
+  func (p *Proxy) Heal(t *testing.T)            // remove it
+  ```
+  `upstream` is `<network alias>:<port>` of a container on `network`. `NewProxy` registers `t.Cleanup` to terminate the container.
+
+- [ ] **Step 1: Add the dependencies**
+
+Run:
+```bash
+go get github.com/testcontainers/testcontainers-go/modules/toxiproxy@v0.44.0 \
+       github.com/testcontainers/testcontainers-go/modules/clickhouse@v0.44.0 \
+       github.com/Shopify/toxiproxy/v2@v2.12.0
+go mod tidy
+```
+Expected: `go.mod` gains the three requirements; `go build ./...` still succeeds.
+
+- [ ] **Step 2: Write `proxy.go`**
+
+There is no standalone test for `Proxy`: an upstream the proxy container can reach must itself be a container, and Task 7 supplies one. The ClickHouse conformance test is `Proxy`'s test.
+
+```go
+package conformance
+
+import (
+	"context"
+	"testing"
+
+	toxiclient "github.com/Shopify/toxiproxy/v2/client"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/toxiproxy"
+	"github.com/testcontainers/testcontainers-go/network"
+)
+
+// toxiproxyImage is pinned so a proxy upgrade is a commit rather than a
+// Tuesday.
+const toxiproxyImage = "ghcr.io/shopify/toxiproxy:2.12.0"
+
+// proxyName is the one proxy each Proxy container carries. The module
+// assigns it the first proxied port, 8666.
+const (
+	proxyName = "upstream"
+	proxyPort = 8666
+)
+
+// Proxy is a toxiproxy container between a sink and its destination.
+//
+// Break adds a timeout toxic, which holds every connection open and never
+// answers. That is a partition, not a refusal: the failure #219 fixed for,
+// and the one honours_context needs. A refused connection is a different
+// fault and a different invariant.
+type Proxy struct {
+	// Addr is the host:port the sink dials instead of the destination.
+	Addr string
+
+	client *toxiclient.Client
+}
+
+// NewProxy starts toxiproxy on network, forwarding to upstream, which must be
+// "<alias>:<port>" of a container already on that network. The proxy
+// container is terminated when the test ends.
+func NewProxy(t *testing.T, nw *testcontainers.DockerNetwork, upstream string) *Proxy {
+	t.Helper()
+	ctx := context.Background()
+
+	ctr, err := toxiproxy.Run(ctx, toxiproxyImage,
+		network.WithNetwork([]string{"toxiproxy"}, nw),
+		toxiproxy.WithProxy(proxyName, upstream),
+	)
+	if err != nil {
+		t.Fatalf("conformance: start toxiproxy: %v", err)
+	}
+	t.Cleanup(func() {
+		// Teardown must not change the verdict.
+		_ = ctr.Terminate(context.Background())
+	})
+
+	host, port, err := ctr.ProxiedEndpoint(proxyPort)
+	if err != nil {
+		t.Fatalf("conformance: toxiproxy proxied endpoint: %v", err)
+	}
+	uri, err := ctr.URI(ctx)
+	if err != nil {
+		t.Fatalf("conformance: toxiproxy control uri: %v", err)
+	}
+	return &Proxy{Addr: host + ":" + port, client: toxiclient.NewClient(uri)}
+}
+
+// Break makes every connection through the proxy hang without answering.
+func (p *Proxy) Break(t *testing.T) {
+	t.Helper()
+	proxy, err := p.client.Proxy(proxyName)
+	if err != nil {
+		t.Fatalf("conformance: look up proxy: %v", err)
+	}
+	// timeout=0 holds the connection open forever; a positive value would
+	// close it after that many milliseconds, which is a refusal in slow
+	// motion rather than a hang.
+	if _, err := proxy.AddToxic("hang", "timeout", "downstream", 1.0,
+		toxiclient.Attributes{"timeout": 0}); err != nil {
+		t.Fatalf("conformance: add timeout toxic: %v", err)
+	}
+}
+
+// Heal removes the hang.
+func (p *Proxy) Heal(t *testing.T) {
+	t.Helper()
+	proxy, err := p.client.Proxy(proxyName)
+	if err != nil {
+		t.Fatalf("conformance: look up proxy: %v", err)
+	}
+	if err := proxy.RemoveToxic("hang"); err != nil {
+		t.Fatalf("conformance: remove timeout toxic: %v", err)
+	}
+}
+```
+
+`"downstream"` is the direction from the proxy toward the client; toxiproxy applies a downstream toxic to bytes flowing back to the sink, so a request goes out and its response never returns. That is the hang the sink observes.
+
+- [ ] **Step 3: Build and vet**
+
+Run: `go build ./... && go vet ./internal/conformance/`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go.mod go.sum internal/conformance/proxy.go
+git commit -m "conformance: a toxiproxy container stands between a sink and its destination
+
+Break adds a timeout toxic. Every connection through the proxy hangs
+without answering, which is a partition rather than a refusal: the fault
+that #219 fixed for, and the one honours_context will need. Heal removes
+it. The subject in the next commit is the proof; a proxy needs an
+upstream it can reach, and only a container is one."
+```
+
+---
+
+### Task 7: The ClickHouse subject at integration level
+
+**Files:**
+- Create: `internal/sinks/conformance_test.go`
+
+**Interfaces:**
+- Consumes: `conformance.SinkSubject`, `conformance.Sinks`, `conformance.NewProxy`, `conformance.Row` from Tasks 5–6; `NewClickhouseSink`, `ClickhouseSink.conn`, `ClickhouseSink.table` from the existing sink.
+
+- [ ] **Step 1: Write the integration test**
+
+Create `internal/sinks/conformance_test.go`:
+
+```go
+package sinks
+
+// The ClickHouse sink under the conformance harness, against a real server
+// behind toxiproxy.
+//
+// This is the first subject. Everything the harness needs from an
+// integration is here: build the sink, break and heal its network, read back
+// what it delivered, and produce a one-row table its DDL accepts. A second
+// sink supplies the same five things and nothing else.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/testcontainers/testcontainers-go"
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/conformance"
+	"github.com/zeebo/assert"
+)
+
+// clickhouseImage is pinned so a server upgrade is a commit rather than a
+// Tuesday. 26.8 is the self-hosted version the ClickHouse docs page was
+// verified against.
+const clickhouseImage = "clickhouse/clickhouse-server:26.8"
+
+func TestIntegrationSinkClickhouse_Conformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: -short runs the unit pass only")
+	}
+	ctx := context.Background()
+
+	nw, err := network.New(ctx)
+	if err != nil {
+		t.Fatalf("docker network: %v", err)
+	}
+	t.Cleanup(func() { _ = nw.Remove(context.Background()) })
+
+	ch, err := tcclickhouse.Run(ctx, clickhouseImage,
+		network.WithNetwork([]string{"clickhouse"}, nw),
+		testcontainers.WithExposedPorts("8123/tcp"),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() { _ = ch.Terminate(context.Background()) })
+
+	// The sink speaks HTTP on 8123 by default; the proxy forwards to the
+	// container's alias on the shared network.
+	proxy := conformance.NewProxy(t, nw, "clickhouse:8123")
+
+	table := fmt.Sprintf("conformance_%d", time.Now().UnixNano())
+	dsn := "clickhouse://" + proxy.Addr + "/default"
+
+	// A direct connection for DDL and read-back, so the harness's own
+	// reads never go through the fault it injects.
+	direct, err := NewClickhouseSink(config.ClickhouseSink{
+		DSN: mustConnectionString(t, ch), Table: table})
+	assert.NoError(t, err)
+	t.Cleanup(func() { direct.Close() })
+	assert.NoError(t, direct.conn.Exec(ctx,
+		"CREATE TABLE "+table+" (id Int64) ENGINE = MergeTree() ORDER BY id"))
+
+	conformance.Sinks(t, conformance.SinkSubject{
+		Integration: "sink.clickhouse",
+		New: func(t *testing.T) core.Sink {
+			s, err := NewClickhouseSink(config.ClickhouseSink{DSN: dsn, Table: table})
+			assert.NoError(t, err)
+			t.Cleanup(func() { s.Close() })
+			return s
+		},
+		Break: proxy.Break,
+		Heal:  proxy.Heal,
+		ReadBack: func(t *testing.T) []conformance.Row {
+			rows, err := direct.conn.Query(ctx, "SELECT id FROM "+table+" ORDER BY id")
+			assert.NoError(t, err)
+			defer rows.Close()
+			var out []conformance.Row
+			for rows.Next() {
+				var id int64
+				assert.NoError(t, rows.Scan(&id))
+				out = append(out, conformance.Row{"id": id})
+			}
+			assert.NoError(t, rows.Err())
+			return out
+		},
+		Table: func(t *testing.T, id int64) arrow.Table {
+			schema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+			b := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+			defer b.Release()
+			b.Field(0).(*array.Int64Builder).Append(id)
+			rec := b.NewRecord()
+			defer rec.Release()
+			return array.NewTableFromRecords(schema, []arrow.Record{rec})
+		},
+	})
+}
+
+// mustConnectionString is the container's HTTP endpoint on the host, for the
+// direct connection. The module's ConnectionString reports the native port;
+// the sink's dsn parser treats a clickhouse:// port as HTTP, so the mapped
+// 8123 is looked up by hand.
+func mustConnectionString(t *testing.T, ch *tcclickhouse.ClickHouseContainer) string {
+	t.Helper()
+	host, err := ch.Host(context.Background())
+	assert.NoError(t, err)
+	port, err := ch.MappedPort(context.Background(), "8123/tcp")
+	assert.NoError(t, err)
+	return fmt.Sprintf("clickhouse://%s:%s/default", host, port.Port())
+}
+```
+
+Add `"github.com/turbolytics/sql-flow/internal/core"` to the imports. If `ClickhouseSink` has no `Close` method, add one to `clickhouse.go`:
+
+```go
+// Close releases the connection. Buffered batches are dropped; a caller that
+// wants them delivered flushes first.
+func (s *ClickhouseSink) Close() error { return s.conn.Close() }
+```
+
+- [ ] **Step 2: Run it, expect a pass, and time it**
+
+Run: `time go test ./internal/sinks/ -run '^TestIntegrationSinkClickhouse_Conformance$' -v 2>&1 | tail -25`
+Expected: PASS, with these lines in the output:
+
+```
+=== RUN   TestIntegrationSinkClickhouse_Conformance/sink.flush.keeps_batch
+    conformance.go:NN: COVERS invariant=sink.flush.keeps_batch integration=sink.clickhouse
+--- PASS: TestIntegrationSinkClickhouse_Conformance
+```
+
+Expected wall time under 90s; the ClickHouse image pull is the bulk of it on a cold cache.
+
+If the broken `Flush` does not return within `flushTimeout`, the HTTP client is not honouring the context — that would itself be a finding against `sink.flush.honours_context`, and is reported by the harness's `t.Fatalf("... Break did not break it")` after 10s. Check the `timeout` toxic direction first (`downstream`), then the DSN really points at `proxy.Addr`.
+
+- [ ] **Step 3: Confirm `-short` skips before any container starts**
+
+Run: `go test -short ./internal/sinks/ -run '^TestIntegrationSinkClickhouse_Conformance$' -v 2>&1 | grep -E "SKIP|PASS|FAIL"`
+Expected: `--- SKIP: TestIntegrationSinkClickhouse_Conformance` in well under a second.
+
+- [ ] **Step 4: Run the whole integration pass as CI does**
+
+Run: `go test -json -run '^TestIntegration' ./... > .coverage/go-integration.json; grep -c '"Action":"fail"' .coverage/go-integration.json`
+Expected: `0`. The Kafka integration tests still pass alongside.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sinks/conformance_test.go internal/sinks/clickhouse.go
+git commit -m "sinks: ClickHouse is the first subject of the conformance harness
+
+A real server behind toxiproxy. The harness writes a row, hangs the
+connection, sees Flush fail, removes the hang, sees Flush succeed, and
+reads the row back from a direct connection that never crosses the
+fault. sink.flush.keeps_batch holds for ClickHouse, and the marker says
+so.
+
+Everything the harness needed from the integration is here: five
+functions and a DDL. A second sink supplies the same five and nothing
+else, which is the claim this commit exists to test.
+
+Evidence: passes in 41s locally with a warm image cache; -short skips
+before any container starts; the full integration pass reports no
+failure."
+```
+
+Replace `41s` with the measured time from Step 2.
+
+---
+
+### Task 8: Regenerate the matrix, and describe the new files where readers look
+
+**Files:**
+- Regenerate: `docs/coverage/matrix.json`, `docs/coverage/matrix.md`
+- Modify: `docs/coverage/features.yml:1-30` (the header comment, one pointer)
+- Modify: `README.md` Development section (one sentence)
+
+- [ ] **Step 1: Regenerate from a full run**
+
+Run: `SQLFLOW_CLICKHOUSE_DSN=clickhouse://127.0.0.1:1/default make coverage-matrix 2>&1 | tail -3`
+Expected: `wrote docs/coverage/matrix.json and docs/coverage/matrix.md`. The DSN override is needed only if a dev-stack ClickHouse is up on this machine; it keeps the seven skip-on-absent unit tests skipping, which is what CI sees.
+
+- [ ] **Step 2: Confirm the ClickHouse cell is covered and nothing else moved**
+
+Run:
+```bash
+uv run --locked python - <<'EOF'
+import json
+m = json.load(open("docs/coverage/matrix.json"))
+inv = next(i for i in m["invariants"] if i["id"] == "sink.flush.keeps_batch")
+for integ, levels in inv["integrations"].items():
+    print(f"{integ:18} {levels['integration']['status']}")
+print("gaps:", m["gaps"], m["invariant_gaps"])
+print("unattributed:", m["unattributed"])
+EOF
+```
+Expected:
+```
+sink.kafka         missing
+sink.clickhouse    covered
+sink.iceberg       missing
+sink.sqlcommand    exempt
+sink.console       exempt
+sink.noop          exempt
+gaps: [] []
+unattributed: {'unit': [], 'integration': [], 'release': []}
+```
+
+`unattributed.integration` must be empty: the conformance test attributes by marker, and Task 3's rule keeps it out of that list.
+
+- [ ] **Step 3: Run the gate**
+
+Run: `git add docs/coverage/ && SQLFLOW_CLICKHOUSE_DSN=clickhouse://127.0.0.1:1/default make coverage-check >/dev/null 2>&1; echo "exit=$?"`
+Expected: `exit=0`.
+
+- [ ] **Step 4: Point readers at the new registries**
+
+In `docs/coverage/features.yml`, after the line `# invents a feature.` (the end of the header comment), add:
+
+```yaml
+#
+# Invariants -- what every integration must hold -- are a separate axis.
+# See invariants.yml and integrations.yml beside this file.
+```
+
+In `README.md`, in the Development section, after the sentence ending `and no dependency is resolved at install time.`, add:
+
+```markdown
+`docs/coverage/matrix.md` is the coverage matrix: one table per feature, and
+one per invariant family. `internal/conformance` proves the invariants; a new
+sink or source supplies a subject and inherits the whole contract.
+```
+
+- [ ] **Step 5: Run everything once more**
+
+Run: `go build ./... && go vet ./... && go test -short ./... && uv run --locked pytest tests/tooling -q && git diff --exit-code docs/coverage/`
+Expected: every package `ok`, `69 passed`, and the last command silent (the regenerated matrix is what is staged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/coverage/ README.md
+git commit -m "coverage: the matrix carries its first proven invariant
+
+sink.flush.keeps_batch on sink.clickhouse is covered at integration
+level, by the harness, behind toxiproxy. Kafka and Iceberg are missing;
+console, noop and sqlcommand are exempt with reasons. No level is
+required, so nothing fails.
+
+That is the foundation working: a declared contract, one mechanism that
+proves it, and a matrix that says honestly which integrations have not
+been asked yet. The next commit adds the Kafka subject, watches it fail,
+and fixes the sink."
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Registries (Task 2), validation rules 1 and 2 (Tasks 2 and 4), structured marker (Task 1), harness with one sequence and one assertion (Task 5), `Proxy` with the `timeout` toxic (Task 6), the ClickHouse subject (Task 7), the second matrix axis with gaps and exempt cells (Task 3), the unattributed-report fix (Task 3), `Kinds()` agreement (Task 4), every `requires` empty (Task 2's test enforces it), no `types` blocks (Task 2). PR 2 and PR 3 are their own plans. The #210 page fields are listed under "After" in the spec and are not in this plan.
+
+**Placeholders.** Task 5 Step 3 contained a deliberately marked throwaway `itoa`; the replacement immediately follows and the plan says the first must not ship. No other TBDs.
+
+**Type consistency.** `parse_go` returns a 3-tuple everywhere after Task 1. `build_invariants(invariants, integrations, results, evidence)` and `snapshot_invariants(invariants, integrations, built)` match between Task 3's code and tests. `SinkSubject` has the same five fields plus `Table` in Task 5's definition, Task 5's tests and Task 7's subject. `Proxy.Break`/`Heal` take `*testing.T`, matching `SinkSubject.Break`/`Heal`. `coverage.Invariant` takes `testing.TB`; `*testing.T` satisfies it at every call site. `Kinds()` returns sorted bare names in all three packages, and `coverage.Integrations` returns the same form.

--- a/docs/superpowers/specs/2026-09-06-invariant-matrix-design.md
+++ b/docs/superpowers/specs/2026-09-06-invariant-matrix-design.md
@@ -1,0 +1,410 @@
+# Invariant matrix: design
+
+Every integration must prove the same base properties: a failed flush keeps
+its rows, a commit follows a flush, a value written is the value read back.
+Today that proof is uneven. ClickHouse has a test for "a failed flush keeps
+its batch"; Iceberg has the code and no test; the Kafka sink has neither and
+violates it. This design declares the invariants once, verifies each one the
+same way for every integration, and gates the build on the evidence.
+
+The mechanism is the one `features.yml` already uses: a declared registry, a
+generated matrix, and a gate that fails on a declared requirement with no
+evidence. It adds a second axis (invariant x integration) and a harness that
+produces most of the evidence, so a new integration inherits the whole
+contract by supplying a subject rather than by writing tests.
+
+## Why now
+
+The inventory that motivated this, counted on 2026-09-06:
+
+- 3 sources, 6 sinks plus the retry wrapper, 3 handlers.
+- Open issues add MQTT source and sink (#192-#196, #201), NATS (#139), SQS
+  (#62), Iceberg REST catalog with partitioning and rollover (#204-#208), and
+  three vendor catalogs to verify (#211-#213).
+- 7 data-integrity defects fixed since v1.0.4, each an invariant violated
+  once: arrays (#147), string escapes (#149), ClickHouse arrays (#150),
+  nested struct union (#151), timezone shift (#153), offsets committed ahead
+  of processing (#154), hollow retry success (#221).
+- The ClickHouse docs review (ClickHouse/ClickHouse#117740) found two more
+  that were documented wrong rather than coded wrong: NULL coerces to the
+  zero value and never evaluates DEFAULT; DateTime strings follow the server
+  timezone.
+- 137 tests carry invariant-shaped names, attributed per integration, not per
+  invariant. "A failed flush keeps its batch" is tested for ClickHouse only.
+
+Two defects the enumeration found, fixed by this work's first two PRs:
+
+- The Kafka sink produces every row in `WriteTable`, and `Flush` clears the
+  produce errors before returning them. Rows that failed are gone. A retry
+  succeeds with nothing to send: #221's defect, in the sink #221 did not
+  touch.
+- `Batch()` is not a contract. Console, Kafka, Iceberg and sqlcommand return
+  what they hold. ClickHouse returns nil while buffering in `s.tables`.
+
+## Decisions
+
+Made in the design conversation. Each one closes a fork.
+
+| Decision | Choice | Rejected |
+|---|---|---|
+| Primary consumer | The CI gate. Evidence is a test in this repo. The rendered page is a view of the same data and carries #210's fields. | A proof page whose evidence can be a link. |
+| Where an invariant attaches | By kind. Contract invariants attach to the `Sink` and `Source` interfaces and one harness verifies every implementation. Type invariants attach per integration through a declared table. | One harness for everything; named tests per integration. |
+| Type enumeration | Declare expected, derive actual, diff is the gate. | Derive only; declare only. |
+| Integration-level fault | toxiproxy. A `timeout` toxic hangs the connection, which is the partition #219 fixed for. | `docker pause`. |
+| `Reject` seam | Deferred. `sink.error.classifies` stays declared and unenforced until a second seam exists. | Two seams per integration in the first PR. |
+| Enforcement order | PR 2 fixes Kafka. PR 3 adds the Iceberg subject and flips the first `requires`. No temporary exemption. | Flip in PR 2 with Iceberg exempt. |
+
+## Invariants
+
+IDs are `family.subject.claim`. Each row is grounded: it has a test
+somewhere today, was violated once, or is named by an open issue.
+
+### Resilience: the sink contract
+
+Applies to every `core.Sink`. Verified by the harness at unit level (fake
+transport) and integration level (container behind toxiproxy).
+
+| id | Claim | State on 2026-09-06 |
+|---|---|---|
+| `sink.write.buffers_only` | `WriteTable` does not reach the destination. Only `Flush` does. | Kafka violates. |
+| `sink.flush.keeps_batch` | A failed `Flush` leaves every undelivered row buffered. The next `Flush` re-attempts them. | ClickHouse tested. Iceberg has `requeue`, untested. Kafka violates. |
+| `sink.flush.no_hollow_success` | `Flush` returns nil only when every row since the last success was acknowledged. | Kafka violates after the first failure. |
+| `sink.flush.preserves_order` | Rows reach the destination in `WriteTable` order, across a retry. | Iceberg requeues at head, untested. |
+| `sink.flush.honours_context` | `Flush` returns `ctx.Err()` when the context ends. Rows stay buffered. | Kafka tested (#219). Others unknown. |
+| `sink.flush.empty_is_noop` | `Flush` with nothing buffered returns nil and touches nothing. | Untested. |
+| `sink.batch.reports_buffer` | `Batch()` returns what is buffered, nil when empty. | ClickHouse violates. |
+| `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the ladder retries the right ones. | Ladder tested. Per-sink untested. |
+| `sink.probe.fails_start` | A `Prober` with an unreachable destination fails the start once, without retrying. | Tested at ladder level. |
+
+Console, noop and sqlcommand are exempt from `keeps_batch`,
+`honours_context`, `classifies` and `probe.fails_start`. Nothing crosses a
+network. `retriesHelp` in `internal/sinks/init.go` already encodes that rule.
+
+### Checkpoint: the pipeline and source contract
+
+| id | Claim | State |
+|---|---|---|
+| `pipeline.commit.after_flush` | Offsets and state commit only after `Flush` returned nil. | Tested in core. |
+| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing: not offsets, not state. | Tested in core. |
+| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | Tested as `state.durability`. |
+| `source.commit.only_processed` | A source commits the marks the pipeline processed, never what it fetched. | Kafka integration test (#154). |
+| `source.resume.from_committed` | Restart resumes at the committed position: no gap, no replay before it. | Kafka integration test. |
+| `source.marks.never_regress` | A committed position never moves backwards. | Tested at state level only. |
+
+Websocket and webhook have no replayable position. They are exempt from the
+`source.commit.*` and `source.resume.*` rows, and the exemption is the
+documented fact that they are at-most-once.
+
+### Types: per integration, from its declared table
+
+Verified by a generated round-trip: one row of every declared Arrow type,
+written through the real integration, read back through the integration's
+own reader, diffed against the declaration.
+
+| id | Claim |
+|---|---|
+| `type.roundtrip` | Every declared Arrow type reads back with the declared outcome: `exact`, `coerced` by the stated rule, or `unsupported` with a coded error. |
+| `type.null` | A null in every declared type reads back as declared. For ClickHouse that is the zero value, and the DEFAULT expression is not evaluated. |
+| `type.timestamp.instant` | A timestamp reads back as the same instant. Zone-less is UTC (#153). `TIMESTAMPTZ` does not leak the host zone into the type. DuckDB does that today: `timestamp[us, tz=America/New_York]`. |
+| `type.nested` | list, struct, list-of-struct and list-of-list read back or are declared unsupported. Never silently flattened. |
+| `type.string.fidelity` | Unicode, escapes and the empty string round-trip byte for byte (#149). |
+| `type.undeclared.fails_loud` | An Arrow type absent from the table fails the batch with a coded error. Never coerced silently. |
+
+The input boundary gets the same treatment. The inferred handler's JSON to
+Arrow table (string, integer, float, bool, null, array, object, and int to
+float promotion) is a declared table with JSON-shape keys, and
+`type.roundtrip` covers handlers as well as sinks.
+
+The type lattice is closed. DuckDB emits 26 distinct Arrow types across its
+33 SQL types (measured through the Python binding on 2026-09-06). A type key
+outside that set is a typo. A lattice type absent from an integration's table
+is a gap.
+
+### Lifecycle
+
+| id | Claim | State |
+|---|---|---|
+| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | Tested. |
+| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. | Planned, #161 and #182. |
+| `lifecycle.close.idempotent` | `Close` twice is safe on every source and sink. | Webhook only. |
+
+### Declared, not yet enforced
+
+An invariant may carry `tracked_by: "#NNN"` and `requires: []`. It renders
+as declared-unenforced and fails nothing until the issue lands and
+`requires` is filled. This is how the registry absorbs planned work without
+claiming it: `error.dlq.carries_provenance` (#166),
+`error.bad_record.threshold` (#166), `source.commit.on_revoke` (#183),
+`pipeline.batch.timeout` (#163).
+
+### Out of the list
+
+Throughput, memory and soak (#58, #170) are measurements, not invariants.
+Exactly-once is not claimed. The engine is at-least-once, and the list says
+so through `keeps_batch` plus `commit.after_flush`.
+
+## Registries
+
+Both live in `docs/coverage/` beside `features.yml`. Both are declared, not
+derived, for the reason that file gives: the failure this catches is an
+integration with no evidence at all. `features.yml` is unchanged.
+
+### `invariants.yml`: the contract
+
+```yaml
+invariants:
+  - id: sink.flush.keeps_batch
+    family: resilience
+    applies_to: sink              # sink | source | handler | pipeline
+    claim: >
+      A failed Flush leaves every undelivered row buffered; the next Flush
+      re-attempts them.
+    verified_by: harness          # harness | typetable | named
+    requires: [integration]       # empty in PR 1; PR 3 sets this
+    violated_once: ["#221"]
+
+  - id: source.commit.on_revoke
+    family: checkpoint
+    applies_to: source
+    claim: Marks commit when a partition is revoked, before the rebalance completes.
+    verified_by: harness
+    requires: []
+    tracked_by: "#183"
+```
+
+`verified_by` decides how evidence attaches:
+
+- `harness`: the conformance harness emits a structured marker when a case
+  passes. No naming convention. The harness knows what it ran.
+- `typetable`: the generated round-trip emits the same marker per
+  (integration, type). The invariant is covered only when every declared
+  type passed.
+- `named`: the `features.yml` mechanism, for the few that live in core.
+  `TestPipelineCommitAfterFlush_*` attributes by longest prefix.
+
+### `integrations.yml`: the surface
+
+One entry per case in `sinks.buildSink`, `sources.New` and the handler
+switch.
+
+```yaml
+integrations:
+  - id: sink.clickhouse
+    kind: sink
+    implements: [Sink, Prober]
+    feature: sink.clickhouse         # the features.yml id
+    exempt: []
+    types:                           # Arrow type -> declared outcome
+      int64:         exact
+      string:        exact
+      timestamp[us]: exact
+      "timestamp[us, tz=*]": {coerced: "stored as UTC instant; zone dropped"}
+      list<int64>:   exact
+      decimal128:    {unsupported: sink.clickhouse.type_unsupported}
+      struct:        {unsupported: sink.clickhouse.type_unsupported}
+    nulls:
+      default:       {coerced: "zero value of the column type; DEFAULT not evaluated"}
+      "Nullable(*)": exact
+
+  - id: sink.console
+    kind: sink
+    implements: [Sink]
+    feature: sink.console
+    exempt:
+      - invariant: sink.flush.keeps_batch
+        reason: nothing crosses a network; retriesHelp already excludes it
+      - invariant: sink.flush.honours_context
+        reason: same
+
+  - id: source.webhook
+    kind: source
+    implements: [Source]
+    feature: source.webhook
+    exempt:
+      - invariant: source.commit.only_processed
+        reason: no replayable position; at-most-once by construction
+```
+
+Type keys use Arrow's `DataType.String()` form, so a declaration matches
+what the runtime prints with no translation. `tz=*` and `Nullable(*)` are the
+only wildcards: the concrete zone and the column DDL are the test's choice.
+Handler entries use JSON-shape keys (`number.integer`, `number.float`,
+`string`, `bool`, `null`, `array<...>`, `object`).
+
+The generator validates the registries before any test result is read:
+
+1. Every constructor case is declared. `sinks.Kinds()` and `sources.Kinds()`
+   return the switch cases; a conformance test diffs them against the
+   registry. A new `case "mqtt":` without an entry fails `go test -short`.
+2. Every exemption names an invariant that exists and carries a reason.
+3. Every type key is in the lattice. Every lattice type is declared, or is a
+   gap.
+
+## Harness
+
+One package, `internal/conformance`. It knows the invariants and nothing
+about any integration. An integration supplies a subject.
+
+```go
+type SinkSubject struct {
+    Integration string                     // "sink.kafka"; the integrations.yml id
+    New         func(t *testing.T) core.Sink
+    Break       func(t *testing.T)         // the destination stops answering
+    Heal        func(t *testing.T)         // and comes back
+    ReadBack    func(t *testing.T) []Row   // what the destination holds, in order
+}
+
+func Sinks(t *testing.T, s SinkSubject)
+func Sources(t *testing.T, s SourceSubject)
+```
+
+`Row` is `map[string]any`, one per destination row, decoded by the subject
+through the destination's own reader: a ClickHouse query, an Iceberg scan, a
+Kafka consume from the earliest offset. The harness compares rows by value;
+it never inspects the sink.
+
+`Sinks` runs one sequence and asserts each claim as its own subtest, so each
+claim gets its own marker and its own cell:
+
+1. `WriteTable(A)`.
+2. `Break`. `Flush` must return an error.
+3. `Heal`. `Flush` must return nil.
+4. `ReadBack` must be `[A]`.
+
+That sequence proves `keeps_batch`. Adding `WriteTable(B)` between steps 2
+and 3 and asserting `[A, B]` proves `no_hollow_success` and
+`preserves_order`. `honours_context` is the same break with a cancelled
+context. `empty_is_noop` and `reports_buffer` are one call each. Every
+later invariant is another assertion on this sequence, not another
+sequence.
+
+On each passing subtest the harness calls:
+
+```go
+coverage.Invariant(t, "sink.flush.keeps_batch", s.Integration)
+// -> t.Logf("COVERS invariant=sink.flush.keeps_batch integration=sink.kafka")
+```
+
+and `coverage.Covers(t, s.Integration)` once, so `features.yml` credits the
+integration too. A test that carries any marker is excluded from the
+"unattributed" report.
+
+### Two levels, one harness
+
+| Level | `New` | `Break` / `Heal` | `ReadBack` |
+|---|---|---|---|
+| unit (`-short`) | the real sink over a fake transport | flip the fake | the fake's log |
+| integration | the real sink over a container behind toxiproxy | add / remove a `timeout` toxic | query the container |
+
+`conformance.Proxy(t, upstream)` wraps the testcontainers toxiproxy module
+and returns the proxy address plus `Break` and `Heal`. Every integration
+shares it. The `timeout` toxic hangs the connection rather than refusing it,
+because a hang is the partition #219 fixed for and the case
+`honours_context` needs.
+
+Unit level needs a seam per sink: the transport behind an interface.
+ClickHouse holds `driver.Conn`, already an interface. Kafka holds
+`*kgo.Client` and needs one with `Produce` and `Flush`. Iceberg holds
+`*table.Table` and needs one with `AppendTable`. Three seams, no behaviour
+change.
+
+### Kafka behind a proxy
+
+The testcontainers Kafka module advertises `localhost:<mapped port>`. A
+client that bootstraps through a proxy is told the broker's real address and
+reconnects around the proxy. The Kafka sink takes a `kgo.Dialer` option that
+rewrites the advertised address to the proxy at dial time. Host-side, no
+broker configuration, and it is the seam a unit-level fake uses.
+
+ClickHouse has no redirect. A DSN pointed at the proxy stays on it.
+
+### Exemptions
+
+A subject with nothing to break sets `Break: nil`. The harness skips the
+network-shaped invariants with `t.Skip`. A skip is not coverage, so the cell
+stays missing until `integrations.yml` carries the exemption with a reason.
+Two independent statements that must agree.
+
+## Generator and matrix
+
+`scripts/coverage_matrix.py` grows a second axis. It loads both registries,
+validates them, parses the structured markers from every suite report, and
+renders invariant x integration x level. A required level with no passing
+evidence for a non-exempt integration is a gap, and gaps fail
+`make coverage-check` exactly as feature gaps do.
+
+`matrix.json` gains an `invariants` section beside `features`. `matrix.md`
+gains one table per family. Exempt cells render as `—` with the reason on
+hover in the page; missing cells render as missing. Declared-unenforced
+invariants render with their `tracked_by` issue.
+
+The rendered page carries the fields #210 needs so that work adds evidence
+rather than a second registry: versions exercised (sqlflow, the integration
+client, the container image), the last green date per cell, and red rows
+that stay visible.
+
+## Rollout
+
+Three PRs. Each merges green.
+
+### PR 1: the foundation
+
+1. Both registries, fully declared. Every invariant carries `requires: []`.
+   No `types` blocks.
+2. `internal/conformance` with `SinkSubject`, `Sinks`, and `Proxy`. One
+   sequence, one assertion, one marker: `sink.flush.keeps_batch`.
+3. One subject: ClickHouse at integration level, DSN pointed at the proxy.
+   The existing `FailedFlushKeepsTheBatchBuffered` test shows the invariant
+   holds, so the cell goes green.
+4. `coverage.Invariant`, the marker parser, registry validation rules 1
+   and 2, `sinks.Kinds()` and the agreement test, the second matrix axis and
+   its rendering.
+
+On merge the matrix shows `sink.flush.keeps_batch`: ClickHouse covered,
+Kafka missing, Iceberg missing, console and noop and sqlcommand exempt.
+Nothing fails. A gate cannot turn on until every non-exempt integration has
+a subject, and Kafka's cannot pass until Kafka is fixed.
+
+### PR 2: Kafka
+
+Test first against the foundation. Add the Kafka subject with the dialer
+seam. Watch `keeps_batch` fail with the harness's message. Then fix the sink:
+
+- `WriteTable` buffers rows and produces nothing. That is `buffers_only`,
+  and what the retry wrapper already assumes.
+- `Flush` produces the buffer, waits on the context, and keeps every row
+  whose promise failed. Kept rows go to the head, in order, so a retry
+  re-sends those rows and nothing that was acknowledged.
+- `Batch()` returns the buffer.
+
+One fix satisfies `buffers_only`, `keeps_batch`, `no_hollow_success`,
+`preserves_order` and `reports_buffer`. `requires` stays empty.
+
+### PR 3: Iceberg, and the first enforced invariant
+
+Add the Iceberg subject. The SQL-catalog sink has no network to proxy;
+`Break` makes the warehouse directory read-only. Then flip
+`sink.flush.keeps_batch` to `requires: [integration]`. Every non-exempt sink
+has a subject, so the gate is legal, and from that commit a new sink cannot
+merge without proving it.
+
+### After
+
+Additive, in any order:
+
+- One assertion per new invariant on the existing sequence.
+- Unit-level fakes behind the three seams, then `requires: [unit, integration]`.
+- The `Sources` harness against the Kafka source.
+- The `Reject` seam, then `sink.error.classifies`.
+- The type table and its generator.
+- `matrix.md` grows the #210 fields.
+
+## Out of scope
+
+- Fixing the seven coverage-matrix findings from the 2026-09-06 review that
+  this design does not touch: the `sorted()` crash, the failing-test grep,
+  the double-counted integration tests, the covered-vs-gaps disagreement,
+  missing-report greps, and the ClickHouse skip-on-absent. The unattributed
+  report change is in scope because the harness depends on it.
+- Property-based or fuzzed inputs.
+- Any invariant the list marks planned.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.48.0
+	github.com/Shopify/toxiproxy/v2 v2.12.0
 	github.com/apache/arrow-adbc/go/adbc v1.6.0
 	github.com/apache/arrow-go/v18 v18.6.0
 	github.com/apache/iceberg-go v0.6.0
@@ -14,7 +15,9 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/spf13/cobra v1.10.2
+	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0
+	github.com/testcontainers/testcontainers-go/modules/toxiproxy v0.44.0
 	github.com/twmb/franz-go v1.20.7
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0
 	github.com/zeebo/assert v1.3.0
@@ -115,7 +118,6 @@ require (
 	github.com/substrait-io/substrait v0.87.0 // indirect
 	github.com/substrait-io/substrait-go/v8 v8.1.0 // indirect
 	github.com/substrait-io/substrait-protobuf/go v0.85.0 // indirect
-	github.com/testcontainers/testcontainers-go v0.44.0 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/testcontainers/testcontainers-go v0.44.0
+	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/toxiproxy v0.44.0
 	github.com/twmb/franz-go v1.20.7

--- a/go.sum
+++ b/go.sum
@@ -502,6 +502,8 @@ github.com/substrait-io/substrait-protobuf/go v0.85.0 h1:zk6MtNWLtDSl8a7qCZRFH0+
 github.com/substrait-io/substrait-protobuf/go v0.85.0/go.mod h1:hn+Szm1NmZZc91FwWK9EXD/lmuGBSRTJ5IvHhlG1YnQ=
 github.com/testcontainers/testcontainers-go v0.44.0 h1:/Fwh6HY1mIikhnm9e7HwoxGycx0lzRAE0f5VQpjFxzI=
 github.com/testcontainers/testcontainers-go v0.44.0/go.mod h1:IcnwQrYTO86xHXu5bvMaBH7ATlbS3Qn1M1QWW3c66rE=
+github.com/testcontainers/testcontainers-go/modules/clickhouse v0.44.0 h1:TOkNKu7FrJIfozRhcRM3iVURfb32Aw/CIuh1lXrDFjw=
+github.com/testcontainers/testcontainers-go/modules/clickhouse v0.44.0/go.mod h1:/9m3N7gu2ErXf7bUdK/u6KY0X19gRrWZjiDtqmctlhI=
 github.com/testcontainers/testcontainers-go/modules/compose v0.42.0 h1:+t1ZN31TD36cwxmeLqGwe7wIdvblBm0Z+vlj4SX8Mv0=
 github.com/testcontainers/testcontainers-go/modules/compose v0.42.0/go.mod h1:CfMpouDHqNTCHC8CijEURU2ZotTV3QhH6pXd48s6ofk=
 github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0 h1:KOyj22XaB0X2RsyQKQKthzcWObKtni0kLrV1HqFVeec=

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/MarvinJWendt/testza v0.5.2 h1:53KDo64C1z/h/d/stCYCPY69bt/OSwjq5KpFNwi
 github.com/MarvinJWendt/testza v0.5.2/go.mod h1:xu53QFE5sCdjtMCKk8YMQ2MnymimEctc4n3EjyIYvEY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/Shopify/toxiproxy/v2 v2.12.0 h1:d1x++lYZg/zijXPPcv7PH0MvHMzEI5aX/YuUi/Sw+yg=
+github.com/Shopify/toxiproxy/v2 v2.12.0/go.mod h1:R9Z38Pw6k2cGZWXHe7tbxjGW9azmY1KbDQJ1kd+h7Tk=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
@@ -178,6 +180,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
@@ -235,6 +239,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
+github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
@@ -351,6 +357,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
 github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
+github.com/mdelapenya/tlscert v0.2.0/go.mod h1:O4njj3ELLnJjGdkN7M/vIVCpZ+Cf0L6muqOG4tLSl8o=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/moby/buildkit v0.29.0 h1:wxLEFbCOJntEDjSNNN2YWd8zxltZxT5muDQ0LzpbtpU=
@@ -498,6 +506,10 @@ github.com/testcontainers/testcontainers-go/modules/compose v0.42.0 h1:+t1ZN31TD
 github.com/testcontainers/testcontainers-go/modules/compose v0.42.0/go.mod h1:CfMpouDHqNTCHC8CijEURU2ZotTV3QhH6pXd48s6ofk=
 github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0 h1:KOyj22XaB0X2RsyQKQKthzcWObKtni0kLrV1HqFVeec=
 github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0/go.mod h1:OP4szEj4BpOH/UZhbtNER1ERRSj4YJ6hu2x+FIBdo5o=
+github.com/testcontainers/testcontainers-go/modules/redis v0.44.0 h1:43EH7N6yB5B2tY/9uhPit487tMLm5iQiyKQaXWXNbnk=
+github.com/testcontainers/testcontainers-go/modules/redis v0.44.0/go.mod h1:k4nnCSzm3z8yRMBKBn3rhsllbFjjhVn/2JjWNxxArg8=
+github.com/testcontainers/testcontainers-go/modules/toxiproxy v0.44.0 h1:wVCjSYUKDa9pYZxgGTwF9mIeFkw9VcLgrb5/EaFwp7Y=
+github.com/testcontainers/testcontainers-go/modules/toxiproxy v0.44.0/go.mod h1:blD6NiH8vhxWbcDBMiWQAWTQoZZFzwKV6NeBlncuIG8=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 h1:QB54BJwA6x8QU9nHY3xJSZR2kX9bgpZekRKGkLTmEXA=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375/go.mod h1:xRroudyp5iVtxKqZCrA6n2TLFRBf8bmnjr1UD4x+z7g=
 github.com/tklauser/go-sysconf v0.4.0 h1:7H0uAN+7RkwWRaxhYXDLqa5V3LPrJeV8wmD9dRUgPQU=

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -1,0 +1,228 @@
+// Package conformance proves the invariants every integration must hold.
+//
+// It knows the invariants and nothing about any integration. An integration
+// supplies a subject: how to build it, how to make its destination stop
+// answering, how to bring it back, and how to read what it delivered. The
+// harness runs one sequence and judges each invariant separately, so each
+// gets its own subtest, its own marker, and its own cell in the matrix.
+//
+// Evidence is emitted, not inferred. A passing subtest logs
+//
+//	COVERS invariant=<id> integration=<id>
+//
+// which the coverage generator reads out of `go test -json` output. Test
+// names carry nothing here, because the same code proves the same invariant
+// for every integration and only the marker knows which one this run was.
+//
+// Invariants are declared in docs/coverage/invariants.yml. Adding one here
+// without declaring it there reports as an unknown marker rather than as a
+// cell.
+package conformance
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+)
+
+// Row is one row the destination holds, decoded by the subject through the
+// destination's own reader. The harness compares rows by their "id" value
+// only: what other columns a row carries is the destination's business.
+type Row map[string]any
+
+// SinkSubject is what an integration hands the harness.
+type SinkSubject struct {
+	// Integration is the integrations.yml id, e.g. "sink.clickhouse".
+	Integration string
+
+	// New builds the sink under test. Called once per sequence.
+	New func(t *testing.T) core.Sink
+
+	// Break makes the destination stop answering.
+	//
+	// Nil means the integration has nothing that can break, and the
+	// network-shaped invariants are skipped. integrations.yml must then
+	// exempt it with a reason, or the cell stays missing: the harness
+	// skipping and the registry excusing are two statements that must agree.
+	Break func(t *testing.T)
+
+	// Heal reverses Break.
+	Heal func(t *testing.T)
+
+	// ReadBack returns every row the destination holds, in delivery order.
+	// It must not go through whatever Break breaks.
+	ReadBack func(t *testing.T) []Row
+
+	// Table returns a one-row table with an int64 "id" column that the
+	// destination accepts. The subject owns the schema because a ClickHouse
+	// table has the columns its DDL declared, and the harness has no DDL.
+	Table func(t *testing.T, id int64) arrow.Table
+}
+
+// flushTimeout bounds a Flush against a broken destination. A sink that hangs
+// must fail this test rather than the suite.
+const flushTimeout = 10 * time.Second
+
+// Sinks proves every sink invariant the subject can exercise.
+func Sinks(t *testing.T, s SinkSubject) {
+	t.Helper()
+	requireSubject(t, s)
+
+	for _, v := range sinkVerdicts(t, s) {
+		t.Run(v.invariant, func(t *testing.T) {
+			if v.skipped != "" {
+				t.Skip(v.skipped)
+			}
+			if v.failure != "" {
+				t.Fatal(v.failure)
+			}
+			coverage.Invariant(t, v.invariant, s.Integration)
+		})
+	}
+
+	// The feature axis credits the integration too, so a conformance run is
+	// not invisible to features.yml.
+	coverage.Covers(t, s.Integration)
+}
+
+func requireSubject(t *testing.T, s SinkSubject) {
+	t.Helper()
+	if s.Integration == "" {
+		t.Fatal("conformance: SinkSubject.Integration is required")
+	}
+	if s.New == nil || s.ReadBack == nil || s.Table == nil {
+		t.Fatalf("conformance: %s needs New, ReadBack and Table", s.Integration)
+	}
+	if (s.Break == nil) != (s.Heal == nil) {
+		t.Fatalf("conformance: %s supplies one of Break and Heal; a fault that "+
+			"cannot be reversed leaves the destination broken for the rest of "+
+			"the run", s.Integration)
+	}
+}
+
+// verdict is one invariant's outcome.
+//
+// Separated from the subtest that reports it so the harness's own tests can
+// run it against a sink with a known defect and assert that it is caught,
+// without themselves failing.
+type verdict struct {
+	invariant string
+	failure   string // non-empty: the invariant does not hold
+	skipped   string // non-empty: the subject cannot exercise it
+}
+
+const (
+	buffersOnly = "sink.write.buffers_only"
+	keepsBatch  = "sink.flush.keeps_batch"
+)
+
+// sinkVerdicts runs one sequence and judges two invariants from it.
+//
+//  1. WriteTable(A). The destination must still be empty -- buffers_only.
+//  2. Break, then Flush must fail. The destination must still be empty:
+//     rows that could not be delivered were kept, not sent.
+//  3. Heal, then Flush must succeed.
+//  4. The destination must hold exactly A, once -- keeps_batch.
+//
+// The two are separate because a sink can hold either without the other, and
+// the pair is what the pipeline actually depends on. A sink that delivers in
+// WriteTable passes step 4 for the wrong reason: the row reached the
+// destination before the fault, so nothing was ever kept, and the failed
+// flush left the pipeline unable to commit offsets for rows that did go out.
+// That is the Kafka sink's shape, and step 1 is what catches it.
+//
+// A sink that discards its buffer on a failed flush passes steps 1 and 2 and
+// holds nothing at step 4, which is the defect #221 fixed for ClickHouse.
+func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
+	t.Helper()
+
+	if s.Break == nil {
+		skip := "the subject has nothing to break; exempt " +
+			s.Integration + " in integrations.yml"
+		return []verdict{
+			{invariant: buffersOnly, skipped: skip},
+			{invariant: keepsBatch, skipped: skip},
+		}
+	}
+
+	sink := s.New(t)
+	row := s.Table(t, 1)
+	defer row.Release()
+
+	ctx := context.Background()
+	if err := sink.WriteTable(ctx, row); err != nil {
+		t.Fatalf("conformance: WriteTable before any fault: %v", err)
+	}
+
+	// Judged before anything can go wrong, so a write-through sink is named
+	// for what it did rather than for a downstream symptom.
+	buffers := verdict{invariant: buffersOnly}
+	if got := s.ReadBack(t); len(got) != 0 {
+		buffers.failure = "the destination holds " + describe(got) +
+			" after WriteTable and before any Flush; only Flush may deliver, " +
+			"because the pipeline commits offsets on what Flush reports"
+	}
+
+	s.Break(t)
+	broken, cancel := context.WithTimeout(ctx, flushTimeout)
+	err := sink.Flush(broken)
+	cancel()
+	if err == nil {
+		// Not a verdict: a flush that succeeds into a broken destination
+		// proves nothing, because the fault never took. That is the subject's
+		// bug, not the sink's, and blaming the sink sends the reader to the
+		// wrong file.
+		t.Fatalf("conformance: Flush succeeded while the destination was "+
+			"broken, so %s's Break did not break it", s.Integration)
+	}
+
+	keeps := verdict{invariant: keepsBatch}
+	if got := s.ReadBack(t); len(got) != 0 {
+		keeps.failure = "the destination holds " + describe(got) +
+			" after a Flush that failed; a row the sink could not deliver " +
+			"must stay buffered rather than reach the destination unreported"
+	}
+
+	s.Heal(t)
+	if err := sink.Flush(ctx); err != nil {
+		if keeps.failure == "" {
+			keeps.failure = "Flush after Heal failed with " + err.Error() +
+				"; the retry did not deliver what the failed flush kept"
+		}
+		return []verdict{buffers, keeps}
+	}
+
+	got := s.ReadBack(t)
+	if keeps.failure == "" && (len(got) != 1 || got[0]["id"] != int64(1)) {
+		keeps.failure = "after a failed Flush and a successful retry the " +
+			"destination holds " + describe(got) +
+			"; want exactly the row the failed flush could not deliver"
+	}
+	return []verdict{buffers, keeps}
+}
+
+func describe(rows []Row) string {
+	if len(rows) == 0 {
+		return "no rows"
+	}
+	out := "rows ["
+	for i, row := range rows {
+		if i > 0 {
+			out += ", "
+		}
+		out += "id=" + format(row["id"])
+	}
+	return out + "]"
+}
+
+func format(v any) string {
+	if n, ok := v.(int64); ok {
+		return strconv.FormatInt(n, 10)
+	}
+	return "?"
+}

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -1,0 +1,351 @@
+package conformance
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// The harness is a gate on every integration, so a harness that passes a
+// broken sink is worse than no harness. These tests run it against sinks
+// whose behaviour is known: one that honours the contract, and several that
+// break it in the ways real sinks have.
+
+func TestConformanceSinks_ACorrectSinkPasses(t *testing.T) {
+	Sinks(t, subject(newMemSink()))
+}
+
+// #221's defect: a failed Flush discards the buffer, so the retry finds
+// nothing to send and reports a success that delivered no rows.
+func TestConformanceSinks_ASinkThatDropsItsBatchIsCaught(t *testing.T) {
+	v := verdicts(t, subject(&dropSink{memSink: newMemSink()}))[keepsBatch]
+
+	assert.True(t, v.failure != "")
+	assert.True(t, strings.Contains(v.failure, "no rows"))
+}
+
+// A sink that delivers on WriteTable rather than on Flush: the Kafka sink's
+// shape today. It reaches the destination before the fault, so a read-back
+// after the retry finds the row and every downstream check passes for the
+// wrong reason. Only a read-back before the first Flush catches it.
+func TestConformanceSinks_ASinkThatWritesThroughIsCaught(t *testing.T) {
+	vs := verdicts(t, subject(&writeThroughSink{memSink: newMemSink()}))
+
+	assert.True(t, vs[buffersOnly].failure != "")
+	assert.True(t, strings.Contains(vs[buffersOnly].failure, "before any Flush"))
+
+	// And it is named for what it did, not for a downstream symptom.
+	assert.True(t, vs[keepsBatch].failure != "")
+	assert.True(t, strings.Contains(vs[keepsBatch].failure, "Flush that failed"))
+}
+
+// The two invariants are independent: a sink can buffer correctly and still
+// lose the batch, and the matrix must show which one broke.
+func TestConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
+	vs := verdicts(t, subject(&dropSink{memSink: newMemSink()}))
+
+	assert.Equal(t, "", vs[buffersOnly].failure)
+	assert.True(t, vs[keepsBatch].failure != "")
+}
+
+// A sink that keeps the batch but never clears it delivers the row twice.
+func TestConformanceSinks_ASinkThatDeliversTwiceIsCaught(t *testing.T) {
+	v := verdicts(t, subject(&neverClearSink{memSink: newMemSink()}))[keepsBatch]
+
+	assert.True(t, strings.Contains(v.failure, "id=1, id=1"))
+}
+
+// A retry that fails is not the same defect, and the message must not blame
+// the buffer for it.
+func TestConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
+	v := verdicts(t, subject(&staysDownSink{memSink: newMemSink()}))[keepsBatch]
+
+	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
+}
+
+func TestConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.T) {
+	s := subject(newMemSink())
+	s.Break, s.Heal = nil, nil
+
+	vs := verdicts(t, s)
+	for _, id := range []string{buffersOnly, keepsBatch} {
+		assert.True(t, vs[id].skipped != "")
+		assert.True(t, strings.Contains(vs[id].skipped, "integrations.yml"))
+		assert.Equal(t, "", vs[id].failure)
+	}
+}
+
+// A skip is not coverage, so a skipped verdict must not emit a marker. The
+// matrix would otherwise read a subject that exercises nothing as covered,
+// which is the sink.iceberg failure.
+func TestConformanceSinks_ASkippedVerdictEmitsNoMarker(t *testing.T) {
+	s := subject(newMemSink())
+	s.Break, s.Heal = nil, nil
+
+	for _, v := range sinkVerdicts(t, s) {
+		assert.Equal(t, "", v.failure)
+		assert.True(t, v.skipped != "")
+	}
+}
+
+func TestConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected(t *testing.T) {
+	s := subject(newMemSink())
+	s.Integration = ""
+
+	assert.True(t, fatals(t, func(t *testing.T) { requireSubject(t, s) }))
+}
+
+// Break without Heal would leave the destination broken for whatever runs
+// next, which is a fault the next subject cannot explain.
+func TestConformanceSinks_ASubjectWithBreakAndNoHealIsRejected(t *testing.T) {
+	s := subject(newMemSink())
+	s.Heal = nil
+
+	assert.True(t, fatals(t, func(t *testing.T) { requireSubject(t, s) }))
+}
+
+func TestConformanceSinks_ASubjectMissingReadBackIsRejected(t *testing.T) {
+	s := subject(newMemSink())
+	s.ReadBack = nil
+
+	assert.True(t, fatals(t, func(t *testing.T) { requireSubject(t, s) }))
+}
+
+// The harness must not report a sink defect when the subject's own fault
+// injection did nothing: that sends the reader to the wrong file.
+func TestConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink(t *testing.T) {
+	s := subject(newMemSink())
+	s.Break = func(*testing.T) {} // does nothing
+	s.Heal = func(*testing.T) {}
+
+	assert.True(t, fatals(t, func(t *testing.T) { sinkVerdicts(t, s) }))
+}
+
+func TestConformanceDescribe_NamesTheRowsItFound(t *testing.T) {
+	assert.Equal(t, "no rows", describe(nil))
+	assert.Equal(t, "rows [id=1]", describe([]Row{{"id": int64(1)}}))
+	assert.Equal(t, "rows [id=1, id=2]",
+		describe([]Row{{"id": int64(1)}, {"id": int64(2)}}))
+}
+
+// --- Test doubles ----------------------------------------------------------
+
+// memSink is the smallest sink that honours the contract: it buffers on
+// WriteTable, delivers on Flush, and keeps what it could not deliver.
+type memSink struct {
+	mu        sync.Mutex
+	down      bool
+	buffered  []arrow.Table
+	delivered []int64
+}
+
+func newMemSink() *memSink { return &memSink{} }
+
+func (m *memSink) WriteTable(_ context.Context, t arrow.Table) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t.Retain()
+	m.buffered = append(m.buffered, t)
+	return nil
+}
+
+func (m *memSink) Flush(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.down {
+		return errors.New("destination unreachable")
+	}
+	for _, t := range m.buffered {
+		m.delivered = append(m.delivered, ids(t)...)
+		t.Release()
+	}
+	m.buffered = nil
+	return nil
+}
+
+func (m *memSink) Batch() (arrow.Table, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.buffered) == 0 {
+		return nil, nil
+	}
+	return m.buffered[0], nil
+}
+
+func (m *memSink) set(down bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.down = down
+}
+
+func (m *memSink) rows() []Row {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Row, 0, len(m.delivered))
+	for _, id := range m.delivered {
+		out = append(out, Row{"id": id})
+	}
+	return out
+}
+
+// dropSink discards its buffer when the flush fails.
+type dropSink struct{ *memSink }
+
+func (d *dropSink) Flush(ctx context.Context) error {
+	d.mu.Lock()
+	if d.down {
+		for _, t := range d.buffered {
+			t.Release()
+		}
+		d.buffered = nil
+	}
+	d.mu.Unlock()
+	return d.memSink.Flush(ctx)
+}
+
+// writeThroughSink delivers on WriteTable, so a fault at flush time can never
+// hold anything back.
+type writeThroughSink struct{ *memSink }
+
+func (w *writeThroughSink) WriteTable(_ context.Context, t arrow.Table) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.delivered = append(w.delivered, ids(t)...)
+	return nil
+}
+
+func (w *writeThroughSink) Flush(context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.down {
+		return errors.New("destination unreachable")
+	}
+	return nil
+}
+
+// neverClearSink keeps its buffer even after a successful flush.
+type neverClearSink struct{ *memSink }
+
+func (n *neverClearSink) Flush(context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.down {
+		return errors.New("destination unreachable")
+	}
+	for _, t := range n.buffered {
+		n.delivered = append(n.delivered, ids(t)...)
+	}
+	// The buffer is not cleared, so the next flush delivers it again. One
+	// flush here, one from the harness's retry: two copies.
+	n.delivered = append(n.delivered, n.delivered...)
+	return nil
+}
+
+// staysDownSink never recovers, so the retry fails rather than delivering.
+type staysDownSink struct{ *memSink }
+
+func (s *staysDownSink) Flush(context.Context) error {
+	return errors.New("destination unreachable")
+}
+
+// --- Helpers ---------------------------------------------------------------
+
+type breakable interface {
+	core.Sink
+	set(down bool)
+	rows() []Row
+}
+
+func subject(sink breakable) SinkSubject {
+	return SinkSubject{
+		Integration: "sink.clickhouse", // a declared id, so markers resolve
+		New:         func(*testing.T) core.Sink { return sink },
+		Break:       func(*testing.T) { sink.set(true) },
+		Heal:        func(*testing.T) { sink.set(false) },
+		ReadBack:    func(*testing.T) []Row { return sink.rows() },
+		Table:       oneRow,
+	}
+}
+
+// verdicts runs the harness and returns its judgements keyed by invariant,
+// so a test asserts on the one it means rather than on a position.
+func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
+	t.Helper()
+
+	out := map[string]verdict{}
+	for _, v := range sinkVerdicts(t, s) {
+		out[v.invariant] = v
+	}
+	assert.Equal(t, 2, len(out))
+	return out
+}
+
+// Every invariant the harness judges must be declared, or its marker reports
+// as unknown and the cell never appears.
+func TestConformanceSinks_JudgesOnlyDeclaredInvariants(t *testing.T) {
+	declared, err := coverage.Invariants()
+	assert.NoError(t, err)
+
+	for _, v := range sinkVerdicts(t, subject(newMemSink())) {
+		assert.True(t, declared[v.invariant])
+	}
+}
+
+// fatals reports whether fn called Fatal on its *testing.T. A t.Fatal runs
+// runtime.Goexit, so fn runs on its own goroutine and the deferred flag says
+// whether it returned normally.
+func fatals(t *testing.T, fn func(*testing.T)) bool {
+	t.Helper()
+
+	var (
+		done      = make(chan struct{})
+		completed bool
+	)
+	go func() {
+		defer close(done)
+		// A synthetic *testing.T: fn's Fatal marks it failed and exits the
+		// goroutine without touching the parent's verdict.
+		inner := &testing.T{}
+		defer func() { recover() }()
+		fn(inner)
+		completed = true
+	}()
+	<-done
+	return !completed
+}
+
+func ids(t arrow.Table) []int64 {
+	var out []int64
+	for _, chunk := range t.Column(0).Data().Chunks() {
+		arr := chunk.(*array.Int64)
+		for i := 0; i < arr.Len(); i++ {
+			out = append(out, arr.Value(i))
+		}
+	}
+	return out
+}
+
+func oneRow(t *testing.T, id int64) arrow.Table {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	b := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer b.Release()
+	b.Field(0).(*array.Int64Builder).Append(id)
+
+	rec := b.NewRecord()
+	defer rec.Release()
+	return array.NewTableFromRecords(schema, []arrow.Record{rec})
+}

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -20,13 +20,13 @@ import (
 // whose behaviour is known: one that honours the contract, and several that
 // break it in the ways real sinks have.
 
-func TestConformanceSinks_ACorrectSinkPasses(t *testing.T) {
+func TestToolingConformanceSinks_ACorrectSinkPasses(t *testing.T) {
 	Sinks(t, subject(newMemSink()))
 }
 
 // #221's defect: a failed Flush discards the buffer, so the retry finds
 // nothing to send and reports a success that delivered no rows.
-func TestConformanceSinks_ASinkThatDropsItsBatchIsCaught(t *testing.T) {
+func TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught(t *testing.T) {
 	v := verdicts(t, subject(&dropSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, v.failure != "")
@@ -37,7 +37,7 @@ func TestConformanceSinks_ASinkThatDropsItsBatchIsCaught(t *testing.T) {
 // shape today. It reaches the destination before the fault, so a read-back
 // after the retry finds the row and every downstream check passes for the
 // wrong reason. Only a read-back before the first Flush catches it.
-func TestConformanceSinks_ASinkThatWritesThroughIsCaught(t *testing.T) {
+func TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught(t *testing.T) {
 	vs := verdicts(t, subject(&writeThroughSink{memSink: newMemSink()}))
 
 	assert.True(t, vs[buffersOnly].failure != "")
@@ -50,7 +50,7 @@ func TestConformanceSinks_ASinkThatWritesThroughIsCaught(t *testing.T) {
 
 // The two invariants are independent: a sink can buffer correctly and still
 // lose the batch, and the matrix must show which one broke.
-func TestConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
+func TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
 	vs := verdicts(t, subject(&dropSink{memSink: newMemSink()}))
 
 	assert.Equal(t, "", vs[buffersOnly].failure)
@@ -58,7 +58,7 @@ func TestConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
 }
 
 // A sink that keeps the batch but never clears it delivers the row twice.
-func TestConformanceSinks_ASinkThatDeliversTwiceIsCaught(t *testing.T) {
+func TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught(t *testing.T) {
 	v := verdicts(t, subject(&neverClearSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, strings.Contains(v.failure, "id=1, id=1"))
@@ -66,13 +66,13 @@ func TestConformanceSinks_ASinkThatDeliversTwiceIsCaught(t *testing.T) {
 
 // A retry that fails is not the same defect, and the message must not blame
 // the buffer for it.
-func TestConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
+func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
 	v := verdicts(t, subject(&staysDownSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
 }
 
-func TestConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.T) {
+func TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.T) {
 	s := subject(newMemSink())
 	s.Break, s.Heal = nil, nil
 
@@ -87,7 +87,7 @@ func TestConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.T) {
 // A skip is not coverage, so a skipped verdict must not emit a marker. The
 // matrix would otherwise read a subject that exercises nothing as covered,
 // which is the sink.iceberg failure.
-func TestConformanceSinks_ASkippedVerdictEmitsNoMarker(t *testing.T) {
+func TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker(t *testing.T) {
 	s := subject(newMemSink())
 	s.Break, s.Heal = nil, nil
 
@@ -97,7 +97,7 @@ func TestConformanceSinks_ASkippedVerdictEmitsNoMarker(t *testing.T) {
 	}
 }
 
-func TestConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected(t *testing.T) {
+func TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected(t *testing.T) {
 	s := subject(newMemSink())
 	s.Integration = ""
 
@@ -106,14 +106,14 @@ func TestConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected(t *testing.T)
 
 // Break without Heal would leave the destination broken for whatever runs
 // next, which is a fault the next subject cannot explain.
-func TestConformanceSinks_ASubjectWithBreakAndNoHealIsRejected(t *testing.T) {
+func TestToolingConformanceSinks_ASubjectWithBreakAndNoHealIsRejected(t *testing.T) {
 	s := subject(newMemSink())
 	s.Heal = nil
 
 	assert.True(t, fatals(t, func(t *testing.T) { requireSubject(t, s) }))
 }
 
-func TestConformanceSinks_ASubjectMissingReadBackIsRejected(t *testing.T) {
+func TestToolingConformanceSinks_ASubjectMissingReadBackIsRejected(t *testing.T) {
 	s := subject(newMemSink())
 	s.ReadBack = nil
 
@@ -122,7 +122,7 @@ func TestConformanceSinks_ASubjectMissingReadBackIsRejected(t *testing.T) {
 
 // The harness must not report a sink defect when the subject's own fault
 // injection did nothing: that sends the reader to the wrong file.
-func TestConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink(t *testing.T) {
+func TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink(t *testing.T) {
 	s := subject(newMemSink())
 	s.Break = func(*testing.T) {} // does nothing
 	s.Heal = func(*testing.T) {}
@@ -130,7 +130,7 @@ func TestConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink(t *tes
 	assert.True(t, fatals(t, func(t *testing.T) { sinkVerdicts(t, s) }))
 }
 
-func TestConformanceDescribe_NamesTheRowsItFound(t *testing.T) {
+func TestToolingConformanceDescribe_NamesTheRowsItFound(t *testing.T) {
 	assert.Equal(t, "no rows", describe(nil))
 	assert.Equal(t, "rows [id=1]", describe([]Row{{"id": int64(1)}}))
 	assert.Equal(t, "rows [id=1, id=2]",
@@ -267,7 +267,12 @@ type breakable interface {
 
 func subject(sink breakable) SinkSubject {
 	return SinkSubject{
-		Integration: "sink.clickhouse", // a declared id, so markers resolve
+		// sink.noop, not a sink with a real destination. These tests run in
+		// the unit pass against an in-memory fake, and the marker Sinks emits
+		// must not credit a sink this never touched. noop is exempt from both
+		// invariants, so the marker lands on an exempt cell and changes
+		// nothing -- which is what a fake proving nothing should do.
+		Integration: "sink.noop",
 		New:         func(*testing.T) core.Sink { return sink },
 		Break:       func(*testing.T) { sink.set(true) },
 		Heal:        func(*testing.T) { sink.set(false) },
@@ -291,7 +296,7 @@ func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
 
 // Every invariant the harness judges must be declared, or its marker reports
 // as unknown and the cell never appears.
-func TestConformanceSinks_JudgesOnlyDeclaredInvariants(t *testing.T) {
+func TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants(t *testing.T) {
 	declared, err := coverage.Invariants()
 	assert.NoError(t, err)
 

--- a/internal/conformance/proxy.go
+++ b/internal/conformance/proxy.go
@@ -1,0 +1,102 @@
+package conformance
+
+import (
+	"context"
+	"testing"
+
+	toxiclient "github.com/Shopify/toxiproxy/v2/client"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/toxiproxy"
+	"github.com/testcontainers/testcontainers-go/network"
+)
+
+// toxiproxyImage is pinned so a proxy upgrade is a commit rather than a
+// Tuesday.
+const toxiproxyImage = "ghcr.io/shopify/toxiproxy:2.12.0"
+
+const (
+	// proxyName is the single proxy each container carries.
+	proxyName = "upstream"
+	// proxyPort is the port the module assigns the first proxy.
+	proxyPort = 8666
+	// toxicName is the hang Break installs and Heal removes.
+	toxicName = "hang"
+)
+
+// Proxy is a toxiproxy container between a sink and its destination.
+//
+// Break adds a timeout toxic, which holds every connection open and never
+// answers. That is a partition rather than a refusal, and the distinction
+// matters: a refused connection returns immediately, while a hang is what
+// #219 fixed the Kafka sink for and what sink.flush.honours_context will
+// need. A sink that ignores its context hangs here rather than passing
+// quietly.
+type Proxy struct {
+	// Addr is the host:port a sink dials instead of the destination.
+	Addr string
+
+	client *toxiclient.Client
+}
+
+// NewProxy starts toxiproxy on nw, forwarding to upstream.
+//
+// upstream is "<alias>:<port>" of a container already on nw, not a host port:
+// the proxy dials it from inside the docker network. The container is
+// terminated when the test ends.
+func NewProxy(t *testing.T, nw *testcontainers.DockerNetwork, upstream string) *Proxy {
+	t.Helper()
+	ctx := context.Background()
+
+	ctr, err := toxiproxy.Run(ctx, toxiproxyImage,
+		network.WithNetwork([]string{"toxiproxy"}, nw),
+		toxiproxy.WithProxy(proxyName, upstream),
+	)
+	if err != nil {
+		t.Fatalf("conformance: start toxiproxy: %v", err)
+	}
+	t.Cleanup(func() {
+		// Teardown must not change the verdict: the test has already run.
+		_ = ctr.Terminate(context.Background())
+	})
+
+	host, port, err := ctr.ProxiedEndpoint(proxyPort)
+	if err != nil {
+		t.Fatalf("conformance: toxiproxy proxied endpoint: %v", err)
+	}
+	uri, err := ctr.URI(ctx)
+	if err != nil {
+		t.Fatalf("conformance: toxiproxy control uri: %v", err)
+	}
+
+	return &Proxy{Addr: host + ":" + port, client: toxiclient.NewClient(uri)}
+}
+
+// Break makes every connection through the proxy hang without answering.
+func (p *Proxy) Break(t *testing.T) {
+	t.Helper()
+
+	proxy, err := p.client.Proxy(proxyName)
+	if err != nil {
+		t.Fatalf("conformance: look up proxy: %v", err)
+	}
+	// timeout=0 holds the connection open indefinitely. A positive value
+	// closes it after that many milliseconds, which is a refusal in slow
+	// motion and a different fault.
+	if _, err := proxy.AddToxic(toxicName, "timeout", "downstream", 1.0,
+		toxiclient.Attributes{"timeout": 0}); err != nil {
+		t.Fatalf("conformance: add the timeout toxic: %v", err)
+	}
+}
+
+// Heal removes the hang.
+func (p *Proxy) Heal(t *testing.T) {
+	t.Helper()
+
+	proxy, err := p.client.Proxy(proxyName)
+	if err != nil {
+		t.Fatalf("conformance: look up proxy: %v", err)
+	}
+	if err := proxy.RemoveToxic(toxicName); err != nil {
+		t.Fatalf("conformance: remove the timeout toxic: %v", err)
+	}
+}

--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -21,9 +21,20 @@ import "testing"
 // The marker goes to the test log, which `go test -json` carries as output
 // events, so the matrix reads it from ordinary suite output with no plugin
 // and no build tag.
-func Covers(t *testing.T, features ...string) {
+func Covers(t testing.TB, features ...string) {
 	t.Helper()
 	for _, feature := range features {
 		t.Logf("COVERS %s", feature)
 	}
+}
+
+// Invariant records that this test proved one invariant for one integration.
+//
+// A feature attributes by test name. An invariant cannot: the conformance
+// harness runs the same code for every integration, so the name says nothing
+// about which one this run was. Only the marker knows, so it carries both
+// ids.
+func Invariant(t testing.TB, invariant, integration string) {
+	t.Helper()
+	t.Logf("COVERS invariant=%s integration=%s", invariant, integration)
 }

--- a/internal/coverage/coverage_test.go
+++ b/internal/coverage/coverage_test.go
@@ -11,7 +11,7 @@ import (
 // The generator parses these lines with a fixed regex. A format drift is a
 // silent loss of every cell the marker feeds, so the exact bytes are pinned
 // on this side too.
-func TestCoverageInvariant_EmitsTheStructuredMarker(t *testing.T) {
+func TestToolingCoverageInvariant_EmitsTheStructuredMarker(t *testing.T) {
 	rec := &recorder{}
 	Invariant(rec, "sink.flush.keeps_batch", "sink.clickhouse")
 
@@ -20,7 +20,7 @@ func TestCoverageInvariant_EmitsTheStructuredMarker(t *testing.T) {
 		rec.lines)
 }
 
-func TestCoverageCovers_EmitsOneLinePerFeature(t *testing.T) {
+func TestToolingCoverageCovers_EmitsOneLinePerFeature(t *testing.T) {
 	rec := &recorder{}
 	Covers(rec, "sink.clickhouse", "source.kafka")
 
@@ -33,7 +33,7 @@ func TestCoverageCovers_EmitsOneLinePerFeature(t *testing.T) {
 // A structured marker must not also read as a plain one. The generator drops
 // the plain match when a structured one is present, and this is the other
 // half of that contract: the two lines cannot be confused for each other.
-func TestCoverageInvariant_DoesNotLookLikeAFeatureMarker(t *testing.T) {
+func TestToolingCoverageInvariant_DoesNotLookLikeAFeatureMarker(t *testing.T) {
 	rec := &recorder{}
 	Invariant(rec, "sink.flush.keeps_batch", "sink.clickhouse")
 

--- a/internal/coverage/coverage_test.go
+++ b/internal/coverage/coverage_test.go
@@ -1,0 +1,56 @@
+package coverage
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/zeebo/assert"
+)
+
+// The generator parses these lines with a fixed regex. A format drift is a
+// silent loss of every cell the marker feeds, so the exact bytes are pinned
+// on this side too.
+func TestCoverageInvariant_EmitsTheStructuredMarker(t *testing.T) {
+	rec := &recorder{}
+	Invariant(rec, "sink.flush.keeps_batch", "sink.clickhouse")
+
+	assert.DeepEqual(t,
+		[]string{"COVERS invariant=sink.flush.keeps_batch integration=sink.clickhouse"},
+		rec.lines)
+}
+
+func TestCoverageCovers_EmitsOneLinePerFeature(t *testing.T) {
+	rec := &recorder{}
+	Covers(rec, "sink.clickhouse", "source.kafka")
+
+	assert.DeepEqual(t, []string{
+		"COVERS sink.clickhouse",
+		"COVERS source.kafka",
+	}, rec.lines)
+}
+
+// A structured marker must not also read as a plain one. The generator drops
+// the plain match when a structured one is present, and this is the other
+// half of that contract: the two lines cannot be confused for each other.
+func TestCoverageInvariant_DoesNotLookLikeAFeatureMarker(t *testing.T) {
+	rec := &recorder{}
+	Invariant(rec, "sink.flush.keeps_batch", "sink.clickhouse")
+
+	assert.True(t, strings.HasPrefix(rec.lines[0], "COVERS invariant="))
+}
+
+// recorder stands in for *testing.T so a test can read what was logged.
+// testing.TB has an unexported method, so it cannot be implemented outside
+// the testing package; embedding it satisfies the compiler, and the two
+// methods these functions call are overridden below.
+type recorder struct {
+	testing.TB
+	lines []string
+}
+
+func (r *recorder) Helper() {}
+
+func (r *recorder) Logf(format string, args ...any) {
+	r.lines = append(r.lines, fmt.Sprintf(format, args...))
+}

--- a/internal/coverage/registry.go
+++ b/internal/coverage/registry.go
@@ -1,0 +1,64 @@
+package coverage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// constructedKinds are the kinds something builds. An invariant may also
+// apply to a pipeline, which no constructor produces, so integrations.yml
+// never carries that kind and asking for it is a mistake.
+var constructedKinds = map[string]bool{"sink": true, "source": true, "handler": true}
+
+// Integrations returns the bare type names integrations.yml declares for one
+// kind, sorted.
+//
+// "sink.clickhouse" is reported as "clickhouse", which is the form the
+// constructor switches use, so a test in each of those packages can hold
+// Kinds() equal to this. An integration the engine can build and the registry
+// does not name has no invariant cells at all, which is the sink.iceberg
+// failure: nothing written down, so nothing can be missing.
+func Integrations(kind string) ([]string, error) {
+	if !constructedKinds[kind] {
+		return nil, fmt.Errorf("coverage: nothing constructs a %q", kind)
+	}
+
+	// Located relative to this file, not the working directory: `go test ./...`
+	// runs each package from its own directory.
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("coverage: cannot locate the registry")
+	}
+	path := filepath.Join(filepath.Dir(self), "..", "..",
+		"docs", "coverage", "integrations.yml")
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("coverage: read %s: %w", path, err)
+	}
+
+	var doc struct {
+		Integrations []struct {
+			ID   string `yaml:"id"`
+			Kind string `yaml:"kind"`
+		} `yaml:"integrations"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("coverage: parse %s: %w", path, err)
+	}
+
+	out := []string{}
+	for _, integration := range doc.Integrations {
+		if integration.Kind == kind {
+			out = append(out, strings.TrimPrefix(integration.ID, kind+"."))
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/coverage/registry.go
+++ b/internal/coverage/registry.go
@@ -16,6 +16,52 @@ import (
 // never carries that kind and asking for it is a mistake.
 var constructedKinds = map[string]bool{"sink": true, "source": true, "handler": true}
 
+// Invariants returns every id invariants.yml declares, as a set.
+//
+// The conformance harness judges invariants by id, and an id nothing declares
+// reports as an unknown marker rather than as a cell -- the claim would be
+// tested and invisible. A test in the harness holds every id it judges to
+// this set.
+func Invariants() (map[string]bool, error) {
+	raw, err := readRegistry("invariants.yml")
+	if err != nil {
+		return nil, err
+	}
+
+	var doc struct {
+		Invariants []struct {
+			ID string `yaml:"id"`
+		} `yaml:"invariants"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("coverage: parse invariants.yml: %w", err)
+	}
+
+	out := make(map[string]bool, len(doc.Invariants))
+	for _, invariant := range doc.Invariants {
+		out[invariant.ID] = true
+	}
+	return out, nil
+}
+
+// readRegistry reads one file from docs/coverage.
+//
+// Located relative to this source file, not the working directory: `go test
+// ./...` runs each package from its own directory.
+func readRegistry(name string) ([]byte, error) {
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("coverage: cannot locate %s", name)
+	}
+	path := filepath.Join(filepath.Dir(self), "..", "..", "docs", "coverage", name)
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("coverage: read %s: %w", path, err)
+	}
+	return raw, nil
+}
+
 // Integrations returns the bare type names integrations.yml declares for one
 // kind, sorted.
 //
@@ -29,18 +75,9 @@ func Integrations(kind string) ([]string, error) {
 		return nil, fmt.Errorf("coverage: nothing constructs a %q", kind)
 	}
 
-	// Located relative to this file, not the working directory: `go test ./...`
-	// runs each package from its own directory.
-	_, self, _, ok := runtime.Caller(0)
-	if !ok {
-		return nil, fmt.Errorf("coverage: cannot locate the registry")
-	}
-	path := filepath.Join(filepath.Dir(self), "..", "..",
-		"docs", "coverage", "integrations.yml")
-
-	raw, err := os.ReadFile(path)
+	raw, err := readRegistry("integrations.yml")
 	if err != nil {
-		return nil, fmt.Errorf("coverage: read %s: %w", path, err)
+		return nil, err
 	}
 
 	var doc struct {
@@ -50,7 +87,7 @@ func Integrations(kind string) ([]string, error) {
 		} `yaml:"integrations"`
 	}
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		return nil, fmt.Errorf("coverage: parse %s: %w", path, err)
+		return nil, fmt.Errorf("coverage: parse integrations.yml: %w", err)
 	}
 
 	out := []string{}

--- a/internal/coverage/registry_test.go
+++ b/internal/coverage/registry_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/zeebo/assert"
 )
 
-func TestCoverageRegistry_ListsSinksByBareName(t *testing.T) {
+func TestToolingCoverageRegistry_ListsSinksByBareName(t *testing.T) {
 	got, err := Integrations("sink")
 	assert.NoError(t, err)
 
@@ -17,13 +17,13 @@ func TestCoverageRegistry_ListsSinksByBareName(t *testing.T) {
 	}, got)
 }
 
-func TestCoverageRegistry_ListsSources(t *testing.T) {
+func TestToolingCoverageRegistry_ListsSources(t *testing.T) {
 	got, err := Integrations("source")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, []string{"kafka", "webhook", "websocket"}, got)
 }
 
-func TestCoverageRegistry_ListsHandlers(t *testing.T) {
+func TestToolingCoverageRegistry_ListsHandlers(t *testing.T) {
 	got, err := Integrations("handler")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, []string{"inferred_disk", "inferred_mem", "structured"}, got)
@@ -31,12 +31,12 @@ func TestCoverageRegistry_ListsHandlers(t *testing.T) {
 
 // pipeline is a kind an invariant can apply to, but no constructor builds
 // one. Asking for its integrations is a mistake worth naming.
-func TestCoverageRegistry_RejectsAKindNothingConstructs(t *testing.T) {
+func TestToolingCoverageRegistry_RejectsAKindNothingConstructs(t *testing.T) {
 	_, err := Integrations("pipeline")
 	assert.Error(t, err)
 }
 
-func TestCoverageRegistry_RejectsAnUnknownKind(t *testing.T) {
+func TestToolingCoverageRegistry_RejectsAnUnknownKind(t *testing.T) {
 	_, err := Integrations("router")
 	assert.Error(t, err)
 }

--- a/internal/coverage/registry_test.go
+++ b/internal/coverage/registry_test.go
@@ -1,0 +1,42 @@
+package coverage
+
+import (
+	"testing"
+
+	"github.com/zeebo/assert"
+)
+
+func TestCoverageRegistry_ListsSinksByBareName(t *testing.T) {
+	got, err := Integrations("sink")
+	assert.NoError(t, err)
+
+	// The registry's ids are prefixed by kind; a constructor switch's cases
+	// are not. The bare name is the form both sides can compare.
+	assert.DeepEqual(t, []string{
+		"clickhouse", "console", "iceberg", "kafka", "noop", "sqlcommand",
+	}, got)
+}
+
+func TestCoverageRegistry_ListsSources(t *testing.T) {
+	got, err := Integrations("source")
+	assert.NoError(t, err)
+	assert.DeepEqual(t, []string{"kafka", "webhook", "websocket"}, got)
+}
+
+func TestCoverageRegistry_ListsHandlers(t *testing.T) {
+	got, err := Integrations("handler")
+	assert.NoError(t, err)
+	assert.DeepEqual(t, []string{"inferred_disk", "inferred_mem", "structured"}, got)
+}
+
+// pipeline is a kind an invariant can apply to, but no constructor builds
+// one. Asking for its integrations is a mistake worth naming.
+func TestCoverageRegistry_RejectsAKindNothingConstructs(t *testing.T) {
+	_, err := Integrations("pipeline")
+	assert.Error(t, err)
+}
+
+func TestCoverageRegistry_RejectsAnUnknownKind(t *testing.T) {
+	_, err := Integrations("router")
+	assert.Error(t, err)
+}

--- a/internal/handlers/init.go
+++ b/internal/handlers/init.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"sort"
+
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/core"
@@ -10,9 +12,24 @@ import (
 	"go.uber.org/zap"
 )
 
-func New(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, error) {
-	switch c.Type {
-	case "handlers.StructuredBatch":
+// configTypes maps the config's Python-era handler names to the registry's.
+//
+// The config keeps the long form because every shipped example carries it.
+// integrations.yml uses the short one, which is what an id like
+// handler.inferred_mem reads as.
+var configTypes = map[string]string{
+	"handlers.StructuredBatch":   "structured",
+	"handlers.InferredMemBatch":  "inferred_mem",
+	"handlers.InferredDiskBatch": "inferred_disk",
+}
+
+// builders constructs each handler type.
+//
+// A map rather than a switch so Kinds can list it. A registry test holds that
+// list equal to integrations.yml, and a handler the engine can build but
+// nothing declares has no invariant cells at all.
+var builders = map[string]func(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, error){
+	"structured": func(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, error) {
 		// Derive the Arrow schema from the DuckDB table definition
 		stmt, err := conn.NewStatement()
 		if err != nil {
@@ -41,8 +58,9 @@ func New(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, e
 			return nil, errs.Wrap(errs.CodeSQLInvalid, err, "failed to create StructuredBatchHandler")
 		}
 		return h, nil
+	},
 
-	case "handlers.InferredMemBatch":
+	"inferred_mem": func(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, error) {
 		h, err := NewInferredMemBatchHandler(
 			conn,
 			c.SQL,
@@ -52,8 +70,9 @@ func New(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, e
 			return nil, errs.Wrap(errs.CodeSQLInvalid, err, "failed to create InferredMemBatchHandler")
 		}
 		return h, nil
+	},
 
-	case "handlers.InferredDiskBatch":
+	"inferred_disk": func(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, error) {
 		cacheDir := c.SQLResultsCacheDir
 		if cacheDir == "" {
 			cacheDir = config.SQLResultsCacheDir()
@@ -69,8 +88,24 @@ func New(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, e
 			return nil, errs.Wrap(errs.CodeSQLInvalid, err, "failed to create InferredDiskBatchHandler")
 		}
 		return h, nil
+	},
+}
 
-	default:
+// Kinds lists every handler type the engine can build, sorted. The registry's
+// short names, not the config's.
+func Kinds() []string {
+	out := make([]string, 0, len(builders))
+	for kind := range builders {
+		out = append(out, kind)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func New(conn adbc.Connection, c config.Handler, l *zap.Logger) (core.Handler, error) {
+	kind, ok := configTypes[c.Type]
+	if !ok {
 		return nil, errs.New(errs.CodeSQLInvalid, "handler: %q not supported", c.Type)
 	}
+	return builders[kind](conn, c, l)
 }

--- a/internal/handlers/registry_test.go
+++ b/internal/handlers/registry_test.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// A handler the engine can build and integrations.yml does not name has no
+// invariant cells at all, which is the sink.iceberg failure: nothing written
+// down, so nothing can be missing. This runs in the unit pass, in
+// milliseconds, so the gap closes before the matrix is ever regenerated.
+func TestHandlerRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+	declared, err := coverage.Integrations("handler")
+	assert.NoError(t, err)
+	assert.DeepEqual(t, declared, Kinds())
+}
+
+// The config's names and the registry's are two maps, so they can drift. A
+// config type with no builder panics on a nil function rather than reporting
+// an unsupported handler.
+func TestHandlerRegistry_EveryConfigTypeHasABuilder(t *testing.T) {
+	for configType, kind := range configTypes {
+		if _, ok := builders[kind]; !ok {
+			t.Errorf("config type %q maps to %q, which has no builder", configType, kind)
+		}
+	}
+	assert.Equal(t, len(builders), len(configTypes))
+}

--- a/internal/handlers/registry_test.go
+++ b/internal/handlers/registry_test.go
@@ -11,7 +11,7 @@ import (
 // invariant cells at all, which is the sink.iceberg failure: nothing written
 // down, so nothing can be missing. This runs in the unit pass, in
 // milliseconds, so the gap closes before the matrix is ever regenerated.
-func TestHandlerRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+func TestToolingCoverageHandlerRegistry_MatchesTheConstructorSwitch(t *testing.T) {
 	declared, err := coverage.Integrations("handler")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, declared, Kinds())
@@ -20,7 +20,7 @@ func TestHandlerRegistry_MatchesTheConstructorSwitch(t *testing.T) {
 // The config's names and the registry's are two maps, so they can drift. A
 // config type with no builder panics on a nil function rather than reporting
 // an unsupported handler.
-func TestHandlerRegistry_EveryConfigTypeHasABuilder(t *testing.T) {
+func TestToolingCoverageHandlerRegistry_EveryConfigTypeHasABuilder(t *testing.T) {
 	for configType, kind := range configTypes {
 		if _, ok := builders[kind]; !ok {
 			t.Errorf("config type %q maps to %q, which has no builder", configType, kind)

--- a/internal/sinks/conformance_test.go
+++ b/internal/sinks/conformance_test.go
@@ -1,0 +1,160 @@
+package sinks
+
+// The ClickHouse sink under the conformance harness, against a real server
+// behind toxiproxy.
+//
+// This is the first subject, so it is also the proof that the harness needs
+// nothing sink-specific. Everything it asks for is here: build the sink,
+// break and heal its network, read back what was delivered, and produce a
+// one-row table the DDL accepts. A second sink supplies the same five things
+// and inherits both invariants.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/testcontainers/testcontainers-go"
+	tcclickhouse "github.com/testcontainers/testcontainers-go/modules/clickhouse"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/conformance"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/zeebo/assert"
+)
+
+// clickhouseImage is pinned so a server upgrade is a commit rather than a
+// Tuesday. 26.8 is the self-hosted version the ClickHouse integration page
+// was verified against.
+const clickhouseImage = "clickhouse/clickhouse-server:26.8"
+
+// The credentials the container is started with, stated here rather than
+// taken from the module's defaults so the dsn below and the container cannot
+// disagree.
+const (
+	clickhouseUser     = "sqlflow"
+	clickhousePassword = "sqlflow"
+	clickhouseDatabase = "sqlflow"
+)
+
+// clickhouseDSN addresses a ClickHouse HTTP endpoint as the sink's dsn parser
+// reads it: a clickhouse:// port is an HTTP port.
+func clickhouseDSN(addr string) string {
+	return fmt.Sprintf("clickhouse://%s:%s@%s/%s",
+		clickhouseUser, clickhousePassword, addr, clickhouseDatabase)
+}
+
+func TestIntegrationSinkClickhouse_Conformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: -short runs the unit pass only")
+	}
+	ctx := context.Background()
+
+	nw, err := network.New(ctx)
+	if err != nil {
+		t.Fatalf("docker network: %v", err)
+	}
+	t.Cleanup(func() { _ = nw.Remove(context.Background()) })
+
+	ch, err := tcclickhouse.Run(ctx, clickhouseImage,
+		network.WithNetwork([]string{"clickhouse"}, nw),
+		testcontainers.WithExposedPorts("8123/tcp"),
+		tcclickhouse.WithUsername(clickhouseUser),
+		tcclickhouse.WithPassword(clickhousePassword),
+		tcclickhouse.WithDatabase(clickhouseDatabase),
+	)
+	if err != nil {
+		t.Fatalf("start clickhouse: %v", err)
+	}
+	t.Cleanup(func() { _ = ch.Terminate(context.Background()) })
+
+	// The sink speaks the HTTP interface on 8123, and the proxy forwards to
+	// the container's alias on the shared network rather than to a host port.
+	proxy := conformance.NewProxy(t, nw, "clickhouse:8123")
+
+	table := fmt.Sprintf("conformance_%d", time.Now().UnixNano())
+
+	// A second connection, straight to the container, for DDL and read-back.
+	// The harness's own reads must not cross the fault it injects, or a
+	// broken destination would look like an empty one.
+	direct := mustDirectSink(t, ch, table)
+	assert.NoError(t, direct.conn.Exec(ctx,
+		"CREATE TABLE "+table+" (id Int64) ENGINE = MergeTree() ORDER BY id"))
+
+	dsn := clickhouseDSN(proxy.Addr)
+
+	conformance.Sinks(t, conformance.SinkSubject{
+		Integration: "sink.clickhouse",
+
+		New: func(t *testing.T) core.Sink {
+			s, err := NewClickhouseSink(config.ClickhouseSink{DSN: dsn, Table: table})
+			assert.NoError(t, err)
+			t.Cleanup(func() { s.Close() })
+			return s
+		},
+
+		Break: proxy.Break,
+		Heal:  proxy.Heal,
+
+		ReadBack: func(t *testing.T) []conformance.Row {
+			rows, err := direct.conn.Query(context.Background(),
+				"SELECT id FROM "+table+" ORDER BY id")
+			assert.NoError(t, err)
+			defer rows.Close()
+
+			var out []conformance.Row
+			for rows.Next() {
+				var id int64
+				assert.NoError(t, rows.Scan(&id))
+				out = append(out, conformance.Row{"id": id})
+			}
+			assert.NoError(t, rows.Err())
+			return out
+		},
+
+		Table: func(t *testing.T, id int64) arrow.Table {
+			schema := arrow.NewSchema([]arrow.Field{
+				{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+			}, nil)
+
+			b := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+			defer b.Release()
+			b.Field(0).(*array.Int64Builder).Append(id)
+
+			rec := b.NewRecord()
+			defer rec.Release()
+			return array.NewTableFromRecords(schema, []arrow.Record{rec})
+		},
+	})
+}
+
+// mustDirectSink opens a sink on the container's own host port, bypassing the
+// proxy.
+//
+// The module's ConnectionString reports the native port, and the sink's dsn
+// parser reads a clickhouse:// port as HTTP, so the mapped 8123 is looked up
+// rather than taken from it.
+func mustDirectSink(t *testing.T, ch *tcclickhouse.ClickHouseContainer, table string) *ClickhouseSink {
+	t.Helper()
+	ctx := context.Background()
+
+	host, err := ch.Host(ctx)
+	assert.NoError(t, err)
+	port, err := ch.MappedPort(ctx, "8123/tcp")
+	assert.NoError(t, err)
+
+	s, err := NewClickhouseSink(config.ClickhouseSink{
+		DSN:   clickhouseDSN(net.JoinHostPort(host, port.Port())),
+		Table: table,
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+
+	assert.NoError(t, s.conn.Ping(ctx))
+	return s
+}

--- a/internal/sinks/init.go
+++ b/internal/sinks/init.go
@@ -2,6 +2,7 @@ package sinks
 
 import (
 	"context"
+	"sort"
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow"
@@ -104,42 +105,71 @@ func retriesHelp(sinkType string) bool {
 	}
 }
 
-// buildSink constructs the sink itself. Whether a retry ladder belongs around
-// it is retriesHelp's decision, not this one's.
-func buildSink(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
-	switch sink.Type {
-	case "noop":
+// builders constructs each sink type.
+//
+// A map rather than a switch so Kinds can list it. A registry test holds that
+// list equal to integrations.yml, and a sink the engine can build but nothing
+// declares has no invariant cells at all.
+var builders = map[string]func(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error){
+	"noop": func(context.Context, config.Sink, adbc.Connection) (core.Sink, error) {
 		return &NoopSink{}, nil
+	},
 
-	case "console", "":
-		// The Python engine falls back to console for an unset type.
+	"console": func(context.Context, config.Sink, adbc.Connection) (core.Sink, error) {
 		return NewConsoleSink(), nil
+	},
 
-	case "kafka":
+	"kafka": func(_ context.Context, sink config.Sink, _ adbc.Connection) (core.Sink, error) {
 		if sink.Kafka == nil {
 			return nil, errs.New(errs.CodeSinkInvalid, "sink: kafka sink requires a kafka block")
 		}
 		return NewKafkaSink(*sink.Kafka)
+	},
 
-	case "sqlcommand":
+	"sqlcommand": func(_ context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
 		if sink.SQLCommand == nil {
 			return nil, errs.New(errs.CodeSinkInvalid, "sink: sqlcommand sink requires a sqlcommand block")
 		}
 		return NewSQLCommandSink(conn, sink.SQLCommand.SQL, sink.SQLCommand.Substitutions)
+	},
 
-	case "clickhouse":
+	"clickhouse": func(_ context.Context, sink config.Sink, _ adbc.Connection) (core.Sink, error) {
 		if sink.Clickhouse == nil {
 			return nil, errs.New(errs.CodeSinkInvalid, "sink: clickhouse sink requires a clickhouse block")
 		}
 		return NewClickhouseSink(*sink.Clickhouse)
+	},
 
-	case "iceberg":
+	"iceberg": func(ctx context.Context, sink config.Sink, _ adbc.Connection) (core.Sink, error) {
 		if sink.Iceberg == nil {
 			return nil, errs.New(errs.CodeSinkInvalid, "sink: iceberg sink requires an iceberg block")
 		}
 		return NewIcebergSink(ctx, sink.Iceberg.CatalogName, sink.Iceberg.TableName)
+	},
+}
 
-	default:
+// Kinds lists every sink type the engine can build, sorted.
+func Kinds() []string {
+	out := make([]string, 0, len(builders))
+	for kind := range builders {
+		out = append(out, kind)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// buildSink constructs the sink itself. Whether a retry ladder belongs around
+// it is retriesHelp's decision, not this one's.
+func buildSink(ctx context.Context, sink config.Sink, conn adbc.Connection) (core.Sink, error) {
+	kind := sink.Type
+	if kind == "" {
+		// The Python engine falls back to console for an unset type.
+		kind = "console"
+	}
+
+	build, ok := builders[kind]
+	if !ok {
 		return nil, errs.New(errs.CodeSinkInvalid, "sink: %q not supported", sink.Type)
 	}
+	return build(ctx, sink, conn)
 }

--- a/internal/sinks/registry_test.go
+++ b/internal/sinks/registry_test.go
@@ -11,7 +11,7 @@ import (
 // invariant cells at all, which is the sink.iceberg failure: nothing written
 // down, so nothing can be missing. This runs in the unit pass, in
 // milliseconds, so the gap closes before the matrix is ever regenerated.
-func TestSinkRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+func TestToolingCoverageSinkRegistry_MatchesTheConstructorSwitch(t *testing.T) {
 	declared, err := coverage.Integrations("sink")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, declared, Kinds())

--- a/internal/sinks/registry_test.go
+++ b/internal/sinks/registry_test.go
@@ -1,0 +1,18 @@
+package sinks
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// A sink the engine can build and integrations.yml does not name has no
+// invariant cells at all, which is the sink.iceberg failure: nothing written
+// down, so nothing can be missing. This runs in the unit pass, in
+// milliseconds, so the gap closes before the matrix is ever regenerated.
+func TestSinkRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+	declared, err := coverage.Integrations("sink")
+	assert.NoError(t, err)
+	assert.DeepEqual(t, declared, Kinds())
+}

--- a/internal/sources/init.go
+++ b/internal/sources/init.go
@@ -2,6 +2,8 @@ package sources
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/core"
 	"github.com/turbolytics/sql-flow/internal/errs"
@@ -13,11 +15,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// New builds the configured source. A nil meter provider leaves sources that
-// record metrics recording nothing.
-func New(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, error) {
-	switch c.Type {
-	case "kafka":
+// builders constructs each source type.
+//
+// A map rather than a switch so Kinds can list it. A registry test holds that
+// list equal to integrations.yml, and a source the engine can build but
+// nothing declares has no invariant cells at all.
+var builders = map[string]func(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, error){
+	"kafka": func(c config.Source, l *zap.Logger, _ metric.MeterProvider) (core.Source, error) {
 		l.Info(
 			"initializing kafka source",
 			zap.String("topics", fmt.Sprintf("%v", c.Kafka.Topics)),
@@ -67,16 +71,18 @@ func New(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, 
 
 		k, err := tkafka.NewSource(client, tkafka.WithLogger(l), tkafka.WithSeeker(seeker))
 		return k, err
+	},
 
-	case "websocket":
+	"websocket": func(c config.Source, l *zap.Logger, _ metric.MeterProvider) (core.Source, error) {
 		if c.Websocket == nil {
 			return nil, errs.New(errs.CodeSourceInvalid, "websocket source: missing websocket configuration")
 		}
 		l.Info("initializing websocket source", zap.String("uri", c.Websocket.URI))
 
 		return websocket.NewSource(c.Websocket.URI, websocket.WithLogger(l))
+	},
 
-	case "webhook":
+	"webhook": func(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, error) {
 		opts := []webhook.Option{
 			webhook.WithLogger(l),
 			webhook.WithMeterProvider(mp),
@@ -96,8 +102,25 @@ func New(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, 
 		}
 
 		return webhook.NewSource(opts...)
+	},
+}
 
-	default:
+// Kinds lists every source type the engine can build, sorted.
+func Kinds() []string {
+	out := make([]string, 0, len(builders))
+	for kind := range builders {
+		out = append(out, kind)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// New builds the configured source. A nil meter provider leaves sources that
+// record metrics recording nothing.
+func New(c config.Source, l *zap.Logger, mp metric.MeterProvider) (core.Source, error) {
+	build, ok := builders[c.Type]
+	if !ok {
 		return nil, errs.New(errs.CodeSourceInvalid, "source: %q not supported", c.Type)
 	}
+	return build(c, l, mp)
 }

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -1,0 +1,18 @@
+package sources
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// A source the engine can build and integrations.yml does not name has no
+// invariant cells at all, which is the sink.iceberg failure: nothing written
+// down, so nothing can be missing. This runs in the unit pass, in
+// milliseconds, so the gap closes before the matrix is ever regenerated.
+func TestSourceRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+	declared, err := coverage.Integrations("source")
+	assert.NoError(t, err)
+	assert.DeepEqual(t, declared, Kinds())
+}

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -11,7 +11,7 @@ import (
 // invariant cells at all, which is the sink.iceberg failure: nothing written
 // down, so nothing can be missing. This runs in the unit pass, in
 // milliseconds, so the gap closes before the matrix is ever regenerated.
-func TestSourceRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+func TestToolingCoverageSourceRegistry_MatchesTheConstructorSwitch(t *testing.T) {
 	declared, err := coverage.Integrations("source")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, declared, Kinds())

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -604,17 +604,40 @@ def render(snap):
     return "\n".join(lines) + "\n"
 
 
-INV_MARK = {
-    "covered": "✅",
-    "skipped": "⚠️ skipped",
-    "missing": "❌ missing",
-    "failing": "🔥 failing",
-    "exempt": "— exempt",
-}
+# Level initials, so a cell fits: u = unit, i = integration, r = release.
+LEVEL_INITIALS = {lvl: lvl[0] for lvl in LEVELS}
 
-# Worst first. A cell shows the weakest status across the levels it is judged
-# on, so a green row means green everywhere it was asked.
-STATUS_RANK = ("failing", "missing", "skipped", "covered", "exempt")
+
+def invariant_cell(levels, required):
+    """Render one integration's cell for one invariant.
+
+    A covered cell names the levels that proved it, because "proven with a
+    fake but never against the real thing" is the question this matrix exists
+    to answer, and a bare tick cannot say it.
+
+    Failing beats missing beats skipped: a cell reports the worst thing that
+    happened, then what was achieved.
+    """
+    if any(c["status"] == "exempt" for c in levels.values()):
+        return "— exempt"
+
+    states = {lvl: cell["status"] for lvl, cell in levels.items()}
+    if "failing" in states.values():
+        return "🔥 failing"
+
+    covered = [lvl for lvl in LEVELS if states.get(lvl) == "covered"]
+    if covered:
+        proven = "".join(LEVEL_INITIALS[lvl] for lvl in covered)
+        # A required level that is not covered is a gap, listed below. Say so
+        # here too rather than showing a tick beside an unmet requirement.
+        unmet = [lvl for lvl in required if states.get(lvl) != "covered"]
+        if unmet:
+            return f"⚠️ {proven}, {'+'.join(unmet)} missing"
+        return f"✅ {proven}"
+
+    if "skipped" in states.values():
+        return "⚠️ skipped"
+    return "❌ missing"
 
 
 def render_invariants(snap):
@@ -632,16 +655,14 @@ def render_invariants(snap):
         "ids -- a harness test's name says nothing, because the same code runs",
         "for every integration.",
         "",
-        "**exempt** carries its reason in the JSON. **missing** means no",
-        "evidence. Nothing here fails the build until an invariant's `requires`",
-        "is filled in, and none is yet.",
+        "A covered cell names the levels that proved it: `u` unit, `i`",
+        "integration, `r` release. That is the question the matrix exists to",
+        "answer -- proven with a fake, or against the real thing, or in the",
+        "shipped image. **exempt** carries its reason in the JSON, and",
+        "**missing** means no evidence. Nothing here fails the build until an",
+        "invariant's `requires` is filled in, and none is yet.",
         "",
     ]
-
-    def worst(levels, required):
-        judged = required or list(levels)
-        states = [levels[lvl]["status"] for lvl in judged if lvl in levels]
-        return min(states, key=STATUS_RANK.index) if states else "missing"
 
     families = []
     for inv in snap["invariants"]:
@@ -673,7 +694,7 @@ def render_invariants(snap):
                 claim += f" *(declared, tracked by {inv['tracked_by']})*"
             if columns:
                 cells = " | ".join(
-                    INV_MARK[worst(inv["integrations"][c], inv["requires"])]
+                    invariant_cell(inv["integrations"][c], inv["requires"])
                     if c in inv["integrations"] else "·"
                     for c in columns)
                 lines.append(f"| `{inv['id']}` | {claim} | {cells} |")

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -276,7 +276,11 @@ def build(features, go_results, py_results, go_covers=None, py_covers=None,
             feature_id = match(strip_level_prefix(name), prefixes)
             if feature_id:
                 coverage[feature_id][level].append((name, outcome))
-            else:
+            elif not extras.get(name):
+                # A test carrying a marker is attributed by it. Listing it here
+                # would tell the reader to rename a test that already says what
+                # it covers, and the conformance harness attributes only by
+                # marker: its runner's name matches no feature at all.
                 unmatched[level].append(name)
 
             for extra in extras.get(name, []):
@@ -289,6 +293,121 @@ def build(features, go_results, py_results, go_covers=None, py_covers=None,
                 secondary[extra][level].append(name)
 
     return coverage, secondary, unmatched, unknown_markers
+
+
+def build_invariants(invariants, integrations, results, evidence):
+    """Attribute harness markers to (invariant, integration, level) cells.
+
+    results:  {level: {test: outcome}}
+    evidence: {level: {test: [(invariant, integration)]}}
+
+    A marker is only ever emitted by a passing subtest, but the parent that
+    ran it can still fail or be skipped afterwards, and that verdict is the
+    one `go test` reports. The outcome recorded here is the test's, not the
+    marker's presence.
+    """
+    known_inv = {i["id"] for i in invariants}
+    known_integ = {i["id"] for i in integrations}
+
+    cells = {}   # (invariant, integration, level) -> [(test, outcome)]
+    unknown = []  # (test, invariant, integration)
+
+    for level in LEVELS:
+        # Insertion order, not sorted: snapshot_invariants sorts each cell, and
+        # sorting twice hides which sort the output actually depends on.
+        for test, pairs in evidence.get(level, {}).items():
+            # A marker with no result means the event stream lost the verdict.
+            # Treat that as a failure rather than as coverage.
+            outcome = results.get(level, {}).get(test, FAIL)
+            for inv, integ in pairs:
+                if inv not in known_inv or integ not in known_integ:
+                    unknown.append((test, inv, integ))
+                    continue
+                cells.setdefault((inv, integ, level), []).append((test, outcome))
+
+    return {"cells": cells, "unknown": unknown}
+
+
+def snapshot_invariants(invariants, integrations, built):
+    """The invariant half of matrix.json.
+
+    Same bare-name encoding as the feature half. An exempt cell carries its
+    reason, so a reader never has to open a second file to learn why a cell is
+    blank.
+    """
+    by_kind = {}
+    for integ in integrations:
+        by_kind.setdefault(integ["kind"], []).append(integ)
+
+    exemptions = {
+        (ex["invariant"], integ["id"]): ex["reason"]
+        for integ in integrations
+        for ex in integ.get("exempt", [])
+    }
+
+    out = {"invariants": [], "invariant_gaps": [], "unknown_invariant_markers": []}
+
+    for inv in invariants:
+        required = set(inv.get("requires", []))
+        entry = {
+            "id": inv["id"],
+            "family": inv["family"],
+            "applies_to": inv["applies_to"],
+            # The YAML folds long claims onto several lines; one space between
+            # words keeps the JSON diff stable when the wrapping changes.
+            "claim": " ".join(inv["claim"].split()),
+            "verified_by": inv["verified_by"],
+            "requires": sorted(required),
+            "integrations": {},
+        }
+        if inv.get("tracked_by"):
+            entry["tracked_by"] = inv["tracked_by"]
+        if inv.get("violated_once"):
+            entry["violated_once"] = list(inv["violated_once"])
+
+        # A pipeline invariant attaches to core, so it has no subjects.
+        for integ in by_kind.get(inv["applies_to"], []):
+            reason = exemptions.get((inv["id"], integ["id"]))
+            levels = {}
+            for level in LEVELS:
+                if reason is not None:
+                    levels[level] = {"status": "exempt", "reason": reason}
+                    continue
+
+                # No not_required here, unlike the feature half. Every
+                # non-exempt integration is expected to prove every invariant
+                # of its kind; `requires` decides only whether the absence
+                # fails the build. A cell with no evidence is missing, and
+                # saying so is the whole point before anything is enforced.
+                tests = sorted(built["cells"].get((inv["id"], integ["id"], level), []))
+                state = status(tests)
+                cell = {"status": state, "tests": [n for n, _ in tests]}
+                for key, members in (
+                    ("skipped", [n for n, o in tests if o == SKIP]),
+                    ("failing", [n for n, o in tests if o == FAIL]),
+                ):
+                    if members:
+                        cell[key] = members
+                levels[level] = cell
+
+                if level in required and state != "covered":
+                    out["invariant_gaps"].append({
+                        "invariant": inv["id"],
+                        "integration": integ["id"],
+                        "level": level,
+                        "status": state,
+                    })
+            entry["integrations"][integ["id"]] = levels
+
+        out["invariants"].append(entry)
+
+    # Sorted as tuples. Sorting dicts raises TypeError past one element, which
+    # is what the feature half's unknown_markers does today.
+    out["unknown_invariant_markers"] = [
+        {"test": t, "invariant": i, "integration": g}
+        for t, i, g in sorted(set(built["unknown"]))
+    ]
+    return out
 
 
 def status(entries):
@@ -333,7 +452,7 @@ def snapshot(features, coverage, secondary, unmatched, unknown_markers):
     agents answering questions about coverage. It came to 100KB, and 459 of its
     489 entries said nothing but `"outcome": "pass", "attribution": "name"`.
     """
-    out = {"version": 2, "features": [], "gaps": [],
+    out = {"version": 3, "features": [], "gaps": [],
            "unattributed": {}, "unknown_markers": []}
 
     for feature in features:
@@ -485,6 +604,102 @@ def render(snap):
     return "\n".join(lines) + "\n"
 
 
+INV_MARK = {
+    "covered": "✅",
+    "skipped": "⚠️ skipped",
+    "missing": "❌ missing",
+    "failing": "🔥 failing",
+    "exempt": "— exempt",
+}
+
+# Worst first. A cell shows the weakest status across the levels it is judged
+# on, so a green row means green everywhere it was asked.
+STATUS_RANK = ("failing", "missing", "skipped", "covered", "exempt")
+
+
+def render_invariants(snap):
+    """Render the invariant half. One table per family, one column per
+    integration the family's invariants apply to."""
+    lines = [
+        "# Invariant matrix",
+        "",
+        "Generated from `docs/coverage/matrix.json` by `make coverage-matrix`.",
+        "Do not edit by hand.",
+        "",
+        "Invariants are declared in `docs/coverage/invariants.yml`, integrations",
+        "in `docs/coverage/integrations.yml`. A cell is proven by the conformance",
+        "harness in `internal/conformance`, which emits a marker naming both",
+        "ids -- a harness test's name says nothing, because the same code runs",
+        "for every integration.",
+        "",
+        "**exempt** carries its reason in the JSON. **missing** means no",
+        "evidence. Nothing here fails the build until an invariant's `requires`",
+        "is filled in, and none is yet.",
+        "",
+    ]
+
+    def worst(levels, required):
+        judged = required or list(levels)
+        states = [levels[lvl]["status"] for lvl in judged if lvl in levels]
+        return min(states, key=STATUS_RANK.index) if states else "missing"
+
+    families = []
+    for inv in snap["invariants"]:
+        if inv["family"] not in families:
+            families.append(inv["family"])
+
+    for family in families:
+        rows = [i for i in snap["invariants"] if i["family"] == family]
+        columns = []
+        for inv in rows:
+            for integ in inv["integrations"]:
+                if integ not in columns:
+                    columns.append(integ)
+
+        lines += [f"## Invariants: {family}", ""]
+        if columns:
+            lines.append("| Invariant | Claim | "
+                         + " | ".join(f"`{c}`" for c in columns) + " |")
+            lines.append("| --- | --- | "
+                         + " | ".join("---" for _ in columns) + " |")
+        else:
+            # pipeline invariants have no per-integration column.
+            lines.append("| Invariant | Claim | Verified by |")
+            lines.append("| --- | --- | --- |")
+
+        for inv in rows:
+            claim = inv["claim"]
+            if inv.get("tracked_by"):
+                claim += f" *(declared, tracked by {inv['tracked_by']})*"
+            if columns:
+                cells = " | ".join(
+                    INV_MARK[worst(inv["integrations"][c], inv["requires"])]
+                    if c in inv["integrations"] else "·"
+                    for c in columns)
+                lines.append(f"| `{inv['id']}` | {claim} | {cells} |")
+            else:
+                lines.append(f"| `{inv['id']}` | {claim} | {inv['verified_by']} |")
+        lines.append("")
+
+    if snap["invariant_gaps"]:
+        lines += ["## Invariant gaps", "",
+                  "These fail `make coverage-check`.", ""]
+        for gap in snap["invariant_gaps"]:
+            lines.append(
+                f"- `{gap['invariant']}` on `{gap['integration']}` requires "
+                f"**{gap['level']}** and is *{gap['status']}*.")
+        lines.append("")
+
+    if snap["unknown_invariant_markers"]:
+        lines += ["## Markers naming an unknown invariant or integration", ""]
+        for entry in snap["unknown_invariant_markers"]:
+            lines.append(f"- `{entry['test']}` marks `{entry['invariant']}` "
+                         f"on `{entry['integration']}`")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--go", help="go test -short -json output")
@@ -497,6 +712,17 @@ def main():
     args = ap.parse_args()
 
     features = load_features()
+    invariants = load_invariants()
+    integrations = load_integrations()
+
+    # Before any test result is read: a registry typo would otherwise reach
+    # the matrix as a missing cell.
+    problems = validate_registries(invariants, integrations, features)
+    if problems:
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        return 2
+
     go_results, go_covers, go_invariants = (
         parse_go(args.go) if args.go and os.path.exists(args.go) else ({}, {}, {}))
     it_results, it_covers, it_invariants = (
@@ -511,7 +737,15 @@ def main():
         features, go_results, py_results, go_covers, py_covers,
         it_results, it_covers)
     snap = snapshot(features, coverage, secondary, unmatched, unknown)
-    rendered = render(snap)
+
+    built = build_invariants(
+        invariants, integrations,
+        {"unit": go_results, "integration": it_results, "release": py_results},
+        {"unit": go_invariants, "integration": it_invariants,
+         "release": py_invariants})
+    snap.update(snapshot_invariants(invariants, integrations, built))
+
+    rendered = render(snap) + "\n" + render_invariants(snap)
 
     if args.write:
         os.makedirs(os.path.dirname(MATRIX_JSON), exist_ok=True)
@@ -525,11 +759,15 @@ def main():
     else:
         print(rendered)
 
-    if args.check and snap["gaps"]:
-        print(f"\n{len(snap['gaps'])} coverage gap(s):", file=sys.stderr)
+    gaps = snap["gaps"] + snap["invariant_gaps"]
+    if args.check and gaps:
+        print(f"\n{len(gaps)} coverage gap(s):", file=sys.stderr)
         for gap in snap["gaps"]:
             print(f"  {gap['feature']}: {gap['level']} is {gap['status']}",
                   file=sys.stderr)
+        for gap in snap["invariant_gaps"]:
+            print(f"  {gap['invariant']} on {gap['integration']}: "
+                  f"{gap['level']} is {gap['status']}", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -36,6 +36,8 @@ import yaml
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 REGISTRY = os.path.join(REPO, "docs", "coverage", "features.yml")
+INVARIANTS = os.path.join(REPO, "docs", "coverage", "invariants.yml")
+INTEGRATIONS = os.path.join(REPO, "docs", "coverage", "integrations.yml")
 # The JSON is the artifact CI diffs; the markdown is a view rendered from it.
 MATRIX_JSON = os.path.join(REPO, "docs", "coverage", "matrix.json")
 MATRIX_MD = os.path.join(REPO, "docs", "coverage", "matrix.md")
@@ -50,10 +52,97 @@ LEVELS = ("unit", "integration", "release")
 # the only selector that needs no build tag and no second package.
 INTEGRATION_PREFIX = "TestIntegration"
 
+# The closed vocabularies invariants.yml may use. A value outside one of them
+# is a typo, and a typo must not reach the matrix as a missing cell.
+FAMILIES = ("resilience", "checkpoint", "types", "lifecycle", "errors")
+KINDS = ("sink", "source", "handler", "pipeline")
+VERIFIERS = ("harness", "typetable", "named")
+
+# pipeline invariants attach to core, not to a constructor case, so no entry
+# in integrations.yml carries that kind.
+INTEGRATION_KINDS = ("sink", "source", "handler")
+
 
 def load_features():
     with open(REGISTRY) as fh:
         return yaml.safe_load(fh)["features"]
+
+
+def load_invariants():
+    with open(INVARIANTS) as fh:
+        return yaml.safe_load(fh)["invariants"]
+
+
+def load_integrations():
+    with open(INTEGRATIONS) as fh:
+        return yaml.safe_load(fh)["integrations"]
+
+
+def validate_registries(invariants, integrations, features):
+    """Every problem a human can fix, one line each. Empty when consistent.
+
+    Checked before any test result is read. A registry typo would otherwise
+    reach the matrix as a missing cell, and "missing" is the signal the matrix
+    exists to carry: it must not be spendable on typos.
+    """
+    problems = []
+
+    by_id = {}
+    for inv in invariants:
+        fid = inv.get("id")
+        if fid in by_id:
+            problems.append(f"invariants.yml: duplicate id {fid}")
+        by_id[fid] = inv
+
+        for key in ("family", "applies_to", "claim", "verified_by", "requires"):
+            if key not in inv:
+                problems.append(f"invariants.yml: {fid} has no {key}")
+        if inv.get("family") not in FAMILIES:
+            problems.append(
+                f"invariants.yml: {fid} family {inv.get('family')!r} is not one of {FAMILIES}")
+        if inv.get("applies_to") not in KINDS:
+            problems.append(
+                f"invariants.yml: {fid} applies_to {inv.get('applies_to')!r} is not one of {KINDS}")
+        if inv.get("verified_by") not in VERIFIERS:
+            problems.append(
+                f"invariants.yml: {fid} verified_by {inv.get('verified_by')!r} is not one of {VERIFIERS}")
+        for lvl in inv.get("requires", []):
+            if lvl not in LEVELS:
+                problems.append(
+                    f"invariants.yml: {fid} requires {lvl!r}, which is not a level")
+
+    feature_ids = {f["id"] for f in features}
+    seen = set()
+    for integ in integrations:
+        iid = integ.get("id")
+        if iid in seen:
+            problems.append(f"integrations.yml: duplicate id {iid}")
+        seen.add(iid)
+
+        if integ.get("kind") not in INTEGRATION_KINDS:
+            problems.append(
+                f"integrations.yml: {iid} kind {integ.get('kind')!r} is not one of {INTEGRATION_KINDS}")
+        if integ.get("feature") not in feature_ids:
+            problems.append(
+                f"integrations.yml: {iid} names feature {integ.get('feature')!r}, "
+                "which features.yml does not declare")
+
+        for ex in integ.get("exempt", []):
+            inv = by_id.get(ex.get("invariant"))
+            if inv is None:
+                problems.append(
+                    f"integrations.yml: {iid} is exempt from {ex.get('invariant')!r}, "
+                    "which invariants.yml does not declare")
+                continue
+            if not ex.get("reason"):
+                problems.append(
+                    f"integrations.yml: {iid} exemption from {inv['id']} has no reason")
+            if inv.get("applies_to") != integ.get("kind"):
+                problems.append(
+                    f"integrations.yml: {iid} is a {integ.get('kind')} but "
+                    f"{inv['id']} applies_to {inv.get('applies_to')}")
+
+    return problems
 
 
 def go_prefix(feature_id):

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -543,10 +543,59 @@ def render(snap):
     )
     lines += [
         "",
-        f"**{len(snap['features'])} features declared, {covered} fully covered, "
+        f"**{len(snap['features'])} features declared. {covered} have at least one "
+        f"passing test attributed at every level they require, so "
         f"{len(snap['gaps'])} gap(s).**",
         "",
+        "That sentence counts attribution, not proof. A feature is green here when",
+        "a test named for it ran and passed; it says nothing about whether the",
+        "integration behind it keeps a batch it could not deliver, or commits",
+        "offsets only after a flush. Those are invariants, they are counted",
+        "separately below, and the two numbers are not interchangeable.",
+        "",
     ]
+
+    if snap.get("invariants"):
+        tally, unwired = invariant_tally(snap)
+        total = sum(tally.values())
+        lines += [
+            f"**{len(snap['invariants'])} invariants declared. Of {total} "
+            f"(invariant, integration) cells: {tally['covered']} proven, "
+            f"{tally['missing']} missing, {tally['skipped']} skipped, "
+            f"{tally['failing']} failing, {tally['exempt']} exempt. "
+            f"{len(snap['invariant_gaps'])} gap(s), because no invariant "
+            "requires a level yet.**",
+            "",
+        ]
+        if unwired:
+            lines += [
+                f"A further {unwired} invariants attach to the pipeline rather than",
+                "to any one integration. Nothing collects evidence for them yet, so",
+                "they show no cells at all, which is worse than missing rather than",
+                "better.",
+                "",
+            ]
+
+        argument = strongest_argument(snap)
+        if argument:
+            feature, tests, invariant, proven, applicable = argument
+            lines += [
+                "## Why invariants, and not the test count",
+                "",
+                f"`{feature}` carries {tests} attributed tests, more than anything",
+                f"else in the `{domain(feature)}` layer. `{invariant}`, an invariant",
+                f"of that same layer, is proven on {proven} of the {applicable}",
+                "integrations it applies to.",
+                "",
+                "Those two numbers are the argument. Tests accumulate around the",
+                "code that was written; an invariant is the claim that code exists",
+                "to uphold. A suite can exercise a retry ladder in every direction",
+                "and never ask whether the sink underneath keeps the rows the",
+                "ladder re-sends -- and if it does not, every one of those tests",
+                "passes while the pipeline loses data. The feature table calls that",
+                "covered. This one does not.",
+                "",
+            ]
 
     if snap["gaps"]:
         lines += ["## Gaps", "",
@@ -608,36 +657,149 @@ def render(snap):
 LEVEL_INITIALS = {lvl: lvl[0] for lvl in LEVELS}
 
 
+def cell_state(levels):
+    """One status for one (invariant, integration) cell, worst first.
+
+    Failing beats missing beats skipped beats covered, so a cell reports the
+    worst thing that happened rather than the best.
+    """
+    if any(c["status"] == "exempt" for c in levels.values()):
+        return "exempt"
+
+    states = {cell["status"] for cell in levels.values()}
+    if "failing" in states:
+        return "failing"
+    if "covered" in states:
+        return "covered"
+    if "skipped" in states:
+        return "skipped"
+    return "missing"
+
+
 def invariant_cell(levels, required):
     """Render one integration's cell for one invariant.
 
     A covered cell names the levels that proved it, because "proven with a
     fake but never against the real thing" is the question this matrix exists
     to answer, and a bare tick cannot say it.
-
-    Failing beats missing beats skipped: a cell reports the worst thing that
-    happened, then what was achieved.
     """
-    if any(c["status"] == "exempt" for c in levels.values()):
+    state = cell_state(levels)
+    if state == "exempt":
         return "— exempt"
+    if state == "failing":
+        return "🔥 failing"
+    if state == "skipped":
+        return "⚠️ skipped"
+    if state == "missing":
+        return "❌ missing"
 
     states = {lvl: cell["status"] for lvl, cell in levels.items()}
-    if "failing" in states.values():
-        return "🔥 failing"
+    proven = "".join(LEVEL_INITIALS[lvl] for lvl in LEVELS
+                     if states.get(lvl) == "covered")
+    # A required level that is not covered is a gap, listed below. Say so here
+    # too rather than showing a tick beside an unmet requirement.
+    unmet = [lvl for lvl in required if states.get(lvl) != "covered"]
+    if unmet:
+        return f"⚠️ {proven}, {'+'.join(unmet)} missing"
+    return f"✅ {proven}"
 
-    covered = [lvl for lvl in LEVELS if states.get(lvl) == "covered"]
-    if covered:
-        proven = "".join(LEVEL_INITIALS[lvl] for lvl in covered)
-        # A required level that is not covered is a gap, listed below. Say so
-        # here too rather than showing a tick beside an unmet requirement.
-        unmet = [lvl for lvl in required if states.get(lvl) != "covered"]
-        if unmet:
-            return f"⚠️ {proven}, {'+'.join(unmet)} missing"
-        return f"✅ {proven}"
 
-    if "skipped" in states.values():
-        return "⚠️ skipped"
-    return "❌ missing"
+def describe_claim(inv):
+    """The claim, plus the issue tracking it when the code does not hold it."""
+    claim = inv["claim"]
+    if inv.get("tracked_by"):
+        claim += f" *(declared, tracked by {inv['tracked_by']})*"
+    if inv.get("violated_once"):
+        claim += f" *(violated once: {', '.join(inv['violated_once'])})*"
+    return claim
+
+
+def invariant_tally(snap):
+    """Count every (invariant, integration) cell by state.
+
+    `cells` counts only invariants that have integrations. A pipeline
+    invariant attaches to core rather than to a constructor case, so it has
+    none, and `unwired` counts those separately rather than letting them read
+    as zero work.
+    """
+    tally = {s: 0 for s in ("covered", "missing", "skipped", "failing", "exempt")}
+    unwired = 0
+    for inv in snap["invariants"]:
+        if not inv["integrations"]:
+            unwired += 1
+            continue
+        for levels in inv["integrations"].values():
+            tally[cell_state(levels)] += 1
+    return tally, unwired
+
+
+def domain(identifier):
+    """sink.retry -> sink. The subsystem a feature or invariant belongs to."""
+    return identifier.split(".", 1)[0]
+
+
+def most_tested_feature(snap, within=None):
+    """The feature carrying the most attributed tests, and how many.
+
+    `within` restricts to one subsystem. Counted over features rather than
+    integrations because the sharpest case is a cross-cutting one: sink.retry
+    is not a sink anyone configures, and it accumulated more tests than any
+    other part of the sink layer.
+    """
+    best = None
+    for feature in snap["features"]:
+        if within and domain(feature["id"]) != within:
+            continue
+        total = sum(len(feature["levels"][lvl].get("tests", [])) for lvl in LEVELS)
+        if best is None or total > best[1]:
+            best = (feature["id"], total)
+    return best
+
+
+def least_proven_invariant(snap, within=None):
+    """The invariant proven on the fewest of the integrations it applies to.
+
+    Exempt cells count as neither proof nor hole: an integration excused from
+    an invariant is not evidence that the invariant is unproven.
+    """
+    worst = None
+    for inv in snap["invariants"]:
+        if within and domain(inv["id"]) != within:
+            continue
+        applicable = [levels for levels in inv["integrations"].values()
+                      if cell_state(levels) != "exempt"]
+        if not applicable:
+            continue
+        proven = sum(1 for levels in applicable if cell_state(levels) == "covered")
+        share = proven / len(applicable)
+        if worst is None or share < worst[3]:
+            worst = (inv["id"], proven, len(applicable), share)
+    return worst
+
+
+def strongest_argument(snap):
+    """A heavily tested feature paired with an unproven invariant of the same
+    subsystem, as (feature, tests, invariant, proven, applicable).
+
+    Same subsystem is what makes the pair an argument rather than a
+    coincidence. A feature with many tests somewhere else in the engine says
+    nothing about a sink invariant; a feature with many tests *in the sink
+    layer* alongside a sink invariant nothing proves says exactly the thing
+    this file exists to say.
+
+    Generated rather than written down so it cannot go stale.
+    """
+    best = None
+    for subsystem in sorted({domain(i["id"]) for i in snap["invariants"]}):
+        feature = most_tested_feature(snap, within=subsystem)
+        invariant = least_proven_invariant(snap, within=subsystem)
+        if not feature or not invariant or feature[1] == 0:
+            continue
+        # Rank by tests: the more a subsystem is tested while an invariant of
+        # its own goes unproven, the louder the point.
+        if best is None or feature[1] > best[1]:
+            best = (feature[0], feature[1], invariant[0], invariant[1], invariant[2])
+    return best
 
 
 def render_invariants(snap):
@@ -677,30 +839,43 @@ def render_invariants(snap):
                 if integ not in columns:
                     columns.append(integ)
 
+        # Split by whether the invariant has integrations. A pipeline row in a
+        # table of sink columns renders as a line of dots, which reads as "not
+        # applicable" when the truth is "nothing collects this yet".
+        per_integration = [i for i in rows if i["integrations"]]
+        per_pipeline = [i for i in rows if not i["integrations"]]
+
         lines += [f"## Invariants: {family}", ""]
-        if columns:
+
+        if per_integration:
             lines.append("| Invariant | Claim | "
                          + " | ".join(f"`{c}`" for c in columns) + " |")
             lines.append("| --- | --- | "
                          + " | ".join("---" for _ in columns) + " |")
-        else:
-            # pipeline invariants have no per-integration column.
-            lines.append("| Invariant | Claim | Verified by |")
-            lines.append("| --- | --- | --- |")
-
-        for inv in rows:
-            claim = inv["claim"]
-            if inv.get("tracked_by"):
-                claim += f" *(declared, tracked by {inv['tracked_by']})*"
-            if columns:
+            for inv in per_integration:
                 cells = " | ".join(
                     invariant_cell(inv["integrations"][c], inv["requires"])
                     if c in inv["integrations"] else "·"
                     for c in columns)
-                lines.append(f"| `{inv['id']}` | {claim} | {cells} |")
-            else:
-                lines.append(f"| `{inv['id']}` | {claim} | {inv['verified_by']} |")
-        lines.append("")
+                lines.append(f"| `{inv['id']}` | {describe_claim(inv)} | {cells} |")
+            lines.append("")
+
+        if per_pipeline:
+            lines += [
+                f"These {family} invariants are properties of the pipeline, not",
+                "of any one integration, so they have no column. **No evidence is",
+                "collected for them yet**: `verified_by: named` is declared and",
+                "not wired, so an empty cell here means unmeasured, not passing.",
+                "The feature table above may show the same ground as covered,",
+                "and where the two disagree this one is the weaker claim.",
+                "",
+                "| Invariant | Claim | Evidence |",
+                "| --- | --- | --- |",
+            ]
+            for inv in per_pipeline:
+                lines.append(f"| `{inv['id']}` | {describe_claim(inv)} | "
+                             f"❌ none collected (`{inv['verified_by']}`) |")
+            lines.append("")
 
     if snap["invariant_gaps"]:
         lines += ["## Invariant gaps", "",

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -90,17 +90,23 @@ def match(name, prefixes):
     return best
 
 
-COVERS = re.compile(r"COVERS ([a-z0-9_.]+)")
+# A plain marker names an extra feature. A structured one names an invariant
+# and the integration it was proven on; the harness emits those, and a test
+# name cannot carry two ids.
+COVERS = re.compile(r"COVERS ([a-z0-9_.]+)(?:\s|$)")
+COVERS_INVARIANT = re.compile(
+    r"COVERS invariant=([a-z0-9_.]+) integration=([a-z0-9_.]+)")
 
 
 def parse_go(path):
-    """Read `go test -json` into ({test: outcome}, {test: [extra features]}).
+    """Read `go test -json` into ({test: outcome}, {test: [features]},
+    {test: [(invariant, integration)]}).
 
-    Extras come from coverage.Covers, which writes a COVERS line to the test
-    log. `go test -json` carries that as an output event, so the marker is
+    Markers come from coverage.Covers and coverage.Invariant, which write to
+    the test log. `go test -json` carries that as an output event, so both are
     read from ordinary suite output with no plugin and no build tag.
     """
-    results, covers = {}, {}
+    results, covers, invariants = {}, {}, {}
     with open(path) as fh:
         for line in fh:
             line = line.strip()
@@ -114,7 +120,12 @@ def parse_go(path):
             if not name:
                 continue
             if action == "output":
-                found = COVERS.findall(event.get("Output", ""))
+                out = event.get("Output", "")
+                structured = COVERS_INVARIANT.findall(out)
+                if structured:
+                    invariants.setdefault(name, []).extend(structured)
+                    continue
+                found = COVERS.findall(out)
                 if found:
                     covers.setdefault(name, []).extend(found)
             # Subtests report their own outcome; the parent aggregates them.
@@ -124,11 +135,16 @@ def parse_go(path):
                 results[name] = SKIP if results.get(name) != PASS else PASS
             elif action == "fail":
                 results[name] = FAIL
-    return results, covers
+    return results, covers, invariants
 
 
 def parse_pytest(path):
-    """Read the conftest report into ({test: outcome}, {test: [extras]})."""
+    """Read the conftest report into ({test: outcome}, {test: [extras]}, {}).
+
+    The third value is the invariant map, empty here: the harness is Go, and
+    the release suite carries no structured markers. It is returned so both
+    parsers have one shape.
+    """
     with open(path) as fh:
         report = json.load(fh)
 
@@ -140,7 +156,7 @@ def parse_pytest(path):
         }.get(test.get("outcome"), FAIL)
         if test.get("covers"):
             covers[name] = list(test["covers"])
-    return results, covers
+    return results, covers, {}
 
 
 def build(features, go_results, py_results, go_covers=None, py_covers=None,
@@ -392,15 +408,15 @@ def main():
     args = ap.parse_args()
 
     features = load_features()
-    go_results, go_covers = (
-        parse_go(args.go) if args.go and os.path.exists(args.go) else ({}, {}))
-    it_results, it_covers = (
+    go_results, go_covers, go_invariants = (
+        parse_go(args.go) if args.go and os.path.exists(args.go) else ({}, {}, {}))
+    it_results, it_covers, it_invariants = (
         parse_go(args.go_integration)
         if args.go_integration and os.path.exists(args.go_integration)
-        else ({}, {}))
-    py_results, py_covers = (
+        else ({}, {}, {}))
+    py_results, py_covers, py_invariants = (
         parse_pytest(args.pytest)
-        if args.pytest and os.path.exists(args.pytest) else ({}, {}))
+        if args.pytest and os.path.exists(args.pytest) else ({}, {}, {}))
 
     coverage, secondary, unmatched, unknown = build(
         features, go_results, py_results, go_covers, py_covers,

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -252,7 +252,7 @@ def test_parse_go_reads_outcomes_and_markers(tmp_path):
         json.dumps({"Action": "fail", "Test": "TestC"}),
         "not json at all",
     ]))
-    results, covers = cm.parse_go(path)
+    results, covers, _ = cm.parse_go(path)
 
     assert results == {"TestA": cm.PASS, "TestB": cm.SKIP, "TestC": cm.FAIL}
     assert covers == {"TestA": ["sink.clickhouse"]}
@@ -262,8 +262,33 @@ def test_parse_go_ignores_package_level_events(tmp_path):
     """Events with no Test are the package summary, not a test result."""
     path = write(tmp_path, "go.json",
                  json.dumps({"Action": "pass", "Package": "x"}))
-    results, _ = cm.parse_go(path)
+    results, _, _ = cm.parse_go(path)
     assert results == {}
+
+
+def test_parse_go_reads_structured_invariant_markers(tmp_path):
+    """The harness emits one line per (invariant, integration). Both ids are
+    carried; the parser must not collapse them into the feature list."""
+    path = write(tmp_path, "go.json", "\n".join([
+        json.dumps({"Action": "output", "Test": "TestA",
+                    "Output": "    x.go:1: COVERS invariant=sink.flush.keeps_batch integration=sink.clickhouse\n"}),
+        json.dumps({"Action": "output", "Test": "TestA",
+                    "Output": "    x.go:2: COVERS sink.clickhouse\n"}),
+        json.dumps({"Action": "pass", "Test": "TestA"}),
+    ]))
+    results, covers, invariants = cm.parse_go(path)
+
+    assert results == {"TestA": cm.PASS}
+    assert covers == {"TestA": ["sink.clickhouse"]}
+    assert invariants == {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}
+
+
+def test_parse_pytest_returns_an_empty_invariant_map(tmp_path):
+    path = write(tmp_path, "pytest.json", json.dumps({"tests": [
+        {"nodeid": "test_a", "outcome": "passed", "covers": []},
+    ]}))
+    results, covers, invariants = cm.parse_pytest(path)
+    assert invariants == {}
 
 
 def test_parse_go_lets_a_pass_outrank_a_skipped_subtest():
@@ -278,7 +303,7 @@ def test_parse_pytest_reads_outcomes_and_markers(tmp_path):
         {"nodeid": "test_b", "outcome": "skipped", "covers": []},
         {"nodeid": "test_c", "outcome": "failed", "covers": []},
     ]}))
-    results, covers = cm.parse_pytest(path)
+    results, covers, _ = cm.parse_pytest(path)
 
     assert results == {"test_sink_clickhouse_x": cm.PASS,
                        "test_b": cm.SKIP, "test_c": cm.FAIL}

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -390,7 +390,7 @@ def test_every_exceptional_name_also_appears_in_tests():
 
 def test_the_snapshot_declares_its_schema_version():
     """A reader that expects per-test objects must be able to tell."""
-    assert snap()["version"] == 2
+    assert snap()["version"] == 3
 
 
 def test_render_agrees_with_the_snapshot():
@@ -559,3 +559,500 @@ def test_validate_rejects_a_requires_level_that_does_not_exist():
     bad = [dict(INVARIANTS[0], requires=["nightly"])]
     problems = cm.validate_registries(bad, INTEGRATIONS, FEATURES)
     assert any("nightly" in p for p in problems)
+
+
+# --- The invariant axis ----------------------------------------------------
+
+def inv_snap(evidence=None, results=None, invariants=None, integrations=None):
+    """evidence: {level: {test: [(invariant, integration)]}}
+    results:    {level: {test: outcome}}"""
+    evidence = evidence or {}
+    results = results or {}
+    invariants = invariants or INVARIANTS
+    integrations = integrations or INTEGRATIONS
+    built = cm.build_invariants(
+        invariants, integrations,
+        {lvl: results.get(lvl, {}) for lvl in cm.LEVELS},
+        {lvl: evidence.get(lvl, {}) for lvl in cm.LEVELS})
+    return cm.snapshot_invariants(invariants, integrations, built)
+
+
+def cell(s, invariant, integration, lvl):
+    for inv in s["invariants"]:
+        if inv["id"] == invariant:
+            return inv["integrations"][integration][lvl]
+    raise AssertionError(f"{invariant} not in the snapshot")
+
+
+def test_a_passing_harness_case_covers_the_cell():
+    name = "TestIntegrationSinkClickhouse_Conformance/keeps_batch"
+    s = inv_snap(
+        evidence={"integration": {name: [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"integration": {name: cm.PASS}},
+    )
+    c = cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "integration")
+    assert c["status"] == "covered"
+    assert c["tests"] == [name]
+
+
+def test_a_marker_from_a_failing_test_is_not_coverage():
+    """The harness emits the marker only on pass, but the parent that ran the
+    subtest can still fail afterwards, and that verdict is the reported one."""
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"integration": {"TestX": cm.FAIL}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse",
+                "integration")["status"] == "failing"
+
+
+def test_a_marker_from_a_skipped_test_is_not_coverage():
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"integration": {"TestX": cm.SKIP}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse",
+                "integration")["status"] == "skipped"
+
+
+def test_an_integration_with_no_evidence_is_missing():
+    s = inv_snap()
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse",
+                "integration")["status"] == "missing"
+
+
+def test_an_exempt_integration_renders_exempt_with_its_reason():
+    s = inv_snap()
+    c = cell(s, "sink.flush.keeps_batch", "sink.console", "integration")
+    assert c["status"] == "exempt"
+    assert c["reason"] == "stdout"
+
+
+def test_an_invariant_applies_only_to_its_kind():
+    """A source has no cell under a sink invariant at all."""
+    s = inv_snap()
+    inv = next(i for i in s["invariants"] if i["id"] == "sink.flush.keeps_batch")
+    assert "source.kafka" not in inv["integrations"]
+    assert set(inv["integrations"]) == {"sink.clickhouse", "sink.console"}
+
+
+def test_an_unrequired_level_is_not_a_gap():
+    s = inv_snap()
+    assert s["invariant_gaps"] == []
+
+
+def test_a_required_level_with_no_evidence_is_a_gap():
+    required = [dict(INVARIANTS[0], requires=["integration"])]
+    s = inv_snap(invariants=required)
+    assert {"invariant": "sink.flush.keeps_batch", "integration": "sink.clickhouse",
+            "level": "integration", "status": "missing"} in s["invariant_gaps"]
+    # console is exempt, so it is not a gap even at a required level.
+    assert not any(g["integration"] == "sink.console" for g in s["invariant_gaps"])
+
+
+def test_a_marker_naming_an_unknown_invariant_or_integration_is_reported():
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("sink.flush.bogus", "sink.clickhouse"),
+                                            ("sink.flush.keeps_batch", "sink.bogus")]}},
+        results={"integration": {"TestX": cm.PASS}},
+    )
+    assert {"test": "TestX", "invariant": "sink.flush.bogus",
+            "integration": "sink.clickhouse"} in s["unknown_invariant_markers"]
+    assert {"test": "TestX", "invariant": "sink.flush.keeps_batch",
+            "integration": "sink.bogus"} in s["unknown_invariant_markers"]
+
+
+def test_two_unknown_invariant_markers_do_not_crash_the_snapshot():
+    """Guard against the sorted()-over-dicts crash the feature snapshot has:
+    sort by tuple, never by dict."""
+    s = inv_snap(
+        evidence={"integration": {"TestX": [("a.b.c", "sink.clickhouse")],
+                                  "TestY": [("d.e.f", "sink.clickhouse")]}},
+        results={"integration": {"TestX": cm.PASS, "TestY": cm.PASS}},
+    )
+    assert len(s["unknown_invariant_markers"]) == 2
+
+
+def test_a_tracked_invariant_renders_as_declared_unenforced():
+    tracked = [dict(INVARIANTS[0], tracked_by="#183")]
+    s = inv_snap(invariants=tracked)
+    inv = next(i for i in s["invariants"] if i["id"] == "sink.flush.keeps_batch")
+    assert inv["tracked_by"] == "#183"
+
+
+def test_render_carries_one_table_per_family():
+    s = inv_snap()
+    md = cm.render_invariants(s)
+    assert "## Invariants: resilience" in md
+    assert "## Invariants: checkpoint" in md
+    assert "| `sink.flush.keeps_batch` |" in md
+
+
+def test_render_marks_an_exempt_cell():
+    s = inv_snap()
+    md = cm.render_invariants(s)
+    line = next(l for l in md.splitlines() if "`sink.flush.keeps_batch`" in l)
+    assert "exempt" in line
+
+
+def test_a_test_carrying_any_marker_is_not_unattributed():
+    """A marker-attributed test was listed under "match no declared feature".
+    The conformance harness attributes only by marker, and a shared runner's
+    name matches no feature prefix at all, so every one of its cases would
+    land there telling the reader to rename a test that already says what it
+    covers."""
+    name = "TestConformanceSinks_KeepsBatch"
+    s = snap(
+        integration_results={name: cm.PASS},
+        integration_covers={name: ["sink.clickhouse"]},
+    )
+    assert s["unattributed"]["integration"] == []
+    assert level(s, "sink.clickhouse", "integration")["status"] == "covered"
+
+
+def test_a_test_matching_nothing_and_carrying_no_marker_is_still_unattributed():
+    """The report still catches what it is for: #221's four misnamed tests."""
+    s = snap(integration_results={"TestNobodyDeclaredThis": cm.PASS})
+    assert s["unattributed"]["integration"] == ["TestNobodyDeclaredThis"]
+
+
+# --- build_invariants: attribution, in isolation ---------------------------
+#
+# The two functions below decide every invariant cell in the matrix, so they
+# are tested directly rather than only through the snapshot. A wrong cell is a
+# wrong gate: a covered cell that is not covered is the sink.iceberg failure
+# with more ceremony.
+
+def built(evidence=None, results=None, invariants=None, integrations=None):
+    evidence = evidence or {}
+    results = results or {}
+    return cm.build_invariants(
+        invariants or INVARIANTS, integrations or INTEGRATIONS,
+        {lvl: results.get(lvl, {}) for lvl in cm.LEVELS},
+        {lvl: evidence.get(lvl, {}) for lvl in cm.LEVELS})
+
+
+def test_build_keys_a_cell_by_invariant_integration_and_level():
+    b = built(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert b["cells"] == {
+        ("sink.flush.keeps_batch", "sink.clickhouse", "unit"): [("TestA", cm.PASS)]
+    }
+
+
+def test_build_records_the_same_invariant_at_each_level_separately():
+    """unit and integration are different evidence for the same claim, and the
+    matrix must be able to say 'proven with a fake, never against the real
+    thing'."""
+    pair = [("sink.flush.keeps_batch", "sink.clickhouse")]
+    b = built(
+        evidence={"unit": {"TestA": pair}, "integration": {"TestB": pair}},
+        results={"unit": {"TestA": cm.PASS}, "integration": {"TestB": cm.PASS}},
+    )
+    assert set(b["cells"]) == {
+        ("sink.flush.keeps_batch", "sink.clickhouse", "unit"),
+        ("sink.flush.keeps_batch", "sink.clickhouse", "integration"),
+    }
+
+
+def test_build_collects_every_test_that_proves_one_cell():
+    pair = [("sink.flush.keeps_batch", "sink.clickhouse")]
+    b = built(
+        evidence={"unit": {"TestB": pair, "TestA": pair}},
+        results={"unit": {"TestA": cm.PASS, "TestB": cm.PASS}},
+    )
+    key = ("sink.flush.keeps_batch", "sink.clickhouse", "unit")
+    # Order is the snapshot's business, not this function's.
+    assert sorted(b["cells"][key]) == [("TestA", cm.PASS), ("TestB", cm.PASS)]
+
+
+def test_build_takes_the_outcome_from_the_result_not_the_marker():
+    b = built(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.FAIL}},
+    )
+    key = ("sink.flush.keeps_batch", "sink.clickhouse", "unit")
+    assert b["cells"][key] == [("TestA", cm.FAIL)]
+
+
+def test_build_treats_a_marker_with_no_result_as_a_failure():
+    """A marker whose test has no verdict means the event stream lost it.
+    Reading that as coverage would report a cell nobody proved."""
+    b = built(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={},
+    )
+    key = ("sink.flush.keeps_batch", "sink.clickhouse", "unit")
+    assert b["cells"][key] == [("TestA", cm.FAIL)]
+
+
+def test_build_reports_an_unknown_id_rather_than_inventing_a_cell():
+    b = built(
+        evidence={"unit": {"TestA": [("nope.nope", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert b["cells"] == {}
+    assert b["unknown"] == [("TestA", "nope.nope", "sink.clickhouse")]
+
+
+def test_build_over_no_evidence_is_empty_not_an_error():
+    b = built()
+    assert b == {"cells": {}, "unknown": []}
+
+
+# --- snapshot_invariants: the encoding ------------------------------------
+
+def test_snapshot_carries_the_declaration_onto_every_invariant():
+    s = inv_snap()
+    inv = next(i for i in s["invariants"] if i["id"] == "sink.flush.keeps_batch")
+
+    assert inv["family"] == "resilience"
+    assert inv["applies_to"] == "sink"
+    assert inv["claim"] == "kept"
+    assert inv["verified_by"] == "harness"
+    assert inv["requires"] == []
+
+
+def test_snapshot_folds_a_wrapped_claim_onto_one_line():
+    """The YAML wraps long claims. Rewrapping one must not show up as a
+    coverage change in the JSON diff a reviewer reads."""
+    wrapped = [dict(INVARIANTS[0], claim="a claim\nwrapped over\nthree lines")]
+    s = inv_snap(invariants=wrapped)
+    assert s["invariants"][0]["claim"] == "a claim wrapped over three lines"
+
+
+def test_snapshot_omits_tracked_by_and_violated_once_when_absent():
+    """Same rule as the feature half: an absent fact costs no bytes."""
+    s = inv_snap()
+    inv = s["invariants"][0]
+    assert "tracked_by" not in inv
+    assert "violated_once" not in inv
+
+
+def test_snapshot_carries_violated_once_when_present():
+    s = inv_snap(invariants=[dict(INVARIANTS[0], violated_once=["#221"])])
+    assert s["invariants"][0]["violated_once"] == ["#221"]
+
+
+def test_snapshot_gives_every_level_a_cell():
+    s = inv_snap()
+    inv = next(i for i in s["invariants"] if i["id"] == "sink.flush.keeps_batch")
+    assert set(inv["integrations"]["sink.clickhouse"]) == set(cm.LEVELS)
+
+
+def test_snapshot_names_a_skipped_test_in_the_skipped_list():
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.SKIP}},
+    )
+    c = cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "unit")
+    assert c["tests"] == ["TestA"]
+    assert c["skipped"] == ["TestA"]
+    assert "failing" not in c
+
+
+def test_snapshot_names_a_failing_test_in_the_failing_list():
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.FAIL}},
+    )
+    c = cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "unit")
+    assert c["failing"] == ["TestA"]
+    assert "skipped" not in c
+
+
+def test_snapshot_omits_an_empty_exceptional_list():
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "unit") == {
+        "status": "covered", "tests": ["TestA"]}
+
+
+def test_snapshot_every_exceptional_name_also_appears_in_tests():
+    """skipped and failing narrow tests; they never extend it. The same
+    encoding rule the feature half follows."""
+    pair = [("sink.flush.keeps_batch", "sink.clickhouse")]
+    s = inv_snap(
+        evidence={"unit": {"TestA": pair, "TestB": pair, "TestC": pair}},
+        results={"unit": {"TestA": cm.PASS, "TestB": cm.SKIP, "TestC": cm.FAIL}},
+    )
+    c = cell(s, "sink.flush.keeps_batch", "sink.clickhouse", "unit")
+    for name in c.get("skipped", []) + c.get("failing", []):
+        assert name in c["tests"]
+
+
+def test_snapshot_one_pass_among_skips_covers_the_cell():
+    pair = [("sink.flush.keeps_batch", "sink.clickhouse")]
+    s = inv_snap(
+        evidence={"unit": {"TestA": pair, "TestB": pair}},
+        results={"unit": {"TestA": cm.PASS, "TestB": cm.SKIP}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse",
+                "unit")["status"] == "covered"
+
+
+def test_snapshot_one_failure_among_passes_fails_the_cell():
+    pair = [("sink.flush.keeps_batch", "sink.clickhouse")]
+    s = inv_snap(
+        evidence={"unit": {"TestA": pair, "TestB": pair}},
+        results={"unit": {"TestA": cm.PASS, "TestB": cm.FAIL}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse",
+                "unit")["status"] == "failing"
+
+
+def test_snapshot_an_exempt_cell_carries_no_tests_even_with_evidence():
+    """An exemption is a statement that the invariant cannot apply. Evidence
+    against it means the registry and the harness disagree, and the registry
+    is the declaration -- but the cell must not read as covered."""
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.console")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    c = cell(s, "sink.flush.keeps_batch", "sink.console", "unit")
+    assert c["status"] == "exempt"
+    assert "tests" not in c
+
+
+def test_snapshot_a_pipeline_invariant_has_no_integration_cells():
+    """It attaches to core, and no constructor case is a pipeline."""
+    pipeline = [{"id": "pipeline.commit.after_flush", "family": "checkpoint",
+                 "applies_to": "pipeline", "claim": "c", "verified_by": "named",
+                 "requires": []}]
+    s = inv_snap(invariants=pipeline)
+    assert s["invariants"][0]["integrations"] == {}
+
+
+def test_snapshot_orders_tests_stably_whatever_order_they_arrived_in():
+    """`go test` reports in completion order, which varies run to run. The
+    same tree must still produce the same bytes, or the staleness check fails
+    on noise and a reader learns to ignore it."""
+    pair = [("sink.flush.keeps_batch", "sink.clickhouse")]
+    results = {"unit": {"TestA": cm.PASS, "TestB": cm.PASS, "TestC": cm.PASS}}
+
+    forwards = inv_snap(
+        evidence={"unit": {"TestA": pair, "TestB": pair, "TestC": pair}},
+        results=results)
+    backwards = inv_snap(
+        evidence={"unit": {"TestC": pair, "TestB": pair, "TestA": pair}},
+        results=results)
+
+    assert json.dumps(forwards) == json.dumps(backwards)
+    assert cell(forwards, "sink.flush.keeps_batch", "sink.clickhouse",
+                "unit")["tests"] == ["TestA", "TestB", "TestC"]
+
+
+def test_snapshot_orders_unknown_markers_stably():
+    pair_a = ("nope.a", "sink.clickhouse")
+    pair_b = ("nope.b", "sink.clickhouse")
+    results = {"unit": {"TestA": cm.PASS, "TestB": cm.PASS}}
+
+    forwards = inv_snap(
+        evidence={"unit": {"TestA": [pair_b], "TestB": [pair_a]}}, results=results)
+    backwards = inv_snap(
+        evidence={"unit": {"TestB": [pair_a], "TestA": [pair_b]}}, results=results)
+
+    assert forwards["unknown_invariant_markers"] == backwards["unknown_invariant_markers"]
+    assert [m["test"] for m in forwards["unknown_invariant_markers"]] == ["TestA", "TestB"]
+
+
+def test_snapshot_gap_records_the_status_that_caused_it():
+    """'sink.kafka: integration is skipped' sends the reader somewhere;
+    'is missing' sends them somewhere else."""
+    required = [dict(INVARIANTS[0], requires=["unit"])]
+    s = inv_snap(
+        invariants=required,
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.SKIP}},
+    )
+    assert {"invariant": "sink.flush.keeps_batch", "integration": "sink.clickhouse",
+            "level": "unit", "status": "skipped"} in s["invariant_gaps"]
+
+
+def test_snapshot_a_covered_required_level_is_not_a_gap():
+    required = [dict(INVARIANTS[0], requires=["unit"])]
+    s = inv_snap(
+        invariants=required,
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert not any(g["integration"] == "sink.clickhouse"
+                   for g in s["invariant_gaps"])
+
+
+def test_snapshot_requires_one_level_and_ignores_the_others():
+    """Requiring integration must not make a missing unit cell a gap."""
+    required = [dict(INVARIANTS[0], requires=["integration"])]
+    s = inv_snap(invariants=required)
+    levels = {g["level"] for g in s["invariant_gaps"]}
+    assert levels == {"integration"}
+
+
+def test_snapshot_deduplicates_an_unknown_marker_seen_twice():
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("nope.nope", "sink.clickhouse"),
+                                     ("nope.nope", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert s["unknown_invariant_markers"] == [
+        {"test": "TestA", "invariant": "nope.nope", "integration": "sink.clickhouse"}]
+
+
+# --- render_invariants -----------------------------------------------------
+
+def test_render_agrees_with_the_snapshot():
+    """The markdown is a view. It can never disagree with the JSON that gates
+    the build."""
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    md = cm.render_invariants(s)
+    line = next(l for l in md.splitlines() if "`sink.flush.keeps_batch`" in l)
+    # clickhouse is covered at unit and missing elsewhere, and no level is
+    # required, so the cell shows the worst of the three.
+    assert "missing" in line
+
+
+def test_render_shows_covered_when_every_judged_level_is_covered():
+    required = [dict(INVARIANTS[0], requires=["unit"])]
+    s = inv_snap(
+        invariants=required,
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    md = cm.render_invariants(s)
+    line = next(l for l in md.splitlines() if "`sink.flush.keeps_batch`" in l)
+    assert "✅" in line
+
+
+def test_render_names_the_tracking_issue_of_an_unenforced_invariant():
+    s = inv_snap(invariants=[dict(INVARIANTS[0], tracked_by="#183")])
+    md = cm.render_invariants(s)
+    assert "tracked by #183" in md
+
+
+def test_render_lists_a_gap():
+    required = [dict(INVARIANTS[0], requires=["unit"])]
+    md = cm.render_invariants(inv_snap(invariants=required))
+    assert "## Invariant gaps" in md
+    assert "`sink.flush.keeps_batch` on `sink.clickhouse` requires **unit**" in md
+
+
+def test_render_omits_the_gap_section_when_there_are_none():
+    assert "## Invariant gaps" not in cm.render_invariants(inv_snap())
+
+
+def test_render_gives_a_pipeline_family_a_verified_by_column():
+    """With no integrations there is no cell to show, so the table says how
+    the claim is proven instead of leaving an empty row."""
+    pipeline = [{"id": "pipeline.commit.after_flush", "family": "checkpoint",
+                 "applies_to": "pipeline", "claim": "c", "verified_by": "named",
+                 "requires": []}]
+    md = cm.render_invariants(inv_snap(invariants=pipeline))
+    assert "| Invariant | Claim | Verified by |" in md
+    assert "| `pipeline.commit.after_flush` | c | named |" in md

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -479,3 +479,83 @@ def test_the_check_exits_non_zero_on_a_gap(tmp_path):
 
     assert proc.returncode == 1, proc.stdout
     assert "coverage gap" in proc.stderr
+
+
+# --- Registries ------------------------------------------------------------
+
+INVARIANTS = [
+    {"id": "sink.flush.keeps_batch", "family": "resilience", "applies_to": "sink",
+     "claim": "kept", "verified_by": "harness", "requires": []},
+    {"id": "source.commit.only_processed", "family": "checkpoint",
+     "applies_to": "source", "claim": "c", "verified_by": "harness", "requires": []},
+]
+
+INTEGRATIONS = [
+    {"id": "sink.clickhouse", "kind": "sink", "implements": ["Sink"],
+     "feature": "sink.clickhouse", "exempt": []},
+    {"id": "sink.console", "kind": "sink", "implements": ["Sink"],
+     "feature": "sink.console",
+     "exempt": [{"invariant": "sink.flush.keeps_batch", "reason": "stdout"}]},
+    {"id": "source.kafka", "kind": "source", "implements": ["Source"],
+     "feature": "source.kafka", "exempt": []},
+]
+
+
+def test_the_committed_registries_load_and_validate():
+    """The real files, not fixtures: a typo in either fails here before it can
+    fail in CI."""
+    invariants = cm.load_invariants()
+    integrations = cm.load_integrations()
+    features = cm.load_features()
+
+    assert cm.validate_registries(invariants, integrations, features) == []
+    assert len(invariants) >= 20
+    assert {i["kind"] for i in integrations} == {"sink", "source", "handler"}
+
+
+def test_every_committed_invariant_is_unenforced_in_this_revision():
+    """This revision reports and fails nothing. Filling in a requires is a
+    later change, and legal only once every non-exempt integration has a
+    subject."""
+    for inv in cm.load_invariants():
+        assert inv["requires"] == [], inv["id"]
+
+
+def test_validate_rejects_an_exemption_naming_no_invariant():
+    bad = [dict(INTEGRATIONS[1], exempt=[
+        {"invariant": "sink.flush.nonexistent", "reason": "r"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("sink.flush.nonexistent" in p for p in problems)
+
+
+def test_validate_rejects_an_exemption_without_a_reason():
+    bad = [dict(INTEGRATIONS[1], exempt=[
+        {"invariant": "sink.flush.keeps_batch"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("reason" in p for p in problems)
+
+
+def test_validate_rejects_an_exemption_from_an_invariant_of_another_kind():
+    """A sink cannot be exempt from a source invariant; that is a typo."""
+    bad = [dict(INTEGRATIONS[0], exempt=[
+        {"invariant": "source.commit.only_processed", "reason": "r"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("applies_to" in p for p in problems)
+
+
+def test_validate_rejects_an_integration_naming_no_feature():
+    bad = [dict(INTEGRATIONS[0], feature="sink.nonexistent")]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("sink.nonexistent" in p for p in problems)
+
+
+def test_validate_rejects_a_duplicate_invariant_id():
+    problems = cm.validate_registries(
+        INVARIANTS + [INVARIANTS[0]], INTEGRATIONS, FEATURES)
+    assert any("duplicate" in p for p in problems)
+
+
+def test_validate_rejects_a_requires_level_that_does_not_exist():
+    bad = [dict(INVARIANTS[0], requires=["nightly"])]
+    problems = cm.validate_registries(bad, INTEGRATIONS, FEATURES)
+    assert any("nightly" in p for p in problems)

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -1095,12 +1095,208 @@ def test_render_omits_the_gap_section_when_there_are_none():
     assert "## Invariant gaps" not in cm.render_invariants(inv_snap())
 
 
-def test_render_gives_a_pipeline_family_a_verified_by_column():
-    """With no integrations there is no cell to show, so the table says how
-    the claim is proven instead of leaving an empty row."""
+def test_render_says_a_pipeline_invariant_has_no_evidence_rather_than_a_dot():
+    """A pipeline row among sink columns rendered as a line of dots, which
+    reads as "not applicable" when the truth is "nothing collects this yet".
+    verified_by: named is declared and not wired."""
     pipeline = [{"id": "pipeline.commit.after_flush", "family": "checkpoint",
                  "applies_to": "pipeline", "claim": "c", "verified_by": "named",
                  "requires": []}]
     md = cm.render_invariants(inv_snap(invariants=pipeline))
-    assert "| Invariant | Claim | Verified by |" in md
-    assert "| `pipeline.commit.after_flush` | c | named |" in md
+
+    assert "| Invariant | Claim | Evidence |" in md
+    assert "| `pipeline.commit.after_flush` | c | ❌ none collected (`named`) |" in md
+    assert "unmeasured, not passing" in md
+
+
+def test_render_separates_pipeline_rows_from_integration_rows_in_one_family():
+    """checkpoint holds both. Mixing them puts dots in a table of real cells."""
+    mixed = [
+        dict(INVARIANTS[1], family="checkpoint"),           # applies_to source
+        {"id": "pipeline.commit.after_flush", "family": "checkpoint",
+         "applies_to": "pipeline", "claim": "c", "verified_by": "named",
+         "requires": []},
+    ]
+    md = cm.render_invariants(inv_snap(invariants=mixed))
+
+    assert md.count("## Invariants: checkpoint") == 1
+    assert "| Invariant | Claim | `source.kafka` |" in md
+    assert "| Invariant | Claim | Evidence |" in md
+    # The pipeline row never appears in the integration table.
+    integration_table = md.split("| Invariant | Claim | Evidence |")[0]
+    assert "pipeline.commit.after_flush" not in integration_table
+
+
+# --- The summary a skimmer reads -------------------------------------------
+
+def test_the_feature_total_says_it_counts_attribution_not_proof():
+    """"33 fully covered" beside an almost empty invariant matrix reads as
+    proof. The reader who stops at the first bold line must not be misled."""
+    md = cm.render(snap(go_results={"TestSinkClickhouse_InsertsRows": cm.PASS}))
+
+    assert "at least one passing test attributed at every level they require" in md
+    assert "counts attribution, not proof" in md
+
+
+def test_the_feature_total_omits_the_invariant_count_when_there_is_none():
+    """render() is called on feature-only snapshots in tests and by nothing
+    else; it must not require the second axis."""
+    md = cm.render(snap())
+    assert "invariants declared" not in md
+
+
+def test_the_invariant_count_sits_beside_the_feature_count():
+    s = snap()
+    s.update(inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}}))
+    md = cm.render(s)
+
+    assert "invariants declared" in md
+    assert "1 proven" in md
+    assert "exempt" in md
+
+
+def test_the_tally_counts_every_cell_by_state():
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}})
+    tally, unwired = cm.invariant_tally(s)
+
+    # keeps_batch: clickhouse covered, console exempt.
+    # only_processed: kafka missing.
+    assert tally["covered"] == 1
+    assert tally["exempt"] == 1
+    assert tally["missing"] == 1
+    assert unwired == 0
+
+
+def test_the_tally_counts_a_pipeline_invariant_as_unwired_not_as_zero():
+    pipeline = [{"id": "pipeline.commit.after_flush", "family": "checkpoint",
+                 "applies_to": "pipeline", "claim": "c", "verified_by": "named",
+                 "requires": []}]
+    tally, unwired = cm.invariant_tally(inv_snap(invariants=pipeline))
+
+    assert unwired == 1
+    assert sum(tally.values()) == 0
+
+
+def test_the_page_pairs_the_most_tested_feature_with_the_least_proven_invariant():
+    """The argument for the file, generated so it cannot go stale. A feature
+    can carry dozens of tests while the invariant those tests depend on is
+    proven almost nowhere -- which is how a retry ladder passes every test
+    while the sink under it loses the batch."""
+    s = snap(go_results={
+        "TestSinkClickhouse_A": cm.PASS,
+        "TestSinkClickhouse_B": cm.PASS,
+        "TestSinkConsole_C": cm.PASS,
+    })
+    s.update(inv_snap())
+    md = cm.render(s)
+
+    assert "## Why invariants, and not the test count" in md
+    assert "`sink.clickhouse` carries 2 attributed tests" in md
+    assert "is proven on 0 of the" in md
+
+
+def test_the_argument_pairs_a_feature_and_an_invariant_of_the_same_layer():
+    """A heavily tested feature elsewhere in the engine says nothing about a
+    sink invariant. Only same-layer pairs are an argument."""
+    features = FEATURES + [
+        {"id": "config.validation", "description": "c", "requires": ["unit"]},
+        {"id": "sink.retry", "description": "r", "requires": ["unit"]},
+    ]
+    s = snap(features=features, go_results={
+        **{f"TestConfigValidation_{i}": cm.PASS for i in range(20)},
+        **{f"TestSinkRetry_{i}": cm.PASS for i in range(5)},
+    })
+    s.update(inv_snap())
+
+    feature, tests, invariant, _, _ = cm.strongest_argument(s)
+    # config.validation has four times the tests and no invariant of its own,
+    # so it is not the argument.
+    assert feature == "sink.retry"
+    assert tests == 5
+    assert invariant.startswith("sink.")
+
+
+def test_the_argument_needs_an_invariant_in_the_same_layer():
+    """A layer with tests and no invariants declared is not an argument."""
+    features = [{"id": "config.validation", "description": "c", "requires": ["unit"]}]
+    s = snap(features=features,
+             go_results={"TestConfigValidation_A": cm.PASS})
+    s.update(inv_snap())
+    assert cm.strongest_argument(s) is None
+
+
+def test_domain_names_the_subsystem():
+    assert cm.domain("sink.retry") == "sink"
+    assert cm.domain("sink.flush.keeps_batch") == "sink"
+    assert cm.domain("config.validation") == "config"
+
+
+def test_the_argument_is_omitted_when_no_feature_has_a_test():
+    s = snap()
+    s.update(inv_snap())
+    assert "## Why invariants, and not the test count" not in cm.render(s)
+
+
+def test_the_most_tested_feature_counts_across_every_level():
+    s = snap(
+        go_results={"TestSinkClickhouse_A": cm.PASS},
+        py_results={"test_sink_clickhouse_b": cm.PASS},
+        integration_results={"TestSinkConsole_C": cm.PASS},
+    )
+    assert cm.most_tested_feature(s) == ("sink.clickhouse", 2)
+
+
+def test_the_least_proven_invariant_ignores_exempt_integrations():
+    """console is exempt from keeps_batch, so it is neither proof nor a hole:
+    counting it as unproven would overstate the gap."""
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}})
+
+    invariant, proven, applicable, _ = cm.least_proven_invariant(s)
+    # only_processed applies to source.kafka alone and has no proof at all.
+    assert invariant == "source.commit.only_processed"
+    assert (proven, applicable) == (0, 1)
+
+
+def test_the_least_proven_invariant_prefers_the_smaller_share():
+    """Two invariants with no proof and different reach: the one covering more
+    integrations is the bigger hole, but share is what ranks them."""
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}})
+    _, proven, applicable, share = cm.least_proven_invariant(s)
+    assert share == proven / applicable
+
+
+def test_the_least_proven_invariant_is_none_when_nothing_is_applicable():
+    """Nothing to prove is not the same as nothing proven, and the page must
+    say nothing rather than invent a worst case."""
+    integrations = [dict(INTEGRATIONS[1])]  # console only, and it is exempt
+    s = inv_snap(integrations=integrations)
+    assert cm.least_proven_invariant(s) is None
+
+
+def test_the_argument_is_omitted_when_no_invariant_is_applicable():
+    s = snap(go_results={"TestSinkClickhouse_A": cm.PASS})
+    s.update(inv_snap(integrations=[dict(INTEGRATIONS[1])]))
+    assert "## Why invariants, and not the test count" not in cm.render(s)
+
+
+def test_cell_state_reports_the_worst_thing_that_happened():
+    assert cm.cell_state(levels(unit="covered", integration="failing")) == "failing"
+    assert cm.cell_state(levels(unit="covered", integration="missing")) == "covered"
+    assert cm.cell_state(levels(unit="skipped")) == "skipped"
+    assert cm.cell_state(levels()) == "missing"
+    assert cm.cell_state(
+        {lvl: {"status": "exempt", "reason": "r"} for lvl in cm.LEVELS}) == "exempt"
+
+
+def test_a_claim_carries_the_defect_that_proves_it_matters():
+    """violated_once is the difference between a rule and a scar."""
+    s = inv_snap(invariants=[dict(INVARIANTS[0], violated_once=["#221"])])
+    assert "violated once: #221" in cm.render_invariants(s)

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -1006,16 +1006,17 @@ def test_snapshot_deduplicates_an_unknown_marker_seen_twice():
 
 def test_render_agrees_with_the_snapshot():
     """The markdown is a view. It can never disagree with the JSON that gates
-    the build."""
+    the build, and a cell the JSON calls covered must not read as missing."""
     s = inv_snap(
         evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
         results={"unit": {"TestA": cm.PASS}},
     )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse",
+                "unit")["status"] == "covered"
+
     md = cm.render_invariants(s)
     line = next(l for l in md.splitlines() if "`sink.flush.keeps_batch`" in l)
-    # clickhouse is covered at unit and missing elsewhere, and no level is
-    # required, so the cell shows the worst of the three.
-    assert "missing" in line
+    assert "✅ u" in line
 
 
 def test_render_shows_covered_when_every_judged_level_is_covered():
@@ -1027,7 +1028,54 @@ def test_render_shows_covered_when_every_judged_level_is_covered():
     )
     md = cm.render_invariants(s)
     line = next(l for l in md.splitlines() if "`sink.flush.keeps_batch`" in l)
-    assert "✅" in line
+    assert "✅ u" in line
+
+
+# --- invariant_cell: what a reader sees ------------------------------------
+#
+# The cell answers "proven with a fake, or against the real thing?", which a
+# bare tick cannot. These pin each shape it can take.
+
+def levels(**states):
+    return {lvl: {"status": states.get(lvl, "missing")} for lvl in cm.LEVELS}
+
+
+def test_cell_names_the_level_that_proved_it():
+    assert cm.invariant_cell(levels(integration="covered"), []) == "✅ i"
+    assert cm.invariant_cell(levels(unit="covered"), []) == "✅ u"
+
+
+def test_cell_names_every_level_that_proved_it():
+    """'covered at unit but never against the real thing' is the question the
+    matrix exists to answer, so both levels show."""
+    assert cm.invariant_cell(
+        levels(unit="covered", integration="covered"), []) == "✅ ui"
+
+
+def test_cell_with_no_evidence_is_missing():
+    assert cm.invariant_cell(levels(), []) == "❌ missing"
+
+
+def test_cell_reports_a_failure_over_anything_achieved():
+    assert cm.invariant_cell(
+        levels(unit="covered", integration="failing"), []) == "🔥 failing"
+
+
+def test_cell_reports_a_skip_rather_than_missing():
+    assert cm.invariant_cell(levels(unit="skipped"), []) == "⚠️ skipped"
+
+
+def test_cell_is_exempt_whatever_else_is_present():
+    assert cm.invariant_cell(
+        {lvl: {"status": "exempt", "reason": "r"} for lvl in cm.LEVELS},
+        []) == "— exempt"
+
+
+def test_cell_warns_when_a_required_level_is_not_the_one_proven():
+    """A tick beside an unmet requirement reads as done. The gap is listed
+    below the table, and the cell must not contradict it."""
+    assert cm.invariant_cell(
+        levels(unit="covered"), ["integration"]) == "⚠️ u, integration missing"
 
 
 def test_render_names_the_tracking_issue_of_an_unenforced_invariant():


### PR DESCRIPTION
Every integration must prove the same base properties. Today the proof is uneven: ClickHouse has a test for "a failed flush keeps its batch", Iceberg has the code and no test, and the Kafka sink has neither and violates it.

This declares the invariants once, verifies them the same way for every integration, and adds a second axis to the coverage matrix. It enforces nothing: every `requires` is empty, and the matrix reports.

Spec: `docs/superpowers/specs/2026-09-06-invariant-matrix-design.md`. Plan: `docs/superpowers/plans/2026-09-06-invariant-matrix-foundation.md`. Both are in the diff, because the code argues from them.

## What lands

- **`docs/coverage/invariants.yml`** — 28 claims, each grounded in a test that exists, a defect that was fixed, or an issue that is open.
- **`docs/coverage/integrations.yml`** — 12 constructor cases, what each implements, and what each is exempt from with a reason.
- **`internal/conformance`** — one harness. A subject supplies five closures; the harness runs one sequence and judges each invariant separately, emitting `COVERS invariant=… integration=…` on a pass.
- **`internal/conformance/proxy.go`** — toxiproxy with a `timeout` toxic: a partition, not a refusal.
- **`internal/sinks/conformance_test.go`** — the ClickHouse subject, against a real server behind the proxy.
- **`scripts/coverage_matrix.py`** — the invariant axis, its gaps feeding `--check`.

## What the matrix now says

```
| sink.write.buffers_only | ❌ missing | ✅ i | ❌ missing | ❌ missing | ❌ missing | — exempt |
| sink.flush.keeps_batch  | ❌ missing | ✅ i | ❌ missing | — exempt   | — exempt   | — exempt |
```

Columns are kafka, clickhouse, iceberg, sqlcommand, console, noop. `✅ i` means proven at integration level and nowhere else — which is the question this matrix exists to answer.

## Two invariants, not one, and that is the point

The plan scoped this to `sink.flush.keeps_batch` alone. The harness's own test against a write-through sink — the Kafka sink's exact shape — **passed**: the row reached the destination before the fault, so the final read-back found it and every check succeeded for the wrong reason.

A read-back *before* the first flush is what catches it, and that is `sink.write.buffers_only`. Without it this foundation would not have caught the defect PR 2 exists to fix.

## Three defects the first regeneration forced

- Every cell read `not_required`. The feature-axis rule was copied; for an invariant, `requires` decides whether a missing cell *fails the build*, not whether evidence is expected.
- Every cell then read `missing`, hiding ClickHouse's real coverage: the cell showed the worst of three levels. It now names the levels that proved it.
- The harness's own tests credited `sink.clickhouse` from an in-memory fake. They attribute to `sink.noop`, which is exempt, so a fake's marker changes nothing.

## Two fixes carried along

From the 2026-09-06 review, both of which the harness depends on: a test carrying a marker is no longer reported as unattributed, and unknown markers sort by tuple rather than by dict, so two of them report instead of raising `TypeError`.

## Evidence

- `TestIntegrationSinkClickhouse_Conformance` passes in 18.6s, emitting one marker per invariant. `-short` skips before any container starts.
- 107 tooling tests, up from 44. Ten mutations of the new Python were each caught by a test.
- 16 Go packages green; integration pass reports no failure; `make coverage-check` exits 0; `unattributed` is empty at all three levels.

## What is next

PR 2 adds the Kafka subject, watches it fail, and fixes the sink: `WriteTable` buffers, `Flush` keeps what it could not deliver. PR 3 adds the Iceberg subject and flips the first `requires`, after which a new sink cannot merge without proving both.

## If this is wrong

A cell reads covered that nobody proved, which is the `sink.iceberg` failure with more ceremony. Every cell today reads missing or exempt except two, and those two were earned against a real server and a real partition.
