### PR TITLE
Batch resiliency, enforced for every sink

### DIFF
--- a/docs/coverage/features.yml
+++ b/docs/coverage/features.yml
@@ -75,6 +75,12 @@ features:
     description: Writes result rows to stdout as JSON.
     requires: [unit, release]
 
+  # Configurable, so it ships. It exists to measure the engine without a sink,
+  # and borrowing sink.console's row hid its tests from the matrix.
+  - id: sink.noop
+    description: Discards every result row, for measuring the engine without a sink.
+    requires: [unit]
+
   - id: sink.retry
     description: Retries a sink whose destination is not answering, bounded by a deadline.
     requires: [unit]

--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -43,56 +43,52 @@ integrations:
     implements: [Sink]
     feature: sink.sqlcommand
     exempt:
-      - invariant: sink.flush.keeps_batch
-        reason: >
-          writes through the pipeline's own DuckDB connection, so a failure is
-          not a network blip. retriesHelp already excludes it.
-      - invariant: sink.flush.honours_context
-        reason: nothing to wait on that a context could cut short
-      - invariant: sink.error.classifies
-        reason: no network, so nothing to classify as unreachable
       - invariant: sink.probe.fails_start
-        reason: nothing to dial
+        reason: implements no Prober, so there is no start-time check to fail
+        proven_by: TestSinkSqlcommand_ImplementsNoProber
 
   - id: sink.console
     kind: sink
     implements: [Sink]
     feature: sink.console
     exempt:
-      - invariant: sink.flush.keeps_batch
-        reason: >
-          stdout cannot be temporarily unavailable. retriesHelp already
-          excludes it.
-      - invariant: sink.flush.honours_context
-        reason: nothing to wait on that a context could cut short
-      - invariant: sink.error.classifies
-        reason: no network, so nothing to classify as unreachable
       - invariant: sink.probe.fails_start
-        reason: nothing to dial
+        reason: implements no Prober, so there is no start-time check to fail
+        proven_by: TestSinkConsole_ImplementsNoProber
 
   - id: sink.noop
     kind: sink
     implements: [Sink]
     feature: sink.console
+    # noop has no destination at all, which is its whole purpose: it exists so
+    # a benchmark can measure the engine without a sink. Every invariant about
+    # delivering rows is vacuous for it, and one test states that contract
+    # directly rather than eight reasons asserting it.
     exempt:
       - invariant: sink.write.buffers_only
-        reason: >
-          discards every row by design, so there is no destination for a
-          write to reach and nothing a read-back could show
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.flush.keeps_batch
-        reason: discards every row by design; it exists for benchmarking
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.flush.no_hollow_success
-        reason: discards every row by design
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.flush.preserves_order
-        reason: discards every row by design
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.flush.honours_context
-        reason: nothing to wait on
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.batch.reports_buffer
-        reason: buffers nothing by design
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.error.classifies
-        reason: never fails
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.probe.fails_start
-        reason: nothing to dial
+        reason: implements no Prober, so there is no start-time check to fail
+        proven_by: TestSinkNoop_ImplementsNoProber
 
   # --- Sources ---------------------------------------------------------------
   - id: source.kafka
@@ -107,13 +103,17 @@ integrations:
     feature: source.websocket
     exempt:
       - invariant: source.commit.only_processed
-        reason: no replayable position; at-most-once by construction
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebsocket_ImplementsNoMarkCommitter
       - invariant: source.resume.from_committed
-        reason: no replayable position; at-most-once by construction
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebsocket_ImplementsNoMarkCommitter
       - invariant: source.marks.never_regress
-        reason: no marks
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebsocket_ImplementsNoMarkCommitter
       - invariant: source.commit.on_revoke
-        reason: no partitions to revoke
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebsocket_ImplementsNoMarkCommitter
 
   - id: source.webhook
     kind: source
@@ -121,13 +121,17 @@ integrations:
     feature: source.webhook
     exempt:
       - invariant: source.commit.only_processed
-        reason: no replayable position; at-most-once by construction
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebhook_ImplementsNoMarkCommitter
       - invariant: source.resume.from_committed
-        reason: no replayable position; at-most-once by construction
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebhook_ImplementsNoMarkCommitter
       - invariant: source.marks.never_regress
-        reason: no marks
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebhook_ImplementsNoMarkCommitter
       - invariant: source.commit.on_revoke
-        reason: no partitions to revoke
+        reason: implements no MarkCommitter; at-most-once by construction
+        proven_by: TestSourceWebhook_ImplementsNoMarkCommitter
 
   # --- Handlers --------------------------------------------------------------
   - id: handler.structured

--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -59,7 +59,7 @@ integrations:
   - id: sink.noop
     kind: sink
     implements: [Sink]
-    feature: sink.console
+    feature: sink.noop
     # noop has no destination at all, which is its whole purpose: it exists so
     # a benchmark can measure the engine without a sink. Every invariant about
     # delivering rows is vacuous for it, and one test states that contract
@@ -83,12 +83,31 @@ integrations:
       - invariant: sink.batch.reports_buffer
         reason: has no destination; discarding every row is the contract
         proven_by: TestSinkNoop_DeliversNothingAndSaysSo
+      - invariant: sink.buffer.reports_depth
+        reason: has no destination; it holds nothing, so there is no depth to report
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.error.classifies
         reason: has no destination; discarding every row is the contract
         proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.probe.fails_start
         reason: implements no Prober, so there is no start-time check to fail
         proven_by: TestSinkNoop_ImplementsNoProber
+
+  # The conformance harness's own doubles run under this id.
+  #
+  # They must name an integration, because a marker carries one. Naming a real
+  # sink would credit that sink for what a double did, and it would force
+  # exemptions onto a customer-facing sink for reasons that have nothing to do
+  # with its contract: the first invariant NoopSink genuinely satisfies would
+  # have to be exempted anyway, hiding real coverage.
+  #
+  # test_only keeps it out of the matrix. Its markers are known, so they are
+  # not reported as unknown, and they land on no cell.
+  - id: sink.conformance_double
+    kind: sink
+    test_only: true
+    implements: [Sink]
+    exempt: []
 
   # --- Sources ---------------------------------------------------------------
   - id: source.kafka

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -31,6 +31,10 @@ invariants:
     claim: WriteTable does not reach the destination. Only Flush does.
     verified_by: harness
     requires: []
+    # Every sink proves this, so a new one cannot merge without a conformance
+    # subject. The level is the integration's business: ClickHouse and Kafka
+    # need a container, console and sqlcommand fail in-process.
+    enforced: true
 
   - id: sink.flush.keeps_batch
     family: resilience
@@ -40,6 +44,7 @@ invariants:
       re-attempts them.
     verified_by: harness
     requires: []
+    enforced: true
     violated_once: ["#221"]
 
   - id: sink.flush.no_hollow_success

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -79,6 +79,16 @@ invariants:
     verified_by: harness
     requires: []
 
+  - id: sink.buffer.reports_depth
+    family: resilience
+    applies_to: sink
+    claim: >
+      A sink reports how many rows it is holding, and the count rises when a
+      flush fails and falls to zero when one succeeds.
+    verified_by: harness
+    requires: []
+    enforced: true
+
   - id: sink.batch.reports_buffer
     family: resilience
     applies_to: sink

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -119,22 +119,25 @@ invariants:
     family: checkpoint
     applies_to: pipeline
     claim: Offsets and state commit only after Flush returned nil.
-    verified_by: named
+    verified_by: harness
     requires: []
+    enforced: true
 
   - id: pipeline.commit.nothing_on_failure
     family: checkpoint
     applies_to: pipeline
     claim: A failed flush commits nothing. Not offsets, not state.
-    verified_by: named
+    verified_by: harness
     requires: []
+    enforced: true
 
   - id: pipeline.state.with_offsets
     family: checkpoint
     applies_to: pipeline
     claim: Window state and the offsets that produced it commit atomically.
-    verified_by: named
+    verified_by: harness
     requires: []
+    enforced: true
 
   - id: source.commit.only_processed
     family: checkpoint
@@ -231,14 +234,15 @@ invariants:
     family: lifecycle
     applies_to: pipeline
     claim: Cancel or SIGTERM flushes the buffered batch, then commits.
-    verified_by: named
+    verified_by: harness
     requires: []
+    enforced: true
 
   - id: lifecycle.drain.bounded
     family: lifecycle
     applies_to: pipeline
     claim: The drain finishes or fails inside its deadline.
-    verified_by: named
+    verified_by: harness
     requires: []
     tracked_by: "#161"
 
@@ -255,7 +259,7 @@ invariants:
     claim: >
       A batch whose query exceeds the timeout fails the batch, not the
       process.
-    verified_by: named
+    verified_by: harness
     requires: []
     tracked_by: "#163"
 
@@ -264,7 +268,7 @@ invariants:
     family: errors
     applies_to: pipeline
     claim: A DLQ record carries the payload, offset, partition and reason.
-    verified_by: named
+    verified_by: harness
     requires: []
     tracked_by: "#166"
 
@@ -274,6 +278,6 @@ invariants:
     claim: >
       N bad records in a window fail the pipeline rather than discarding
       forever.
-    verified_by: named
+    verified_by: harness
     requires: []
     tracked_by: "#166"

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -2395,30 +2395,82 @@
       "family": "checkpoint",
       "applies_to": "pipeline",
       "claim": "Offsets and state commit only after Flush returned nil.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
-      "enforced": false,
-      "integrations": {}
+      "enforced": true,
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestCoreConsumeLoop_ProcessBatchFlushesSinkBeforeCommittingState"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
     },
     {
       "id": "pipeline.commit.nothing_on_failure",
       "family": "checkpoint",
       "applies_to": "pipeline",
       "claim": "A failed flush commits nothing. Not offsets, not state.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
-      "enforced": false,
-      "integrations": {}
+      "enforced": true,
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestCoreConsumeLoop_ProcessBatchCommitFailureDoesNotCommitSource",
+              "TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
     },
     {
       "id": "pipeline.state.with_offsets",
       "family": "checkpoint",
       "applies_to": "pipeline",
       "claim": "Window state and the offsets that produced it commit atomically.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
-      "enforced": false,
-      "integrations": {}
+      "enforced": true,
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestCoreConsumeLoop_ProcessBatchRollsBackWhenOffsetSaveFails"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
     },
     {
       "id": "source.commit.only_processed",
@@ -3246,20 +3298,52 @@
       "family": "lifecycle",
       "applies_to": "pipeline",
       "claim": "Cancel or SIGTERM flushes the buffered batch, then commits.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
-      "enforced": false,
-      "integrations": {}
+      "enforced": true,
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestLifecycleDrain_CancelDrainsTheBufferedBatch"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
     },
     {
       "id": "lifecycle.drain.bounded",
       "family": "lifecycle",
       "applies_to": "pipeline",
       "claim": "The drain finishes or fails inside its deadline.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
       "enforced": false,
-      "integrations": {},
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
       "tracked_by": "#161"
     },
     {
@@ -3362,10 +3446,25 @@
       "family": "lifecycle",
       "applies_to": "pipeline",
       "claim": "A batch whose query exceeds the timeout fails the batch, not the process.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
       "enforced": false,
-      "integrations": {},
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
       "tracked_by": "#163"
     },
     {
@@ -3373,10 +3472,25 @@
       "family": "errors",
       "applies_to": "pipeline",
       "claim": "A DLQ record carries the payload, offset, partition and reason.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
       "enforced": false,
-      "integrations": {},
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
       "tracked_by": "#166"
     },
     {
@@ -3384,10 +3498,25 @@
       "family": "errors",
       "applies_to": "pipeline",
       "claim": "N bad records in a window fail the pipeline rather than discarding forever.",
-      "verified_by": "named",
+      "verified_by": "harness",
       "requires": [],
       "enforced": false,
-      "integrations": {},
+      "integrations": {
+        "pipeline": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
       "tracked_by": "#166"
     }
   ],

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -145,16 +145,25 @@
         "unit": {
           "status": "covered",
           "tests": [
+            "TestIntegrationSinkKafka_Conformance",
             "TestSinkKafka_BatchIsTheLastWrite",
             "TestSinkKafka_FlushHonoursItsContext",
             "TestSinkKafka_FlushReportsProduceErrors",
             "TestSinkKafka_NewRejectsAnUnknownSecurityProtocol",
             "TestSinkKafka_NewRequiresATopic",
-            "TestSinkKafka_WriteTableHonoursItsContext"
+            "TestSinkKafka_WriteTableBuffersWhateverItsContextSays"
+          ],
+          "skipped": [
+            "TestIntegrationSinkKafka_Conformance"
           ]
         },
         "integration": {
-          "status": "not_required"
+          "status": "covered",
+          "tests": [
+            "TestIntegrationSinkKafka_Conformance",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.keeps_batch",
+            "TestIntegrationSinkKafka_Conformance/sink.write.buffers_only"
+          ]
         },
         "release": {
           "status": "covered",
@@ -242,6 +251,9 @@
             "TestSinkIceberg_CatalogPropertiesFromPyicebergFile",
             "TestSinkIceberg_CatalogPropertiesRejectAnUnsupportedScheme",
             "TestSinkIceberg_CatalogPropertiesRequireAURI",
+            "TestSinkIceberg_Conformance",
+            "TestSinkIceberg_Conformance/sink.flush.keeps_batch",
+            "TestSinkIceberg_Conformance/sink.write.buffers_only",
             "TestSinkIceberg_EmptyBatchAppendsNothing",
             "TestSinkIceberg_FlushWithNothingPendingAppendsNothing",
             "TestSinkIceberg_MissingTableFailsTheStart",
@@ -293,9 +305,13 @@
           "tests": [
             "TestSinkSqlcommand_AccumulatesUntilFlush",
             "TestSinkSqlcommand_BatchIsTheLastWrite",
+            "TestSinkSqlcommand_Conformance",
+            "TestSinkSqlcommand_Conformance/sink.flush.keeps_batch",
+            "TestSinkSqlcommand_Conformance/sink.write.buffers_only",
             "TestSinkSqlcommand_EachFlushReplacesTheBatchTable",
             "TestSinkSqlcommand_EmptyBatchStillRunsTheSQL",
             "TestSinkSqlcommand_FlushWithNothingPendingIsANoop",
+            "TestSinkSqlcommand_ImplementsNoProber",
             "TestSinkSqlcommand_NewRequiresSQL",
             "TestSinkSqlcommand_RejectsAnUnknownSubstitution",
             "TestSinkSqlcommand_ReportsASQLError",
@@ -322,6 +338,10 @@
         "unit": {
           "status": "covered",
           "tests": [
+            "TestSinkConsole_Conformance",
+            "TestSinkConsole_Conformance/sink.flush.keeps_batch",
+            "TestSinkConsole_Conformance/sink.write.buffers_only",
+            "TestSinkConsole_ImplementsNoProber",
             "TestSinkConsole_RowsAsJSONEmptyTable",
             "TestSinkConsole_RowsAsJSONOneObjectPerRow"
           ]
@@ -1263,6 +1283,7 @@
             "TestToolingConformanceSinks_ASubjectWithBreakAndNoHealIsRejected",
             "TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped",
             "TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected",
+            "TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject",
             "TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants"
           ]
         },
@@ -1309,7 +1330,10 @@
   ],
   "gaps": [],
   "unattributed": {
-    "unit": [],
+    "unit": [
+      "TestSinkNoop_DeliversNothingAndSaysSo",
+      "TestSinkNoop_ImplementsNoProber"
+    ],
     "integration": [],
     "release": []
   },
@@ -1327,6 +1351,7 @@
       "claim": "WriteTable does not reach the destination. Only Flush does.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": true,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -1334,8 +1359,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.write.buffers_only"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1360,8 +1387,10 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkIceberg_Conformance/sink.write.buffers_only"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1374,8 +1403,10 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.write.buffers_only"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1388,8 +1419,10 @@
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.write.buffers_only"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1403,15 +1436,18 @@
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "discards every row by design, so there is no destination for a write to reach and nothing a read-back could show\n"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
             "status": "exempt",
-            "reason": "discards every row by design, so there is no destination for a write to reach and nothing a read-back could show\n"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
             "status": "exempt",
-            "reason": "discards every row by design, so there is no destination for a write to reach and nothing a read-back could show\n"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       }
@@ -1423,6 +1459,7 @@
       "claim": "A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": true,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -1430,8 +1467,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.keeps_batch"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1456,8 +1495,10 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkIceberg_Conformance/sink.flush.keeps_batch"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1470,44 +1511,51 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "exempt",
-            "reason": "writes through the pipeline's own DuckDB connection, so a failure is not a network blip. retriesHelp already excludes it.\n"
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.flush.keeps_batch"
+            ]
           },
           "integration": {
-            "status": "exempt",
-            "reason": "writes through the pipeline's own DuckDB connection, so a failure is not a network blip. retriesHelp already excludes it.\n"
+            "status": "missing",
+            "tests": []
           },
           "release": {
-            "status": "exempt",
-            "reason": "writes through the pipeline's own DuckDB connection, so a failure is not a network blip. retriesHelp already excludes it.\n"
+            "status": "missing",
+            "tests": []
           }
         },
         "sink.console": {
           "unit": {
-            "status": "exempt",
-            "reason": "stdout cannot be temporarily unavailable. retriesHelp already excludes it.\n"
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.flush.keeps_batch"
+            ]
           },
           "integration": {
-            "status": "exempt",
-            "reason": "stdout cannot be temporarily unavailable. retriesHelp already excludes it.\n"
+            "status": "missing",
+            "tests": []
           },
           "release": {
-            "status": "exempt",
-            "reason": "stdout cannot be temporarily unavailable. retriesHelp already excludes it.\n"
+            "status": "missing",
+            "tests": []
           }
         },
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "discards every row by design; it exists for benchmarking"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
             "status": "exempt",
-            "reason": "discards every row by design; it exists for benchmarking"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
             "status": "exempt",
-            "reason": "discards every row by design; it exists for benchmarking"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       },
@@ -1522,6 +1570,7 @@
       "claim": "Flush returns nil only when every row since the last success was acknowledged by the destination.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -1596,15 +1645,18 @@
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "discards every row by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
             "status": "exempt",
-            "reason": "discards every row by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
             "status": "exempt",
-            "reason": "discards every row by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       },
@@ -1619,6 +1671,7 @@
       "claim": "Rows reach the destination in WriteTable order, across a retry.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -1693,15 +1746,18 @@
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "discards every row by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
             "status": "exempt",
-            "reason": "discards every row by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
             "status": "exempt",
-            "reason": "discards every row by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       }
@@ -1713,6 +1769,7 @@
       "claim": "Flush returns ctx.Err() when the context ends. Rows stay buffered.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -1758,44 +1815,47 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "exempt",
-            "reason": "nothing to wait on that a context could cut short"
+            "status": "missing",
+            "tests": []
           },
           "integration": {
-            "status": "exempt",
-            "reason": "nothing to wait on that a context could cut short"
+            "status": "missing",
+            "tests": []
           },
           "release": {
-            "status": "exempt",
-            "reason": "nothing to wait on that a context could cut short"
+            "status": "missing",
+            "tests": []
           }
         },
         "sink.console": {
           "unit": {
-            "status": "exempt",
-            "reason": "nothing to wait on that a context could cut short"
+            "status": "missing",
+            "tests": []
           },
           "integration": {
-            "status": "exempt",
-            "reason": "nothing to wait on that a context could cut short"
+            "status": "missing",
+            "tests": []
           },
           "release": {
-            "status": "exempt",
-            "reason": "nothing to wait on that a context could cut short"
+            "status": "missing",
+            "tests": []
           }
         },
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "nothing to wait on"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
             "status": "exempt",
-            "reason": "nothing to wait on"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
             "status": "exempt",
-            "reason": "nothing to wait on"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       },
@@ -1810,6 +1870,7 @@
       "claim": "Flush with nothing buffered returns nil and touches nothing.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -1904,6 +1965,7 @@
       "claim": "Batch returns what is buffered, and nil when nothing is.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -1978,15 +2040,18 @@
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "buffers nothing by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
             "status": "exempt",
-            "reason": "buffers nothing by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
             "status": "exempt",
-            "reason": "buffers nothing by design"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       }
@@ -1998,6 +2063,7 @@
       "claim": "The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -2043,44 +2109,47 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "exempt",
-            "reason": "no network, so nothing to classify as unreachable"
+            "status": "missing",
+            "tests": []
           },
           "integration": {
-            "status": "exempt",
-            "reason": "no network, so nothing to classify as unreachable"
+            "status": "missing",
+            "tests": []
           },
           "release": {
-            "status": "exempt",
-            "reason": "no network, so nothing to classify as unreachable"
+            "status": "missing",
+            "tests": []
           }
         },
         "sink.console": {
           "unit": {
-            "status": "exempt",
-            "reason": "no network, so nothing to classify as unreachable"
+            "status": "missing",
+            "tests": []
           },
           "integration": {
-            "status": "exempt",
-            "reason": "no network, so nothing to classify as unreachable"
+            "status": "missing",
+            "tests": []
           },
           "release": {
-            "status": "exempt",
-            "reason": "no network, so nothing to classify as unreachable"
+            "status": "missing",
+            "tests": []
           }
         },
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "never fails"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
             "status": "exempt",
-            "reason": "never fails"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
             "status": "exempt",
-            "reason": "never fails"
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       }
@@ -2092,6 +2161,7 @@
       "claim": "A Prober whose destination is unreachable fails the start once, without retrying.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -2138,43 +2208,52 @@
         "sink.sqlcommand": {
           "unit": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoProber"
           },
           "integration": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoProber"
           },
           "release": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoProber"
           }
         },
         "sink.console": {
           "unit": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkConsole_ImplementsNoProber"
           },
           "integration": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkConsole_ImplementsNoProber"
           },
           "release": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkConsole_ImplementsNoProber"
           }
         },
         "sink.noop": {
           "unit": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkNoop_ImplementsNoProber"
           },
           "integration": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkNoop_ImplementsNoProber"
           },
           "release": {
             "status": "exempt",
-            "reason": "nothing to dial"
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkNoop_ImplementsNoProber"
           }
         }
       }
@@ -2186,6 +2265,7 @@
       "claim": "Offsets and state commit only after Flush returned nil.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {}
     },
     {
@@ -2195,6 +2275,7 @@
       "claim": "A failed flush commits nothing. Not offsets, not state.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {}
     },
     {
@@ -2204,6 +2285,7 @@
       "claim": "Window state and the offsets that produced it commit atomically.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {}
     },
     {
@@ -2213,6 +2295,7 @@
       "claim": "A source commits the marks the pipeline processed, never what it fetched.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "source.kafka": {
           "unit": {
@@ -2231,29 +2314,35 @@
         "source.websocket": {
           "unit": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           }
         },
         "source.webhook": {
           "unit": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           }
         }
       },
@@ -2268,6 +2357,7 @@
       "claim": "Restart resumes at the committed position. No gap, and no replay before it.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "source.kafka": {
           "unit": {
@@ -2286,29 +2376,35 @@
         "source.websocket": {
           "unit": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           }
         },
         "source.webhook": {
           "unit": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no replayable position; at-most-once by construction"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           }
         }
       }
@@ -2320,6 +2416,7 @@
       "claim": "A committed position never moves backwards.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "source.kafka": {
           "unit": {
@@ -2338,29 +2435,35 @@
         "source.websocket": {
           "unit": {
             "status": "exempt",
-            "reason": "no marks"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no marks"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no marks"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           }
         },
         "source.webhook": {
           "unit": {
             "status": "exempt",
-            "reason": "no marks"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no marks"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no marks"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           }
         }
       }
@@ -2372,6 +2475,7 @@
       "claim": "Marks commit when a partition is revoked, before the rebalance completes.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "source.kafka": {
           "unit": {
@@ -2390,29 +2494,35 @@
         "source.websocket": {
           "unit": {
             "status": "exempt",
-            "reason": "no partitions to revoke"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no partitions to revoke"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no partitions to revoke"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebsocket_ImplementsNoMarkCommitter"
           }
         },
         "source.webhook": {
           "unit": {
             "status": "exempt",
-            "reason": "no partitions to revoke"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "integration": {
             "status": "exempt",
-            "reason": "no partitions to revoke"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           },
           "release": {
             "status": "exempt",
-            "reason": "no partitions to revoke"
+            "reason": "implements no MarkCommitter; at-most-once by construction",
+            "proven_by": "TestSourceWebhook_ImplementsNoMarkCommitter"
           }
         }
       },
@@ -2425,6 +2535,7 @@
       "claim": "Every declared Arrow type reads back with the declared outcome: exact, coerced by the stated rule, or unsupported with a coded error.",
       "verified_by": "typetable",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -2524,6 +2635,7 @@
       "claim": "A null in every declared type reads back as declared.",
       "verified_by": "typetable",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -2618,6 +2730,7 @@
       "claim": "A timestamp reads back as the same instant. Zone-less is UTC, and the host zone never leaks into the type.",
       "verified_by": "typetable",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -2715,6 +2828,7 @@
       "claim": "list, struct, list-of-struct and list-of-list read back, or are declared unsupported. Never silently flattened.",
       "verified_by": "typetable",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -2809,6 +2923,7 @@
       "claim": "Unicode, escapes and the empty string round-trip byte for byte.",
       "verified_by": "typetable",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -2906,6 +3021,7 @@
       "claim": "An Arrow type absent from the table fails the batch with a coded error. Never coerced silently.",
       "verified_by": "typetable",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -3000,6 +3116,7 @@
       "claim": "Cancel or SIGTERM flushes the buffered batch, then commits.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {}
     },
     {
@@ -3009,6 +3126,7 @@
       "claim": "The drain finishes or fails inside its deadline.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {},
       "tracked_by": "#161"
     },
@@ -3019,6 +3137,7 @@
       "claim": "Close twice is safe.",
       "verified_by": "harness",
       "requires": [],
+      "enforced": false,
       "integrations": {
         "sink.kafka": {
           "unit": {
@@ -3113,6 +3232,7 @@
       "claim": "A batch whose query exceeds the timeout fails the batch, not the process.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {},
       "tracked_by": "#163"
     },
@@ -3123,6 +3243,7 @@
       "claim": "A DLQ record carries the payload, offset, partition and reason.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {},
       "tracked_by": "#166"
     },
@@ -3133,6 +3254,7 @@
       "claim": "N bad records in a window fail the pipeline rather than discarding forever.",
       "verified_by": "named",
       "requires": [],
+      "enforced": false,
       "integrations": {},
       "tracked_by": "#166"
     }

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -161,6 +161,7 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkKafka_Conformance",
+            "TestIntegrationSinkKafka_Conformance/sink.buffer.reports_depth",
             "TestIntegrationSinkKafka_Conformance/sink.flush.keeps_batch",
             "TestIntegrationSinkKafka_Conformance/sink.write.buffers_only"
           ]
@@ -221,6 +222,7 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkClickhouse_Conformance",
+            "TestIntegrationSinkClickhouse_Conformance/sink.buffer.reports_depth",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.keeps_batch",
             "TestIntegrationSinkClickhouse_Conformance/sink.write.buffers_only"
           ]
@@ -252,6 +254,7 @@
             "TestSinkIceberg_CatalogPropertiesRejectAnUnsupportedScheme",
             "TestSinkIceberg_CatalogPropertiesRequireAURI",
             "TestSinkIceberg_Conformance",
+            "TestSinkIceberg_Conformance/sink.buffer.reports_depth",
             "TestSinkIceberg_Conformance/sink.flush.keeps_batch",
             "TestSinkIceberg_Conformance/sink.write.buffers_only",
             "TestSinkIceberg_EmptyBatchAppendsNothing",
@@ -306,6 +309,7 @@
             "TestSinkSqlcommand_AccumulatesUntilFlush",
             "TestSinkSqlcommand_BatchIsTheLastWrite",
             "TestSinkSqlcommand_Conformance",
+            "TestSinkSqlcommand_Conformance/sink.buffer.reports_depth",
             "TestSinkSqlcommand_Conformance/sink.flush.keeps_batch",
             "TestSinkSqlcommand_Conformance/sink.write.buffers_only",
             "TestSinkSqlcommand_EachFlushReplacesTheBatchTable",
@@ -339,6 +343,7 @@
           "status": "covered",
           "tests": [
             "TestSinkConsole_Conformance",
+            "TestSinkConsole_Conformance/sink.buffer.reports_depth",
             "TestSinkConsole_Conformance/sink.flush.keeps_batch",
             "TestSinkConsole_Conformance/sink.write.buffers_only",
             "TestSinkConsole_ImplementsNoProber",
@@ -357,6 +362,28 @@
           "by_marker": [
             "test_handler_inferred_mem_invoke_renders_rows"
           ]
+        }
+      }
+    },
+    {
+      "id": "sink.noop",
+      "description": "Discards every result row, for measuring the engine without a sink.",
+      "requires": [
+        "unit"
+      ],
+      "levels": {
+        "unit": {
+          "status": "covered",
+          "tests": [
+            "TestSinkNoop_DeliversNothingAndSaysSo",
+            "TestSinkNoop_ImplementsNoProber"
+          ]
+        },
+        "integration": {
+          "status": "not_required"
+        },
+        "release": {
+          "status": "not_required"
         }
       }
     },
@@ -1271,12 +1298,15 @@
             "TestToolingConformanceDescribe_NamesTheRowsItFound",
             "TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink",
             "TestToolingConformanceSinks_ACorrectSinkPasses",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.buffer.reports_depth",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.keeps_batch",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.write.buffers_only",
             "TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly",
             "TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught",
             "TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught",
             "TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught",
+            "TestToolingConformanceSinks_ASinkThatMisreportsItsDepthIsCaught",
+            "TestToolingConformanceSinks_ASinkThatReportsNoDepthIsSkipped",
             "TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught",
             "TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker",
             "TestToolingConformanceSinks_ASubjectMissingReadBackIsRejected",
@@ -1284,7 +1314,9 @@
             "TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped",
             "TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected",
             "TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject",
-            "TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants"
+            "TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants",
+            "TestToolingConformanceSinks_TheDoublesIntegrationIsNotAShippedSink",
+            "TestToolingConformanceSinks_TheDoublesRunUnderATestOnlyIntegration"
           ]
         },
         "integration": {
@@ -1330,19 +1362,11 @@
   ],
   "gaps": [],
   "unattributed": {
-    "unit": [
-      "TestSinkNoop_DeliversNothingAndSaysSo",
-      "TestSinkNoop_ImplementsNoProber"
-    ],
+    "unit": [],
     "integration": [],
     "release": []
   },
-  "unknown_markers": [
-    {
-      "test": "TestToolingConformanceSinks_ACorrectSinkPasses",
-      "feature": "sink.noop"
-    }
-  ],
+  "unknown_markers": [],
   "invariants": [
     {
       "id": "sink.write.buffers_only",
@@ -1954,6 +1978,114 @@
           "release": {
             "status": "missing",
             "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "sink.buffer.reports_depth",
+      "family": "resilience",
+      "applies_to": "sink",
+      "claim": "A sink reports how many rows it is holding, and the count rises when a flush fails and falls to zero when one succeeds.",
+      "verified_by": "harness",
+      "requires": [],
+      "enforced": true,
+      "integrations": {
+        "sink.kafka": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.buffer.reports_depth"
+            ]
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.clickhouse": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.buffer.reports_depth"
+            ]
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.iceberg": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestSinkIceberg_Conformance/sink.buffer.reports_depth"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.sqlcommand": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.buffer.reports_depth"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.console": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.buffer.reports_depth"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "sink.noop": {
+          "unit": {
+            "status": "exempt",
+            "reason": "has no destination; it holds nothing, so there is no depth to report",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "has no destination; it holds nothing, so there is no depth to report",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "has no destination; it holds nothing, so there is no depth to report",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       }

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -24,12 +24,12 @@ names every one of them.
 | `source.kafka` | Consumes a Kafka topic, tracking offsets and leader epochs. | ✅ | ✅ | ✅ | 28 |
 | `source.webhook` | Accepts records over HTTP, with optional HMAC signature checks. | ✅ | — | — | 15 |
 | `source.websocket` | Consumes a websocket stream, reconnecting on drop. | ✅ | — | ✅ | 6 |
-| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | — | ✅ | 7 |
+| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 11 |
 | `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 20 |
-| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 13 |
+| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 16 |
 | `sink.parquet` | Writes result batches as parquet files to a local path. | — | — | ✅ | 1 |
-| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 10 |
-| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 3 |
+| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 14 |
+| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 7 |
 | `sink.retry` | Retries a sink whose destination is not answering, bounded by a deadline. | ✅ | — | — | 71 |
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
@@ -52,7 +52,7 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
-| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 16 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 17 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
 **33 features declared. 33 have at least one passing test attributed at every level they require, so 0 gap(s).**
@@ -63,7 +63,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**28 invariants declared. Of 108 (invariant, integration) cells: 2 proven, 82 missing, 0 skipped, 0 failing, 24 exempt. 0 gap(s), because no invariant requires a level yet.**
+**28 invariants declared. Of 108 (invariant, integration) cells: 10 proven, 80 missing, 0 skipped, 0 failing, 18 exempt. 0 gap(s), because no invariant requires a level yet.**
 
 A further 8 invariants attach to the pipeline rather than
 to any one integration. Nothing collects evidence for them yet, so
@@ -102,6 +102,14 @@ that deserves its own test.
 - `config.templating` (release) — via `test_config_validation_accepts_a_shipped_example`
 - `cli.dev_invoke` (release) — via `test_handler_inferred_mem_invoke_renders_rows`
 
+## Unattributed unit tests (2)
+
+These match no declared feature. Either rename them to the
+convention, or add the feature to `features.yml`.
+
+- `TestSinkNoop_DeliversNothingAndSaysSo`
+- `TestSinkNoop_ImplementsNoProber`
+
 ## Markers naming an unknown feature
 
 - `TestToolingConformanceSinks_ACorrectSinkPasses` marks `sink.noop`
@@ -129,14 +137,14 @@ invariant's `requires` is filled in, and none is yet.
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ❌ missing | ✅ i | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. *(violated once: #221)* | ❌ missing | ✅ i | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
+| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. *(violated once: #221)* | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
 | `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. *(violated once: #221)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 | `sink.batch.reports_buffer` | Batch returns what is buffered, and nil when nothing is. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
 
 ## Invariants: checkpoint

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -64,12 +64,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**29 invariants declared. Of 114 (invariant, integration) cells: 15 proven, 80 missing, 0 skipped, 0 failing, 19 exempt. 0 gap(s), because no invariant requires a level yet.**
-
-A further 8 invariants attach to the pipeline rather than
-to any one integration. Nothing collects evidence for them yet, so
-they show no cells at all, which is worse than missing rather than
-better.
+**29 invariants declared. Of 122 (invariant, integration) cells: 19 proven, 84 missing, 0 skipped, 0 failing, 19 exempt. 0 gap(s), because no invariant requires a level yet.**
 
 ## Why invariants, and not the test count
 
@@ -146,18 +141,16 @@ invariant's `requires` is filled in, and none is yet.
 | `source.marks.never_regress` | A committed position never moves backwards. | ❌ missing | — exempt | — exempt |
 | `source.commit.on_revoke` | Marks commit when a partition is revoked, before the rebalance completes. *(declared, tracked by #183)* | ❌ missing | — exempt | — exempt |
 
-These checkpoint invariants are properties of the pipeline, not
-of any one integration, so they have no column. **No evidence is
-collected for them yet**: `verified_by: named` is declared and
-not wired, so an empty cell here means unmeasured, not passing.
-The feature table above may show the same ground as covered,
-and where the two disagree this one is the weaker claim.
+These checkpoint invariants are properties of the engine rather
+than of anything a config names, so they carry one cell instead
+of a column per integration. A test proves one by calling
+`coverage.PipelineInvariant`.
 
-| Invariant | Claim | Evidence |
+| Invariant | Claim | Proven |
 | --- | --- | --- |
-| `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | ❌ none collected (`named`) |
-| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | ❌ none collected (`named`) |
-| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | ❌ none collected (`named`) |
+| `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | ✅ u |
+| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | ✅ u |
+| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | ✅ u |
 
 ## Invariants: types
 
@@ -176,30 +169,26 @@ and where the two disagree this one is the weaker claim.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `lifecycle.close.idempotent` | Close twice is safe. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 
-These lifecycle invariants are properties of the pipeline, not
-of any one integration, so they have no column. **No evidence is
-collected for them yet**: `verified_by: named` is declared and
-not wired, so an empty cell here means unmeasured, not passing.
-The feature table above may show the same ground as covered,
-and where the two disagree this one is the weaker claim.
+These lifecycle invariants are properties of the engine rather
+than of anything a config names, so they carry one cell instead
+of a column per integration. A test proves one by calling
+`coverage.PipelineInvariant`.
 
-| Invariant | Claim | Evidence |
+| Invariant | Claim | Proven |
 | --- | --- | --- |
-| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | ❌ none collected (`named`) |
-| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ none collected (`named`) |
-| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ none collected (`named`) |
+| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | ✅ u |
+| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ missing |
+| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ missing |
 
 ## Invariants: errors
 
-These errors invariants are properties of the pipeline, not
-of any one integration, so they have no column. **No evidence is
-collected for them yet**: `verified_by: named` is declared and
-not wired, so an empty cell here means unmeasured, not passing.
-The feature table above may show the same ground as covered,
-and where the two disagree this one is the weaker claim.
+These errors invariants are properties of the engine rather
+than of anything a config names, so they carry one cell instead
+of a column per integration. A test proves one by calling
+`coverage.PipelineInvariant`.
 
-| Invariant | Claim | Evidence |
+| Invariant | Claim | Proven |
 | --- | --- | --- |
-| `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | ❌ none collected (`named`) |
-| `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | ❌ none collected (`named`) |
+| `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | ❌ missing |
+| `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | ❌ missing |
 

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -24,12 +24,13 @@ names every one of them.
 | `source.kafka` | Consumes a Kafka topic, tracking offsets and leader epochs. | ✅ | ✅ | ✅ | 28 |
 | `source.webhook` | Accepts records over HTTP, with optional HMAC signature checks. | ✅ | — | — | 15 |
 | `source.websocket` | Consumes a websocket stream, reconnecting on drop. | ✅ | — | ✅ | 6 |
-| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 11 |
-| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 20 |
-| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 16 |
+| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 12 |
+| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 21 |
+| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 17 |
 | `sink.parquet` | Writes result batches as parquet files to a local path. | — | — | ✅ | 1 |
-| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 14 |
-| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 7 |
+| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 15 |
+| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 8 |
+| `sink.noop` | Discards every result row, for measuring the engine without a sink. | ✅ | — | — | 2 |
 | `sink.retry` | Retries a sink whose destination is not answering, bounded by a deadline. | ✅ | — | — | 71 |
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
@@ -52,10 +53,10 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
-| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 17 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 22 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
-**33 features declared. 33 have at least one passing test attributed at every level they require, so 0 gap(s).**
+**34 features declared. 34 have at least one passing test attributed at every level they require, so 0 gap(s).**
 
 That sentence counts attribution, not proof. A feature is green here when
 a test named for it ran and passed; it says nothing about whether the
@@ -63,7 +64,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**28 invariants declared. Of 108 (invariant, integration) cells: 10 proven, 80 missing, 0 skipped, 0 failing, 18 exempt. 0 gap(s), because no invariant requires a level yet.**
+**29 invariants declared. Of 114 (invariant, integration) cells: 15 proven, 80 missing, 0 skipped, 0 failing, 19 exempt. 0 gap(s), because no invariant requires a level yet.**
 
 A further 8 invariants attach to the pipeline rather than
 to any one integration. Nothing collects evidence for them yet, so
@@ -102,18 +103,6 @@ that deserves its own test.
 - `config.templating` (release) — via `test_config_validation_accepts_a_shipped_example`
 - `cli.dev_invoke` (release) — via `test_handler_inferred_mem_invoke_renders_rows`
 
-## Unattributed unit tests (2)
-
-These match no declared feature. Either rename them to the
-convention, or add the feature to `features.yml`.
-
-- `TestSinkNoop_DeliversNothingAndSaysSo`
-- `TestSinkNoop_ImplementsNoProber`
-
-## Markers naming an unknown feature
-
-- `TestToolingConformanceSinks_ACorrectSinkPasses` marks `sink.noop`
-
 
 # Invariant matrix
 
@@ -143,6 +132,7 @@ invariant's `requires` is filled in, and none is yet.
 | `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `sink.buffer.reports_depth` | A sink reports how many rows it is holding, and the count rises when a flush fails and falls to zero when one succeeds. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
 | `sink.batch.reports_buffer` | Batch returns what is buffered, and nil when nothing is. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -172,13 +172,29 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	broken, cancel := context.WithTimeout(ctx, flushTimeout)
 	err := sink.Flush(broken)
 	cancel()
+
 	if err == nil {
-		// Not a verdict: a flush that succeeds into a broken destination
-		// proves nothing, because the fault never took. That is the subject's
-		// bug, not the sink's, and blaming the sink sends the reader to the
-		// wrong file.
-		t.Fatalf("conformance: Flush succeeded while the destination was "+
-			"broken, so %s's Break did not break it", s.Integration)
+		// A flush that succeeds into a broken destination means one of two
+		// things, and they point at different files.
+		//
+		// If the rows had already been delivered, this sink writes through:
+		// there was nothing left for the flush to fail on. That is the sink's
+		// bug, buffers_only already caught it, and reporting it as a broken
+		// fault would send the reader to the subject instead.
+		//
+		// If nothing was delivered and the flush still succeeded, the fault
+		// never took. That is the subject's bug and nothing can be judged.
+		if buffers.failure == "" {
+			t.Fatalf("conformance: Flush succeeded while the destination was "+
+				"broken and nothing had been delivered, so %s's Break did not "+
+				"break it", s.Integration)
+		}
+		return []verdict{buffers, {
+			invariant: keepsBatch,
+			failure: "Flush returned nil while the destination was broken, " +
+				"because the rows had already been delivered by WriteTable; " +
+				"there was nothing left to keep",
+		}}
 	}
 
 	keeps := verdict{invariant: keepsBatch}

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -85,9 +85,17 @@ func Sinks(t *testing.T, s SinkSubject) {
 		})
 	}
 
-	// The feature axis credits the integration too, so a conformance run is
-	// not invisible to features.yml.
-	coverage.Covers(t, s.Integration)
+	// The feature axis credits the run too, so a conformance test is not
+	// invisible to features.yml. The feature comes from the registry rather
+	// than from the integration id: sink.noop attributes to sink.console, and
+	// a test_only integration attributes to nothing.
+	feature, has, err := coverage.FeatureFor(s.Integration)
+	if err != nil {
+		t.Fatalf("conformance: %v", err)
+	}
+	if has {
+		coverage.Covers(t, feature)
+	}
 }
 
 func requireSubject(t *testing.T, s SinkSubject) {
@@ -117,20 +125,22 @@ type verdict struct {
 }
 
 const (
-	buffersOnly = "sink.write.buffers_only"
-	keepsBatch  = "sink.flush.keeps_batch"
+	buffersOnly  = "sink.write.buffers_only"
+	keepsBatch   = "sink.flush.keeps_batch"
+	reportsDepth = "sink.buffer.reports_depth"
 )
 
-// sinkVerdicts runs one sequence and judges two invariants from it.
+// sinkVerdicts runs one sequence and judges three invariants from it.
 //
-//  1. WriteTable(A). The destination must still be empty -- buffers_only.
-//  2. Break, then Flush must fail. The destination must still be empty:
-//     rows that could not be delivered were kept, not sent.
-//  3. Heal, then Flush must succeed.
+//  1. WriteTable(A). The destination must still be empty -- buffers_only --
+//     and the sink must report one buffered row -- reports_depth.
+//  2. Break, then Flush must fail. The destination must still be empty and the
+//     sink must still report one row: what it could not deliver, it still owes.
+//  3. Heal, then Flush must succeed. The sink must now report none.
 //  4. The destination must hold exactly A, once -- keeps_batch.
 //
-// The two are separate because a sink can hold either without the other, and
-// the pair is what the pipeline actually depends on. A sink that delivers in
+// The three are separate because a sink can hold any one without the others,
+// and together they are what the pipeline depends on. A sink that delivers in
 // WriteTable passes step 4 for the wrong reason: the row reached the
 // destination before the fault, so nothing was ever kept, and the failed
 // flush left the pipeline unable to commit offsets for rows that did go out.
@@ -147,6 +157,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 		return []verdict{
 			{invariant: buffersOnly, skipped: skip},
 			{invariant: keepsBatch, skipped: skip},
+			{invariant: reportsDepth, skipped: skip},
 		}
 	}
 
@@ -166,6 +177,20 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 		buffers.failure = "the destination holds " + describe(got) +
 			" after WriteTable and before any Flush; only Flush may deliver, " +
 			"because the pipeline commits offsets on what Flush reports"
+	}
+
+	// The sink's own account of what it is holding. The pipeline publishes it
+	// as sink_buffered_rows, and a gauge nobody checks is a gauge that lies
+	// quietly: an operator watching a buffer that stops draining needs this
+	// number to be the truth.
+	depth := verdict{invariant: reportsDepth}
+	reporter, reports := sink.(core.BufferedRowReporter)
+	if !reports {
+		depth.skipped = s.Integration + " reports no buffer depth; exempt it " +
+			"in integrations.yml or implement core.BufferedRowReporter"
+	} else if n := reporter.BufferedRows(); n != 1 {
+		depth.failure = "reports " + strconv.Itoa(n) +
+			" buffered rows after one WriteTable; want 1"
 	}
 
 	s.Break(t)
@@ -194,7 +219,15 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			failure: "Flush returned nil while the destination was broken, " +
 				"because the rows had already been delivered by WriteTable; " +
 				"there was nothing left to keep",
-		}}
+		}, depth}
+	}
+
+	if reports && depth.failure == "" {
+		if n := reporter.BufferedRows(); n != 1 {
+			depth.failure = "reports " + strconv.Itoa(n) +
+				" buffered rows after a Flush that failed; want 1, because " +
+				"the row is still owed"
+		}
 	}
 
 	keeps := verdict{invariant: keepsBatch}
@@ -210,7 +243,14 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			keeps.failure = "Flush after Heal failed with " + err.Error() +
 				"; the retry did not deliver what the failed flush kept"
 		}
-		return []verdict{buffers, keeps}
+		return []verdict{buffers, keeps, depth}
+	}
+
+	if reports && depth.failure == "" {
+		if n := reporter.BufferedRows(); n != 0 {
+			depth.failure = "reports " + strconv.Itoa(n) +
+				" buffered rows after a Flush that succeeded; want 0"
+		}
 	}
 
 	got := s.ReadBack(t)
@@ -219,7 +259,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			"destination holds " + describe(got) +
 			"; want exactly the row the failed flush could not deliver"
 	}
-	return []verdict{buffers, keeps}
+	return []verdict{buffers, keeps, depth}
 }
 
 func describe(rows []Row) string {

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -43,9 +43,9 @@ func TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught(t *testing.T) {
 	assert.True(t, vs[buffersOnly].failure != "")
 	assert.True(t, strings.Contains(vs[buffersOnly].failure, "before any Flush"))
 
-	// And it is named for what it did, not for a downstream symptom.
+	// keeps_batch fails too, and says why: there was nothing left to keep.
 	assert.True(t, vs[keepsBatch].failure != "")
-	assert.True(t, strings.Contains(vs[keepsBatch].failure, "Flush that failed"))
+	assert.True(t, strings.Contains(vs[keepsBatch].failure, "already been delivered"))
 }
 
 // The two invariants are independent: a sink can buffer correctly and still
@@ -128,6 +128,16 @@ func TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink
 	s.Heal = func(*testing.T) {}
 
 	assert.True(t, fatals(t, func(t *testing.T) { sinkVerdicts(t, s) }))
+}
+
+// A write-through sink also flushes successfully while broken, and it must
+// not be reported as a broken fault: buffers_only already showed that the
+// rows went out early, so the sink is at fault and the subject is not.
+func TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject(t *testing.T) {
+	vs := verdicts(t, subject(&writeThroughSink{memSink: newMemSink()}))
+
+	assert.True(t, vs[buffersOnly].failure != "")
+	assert.True(t, vs[keepsBatch].failure != "")
 }
 
 func TestToolingConformanceDescribe_NamesTheRowsItFound(t *testing.T) {
@@ -223,14 +233,12 @@ func (w *writeThroughSink) WriteTable(_ context.Context, t arrow.Table) error {
 	return nil
 }
 
-func (w *writeThroughSink) Flush(context.Context) error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.down {
-		return errors.New("destination unreachable")
-	}
-	return nil
-}
+// Flush returns nil even while the destination is broken, because there is
+// nothing left to send: the rows went out on WriteTable. That is what the
+// real Kafka sink did -- franz-go's Flush has an empty buffer to wait on --
+// and an earlier version of this fake returned an error instead, which hid a
+// harness bug until a real broker exposed it.
+func (w *writeThroughSink) Flush(context.Context) error { return nil }
 
 // neverClearSink keeps its buffer even after a successful flush.
 type neverClearSink struct{ *memSink }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -72,12 +72,32 @@ func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
 }
 
+func TestToolingConformanceSinks_ASinkThatMisreportsItsDepthIsCaught(t *testing.T) {
+	vs := verdicts(t, subject(&lyingSink{memSink: newMemSink()}))
+
+	// It keeps its batch, so the other two hold. Only the gauge lies.
+	assert.Equal(t, "", vs[buffersOnly].failure)
+	assert.Equal(t, "", vs[keepsBatch].failure)
+	assert.True(t, strings.Contains(vs[reportsDepth].failure,
+		"0 buffered rows after one WriteTable"))
+}
+
+// A sink that reports no depth at all is skipped rather than failed, and the
+// registry must then exempt it. Two statements that have to agree.
+func TestToolingConformanceSinks_ASinkThatReportsNoDepthIsSkipped(t *testing.T) {
+	vs := verdicts(t, subject(&noDepthSink{inner: newMemSink()}))
+
+	assert.Equal(t, "", vs[keepsBatch].failure)
+	assert.True(t, strings.Contains(vs[reportsDepth].skipped,
+		"reports no buffer depth"))
+}
+
 func TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.T) {
 	s := subject(newMemSink())
 	s.Break, s.Heal = nil, nil
 
 	vs := verdicts(t, s)
-	for _, id := range []string{buffersOnly, keepsBatch} {
+	for _, id := range []string{buffersOnly, keepsBatch, reportsDepth} {
 		assert.True(t, vs[id].skipped != "")
 		assert.True(t, strings.Contains(vs[id].skipped, "integrations.yml"))
 		assert.Equal(t, "", vs[id].failure)
@@ -147,6 +167,18 @@ func TestToolingConformanceDescribe_NamesTheRowsItFound(t *testing.T) {
 		describe([]Row{{"id": int64(1)}, {"id": int64(2)}}))
 }
 
+// fakeIntegration is the id the doubles below run under.
+//
+// Not a real sink. A marker carries an integration id, so the doubles need
+// one, and naming a shipped sink would credit it for what a double did. It
+// would also force exemptions onto that sink for reasons unrelated to its
+// contract: the first invariant it genuinely satisfied would have to be
+// exempted anyway, hiding real coverage.
+//
+// integrations.yml marks this id test_only, so it gets no cells and a
+// double's marker lands nowhere.
+const fakeIntegration = "sink.conformance_double"
+
 // --- Test doubles ----------------------------------------------------------
 
 // memSink is the smallest sink that honours the contract: it buffers on
@@ -189,6 +221,19 @@ func (m *memSink) Batch() (arrow.Table, error) {
 		return nil, nil
 	}
 	return m.buffered[0], nil
+}
+
+// BufferedRows makes the fakes honest about what they hold, so the harness
+// can judge reports_depth against them the way it does against a real sink.
+func (m *memSink) BufferedRows() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var rows int64
+	for _, t := range m.buffered {
+		rows += t.NumRows()
+	}
+	return int(rows)
 }
 
 func (m *memSink) set(down bool) {
@@ -258,6 +303,13 @@ func (n *neverClearSink) Flush(context.Context) error {
 	return nil
 }
 
+// lyingSink keeps its batch correctly and misreports the depth. A gauge that
+// reads zero while rows pile up is worse than no gauge: an operator watching
+// it concludes the sink is draining.
+type lyingSink struct{ *memSink }
+
+func (l *lyingSink) BufferedRows() int { return 0 }
+
 // staysDownSink never recovers, so the retry fails rather than delivering.
 type staysDownSink struct{ *memSink }
 
@@ -267,6 +319,19 @@ func (s *staysDownSink) Flush(context.Context) error {
 
 // --- Helpers ---------------------------------------------------------------
 
+// noDepthSink implements core.Sink and nothing else, so the harness cannot ask
+// it for a depth. It forwards rather than embeds: embedding memSink would
+// inherit BufferedRows and satisfy the interface after all.
+type noDepthSink struct{ inner *memSink }
+
+func (n *noDepthSink) WriteTable(ctx context.Context, t arrow.Table) error {
+	return n.inner.WriteTable(ctx, t)
+}
+func (n *noDepthSink) Flush(ctx context.Context) error { return n.inner.Flush(ctx) }
+func (n *noDepthSink) Batch() (arrow.Table, error)     { return n.inner.Batch() }
+func (n *noDepthSink) set(down bool)                   { n.inner.set(down) }
+func (n *noDepthSink) rows() []Row                     { return n.inner.rows() }
+
 type breakable interface {
 	core.Sink
 	set(down bool)
@@ -275,12 +340,12 @@ type breakable interface {
 
 func subject(sink breakable) SinkSubject {
 	return SinkSubject{
-		// sink.noop, not a sink with a real destination. These tests run in
-		// the unit pass against an in-memory fake, and the marker Sinks emits
-		// must not credit a sink this never touched. noop is exempt from both
-		// invariants, so the marker lands on an exempt cell and changes
-		// nothing -- which is what a fake proving nothing should do.
-		Integration: "sink.noop",
+		// Not a sink with a real destination. These tests run in the unit pass
+		// against an in-memory fake, and the marker Sinks emits must not
+		// credit a sink the fake never touched. Every invariant the harness
+		// judges is exempt for this id, so the marker lands on an exempt cell
+		// and changes nothing. A test below holds that true.
+		Integration: fakeIntegration,
 		New:         func(*testing.T) core.Sink { return sink },
 		Break:       func(*testing.T) { sink.set(true) },
 		Heal:        func(*testing.T) { sink.set(false) },
@@ -298,7 +363,7 @@ func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
 	for _, v := range sinkVerdicts(t, s) {
 		out[v.invariant] = v
 	}
-	assert.Equal(t, 2, len(out))
+	assert.Equal(t, 3, len(out))
 	return out
 }
 
@@ -361,4 +426,28 @@ func oneRow(t *testing.T, id int64) arrow.Table {
 	rec := b.NewRecord()
 	defer rec.Release()
 	return array.NewTableFromRecords(schema, []arrow.Record{rec})
+}
+
+// The doubles must never credit a shipped sink.
+//
+// They emit markers like any subject, and a marker names an integration. This
+// held sink.buffer.reports_depth green for sink.noop on the strength of an
+// in-memory double that never touched NoopSink. The id the doubles use has to
+// be test_only, which is what keeps its markers off every cell.
+func TestToolingConformanceSinks_TheDoublesRunUnderATestOnlyIntegration(t *testing.T) {
+	testOnly, err := coverage.IsTestOnly(fakeIntegration)
+	assert.NoError(t, err)
+	assert.True(t, testOnly)
+}
+
+// And it must not be a sink the engine can build. A test_only id that the
+// constructor switch also names would put a double's marker on a real sink
+// after all.
+func TestToolingConformanceSinks_TheDoublesIntegrationIsNotAShippedSink(t *testing.T) {
+	shipped, err := coverage.Integrations("sink")
+	assert.NoError(t, err)
+
+	for _, kind := range shipped {
+		assert.That(t, "sink."+kind != fakeIntegration)
+	}
 }

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -15,6 +15,7 @@ type Metrics struct {
 	SourceReadLatency      metric.Float64Histogram
 	SinkFlushLatency       metric.Float64Histogram
 	SinkFlushNumRows       metric.Int64Gauge
+	SinkBufferedRows       metric.Int64Gauge
 	SinkFlushCount         metric.Int64Counter
 	BatchProcessingLatency metric.Float64Histogram
 	StateCommitLatency     metric.Float64Histogram
@@ -76,6 +77,18 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		metric.WithUnit("rows"),
 	); err != nil {
 		return nil, fmt.Errorf("sink_flush_num_rows: %w", err)
+	}
+
+	// A sink holds every row a flush could not deliver, and nothing bounds
+	// that buffer. Today a failed flush stops the pipeline, so the buffer dies
+	// with the process; the day a flush failure stops being fatal, this gauge
+	// is what tells an operator the buffer is growing rather than draining.
+	if m.SinkBufferedRows, err = meter.Int64Gauge(
+		"sink_buffered_rows",
+		metric.WithDescription("Rows the sink is holding that no flush has delivered yet"),
+		metric.WithUnit("rows"),
+	); err != nil {
+		return nil, fmt.Errorf("sink_buffered_rows: %w", err)
 	}
 
 	if m.SinkFlushCount, err = meter.Int64Counter(

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -83,6 +83,20 @@ type Sink interface {
 	Batch() (arrow.Table, error)
 }
 
+// BufferedRowReporter is implemented by a sink that can say how many rows it
+// is holding.
+//
+// A sink keeps every row a failed flush could not deliver, and nothing bounds
+// that buffer. Today a failed flush stops the pipeline, so the buffer dies
+// with the process. That bound is a property of the call pattern rather than
+// of the design, and it disappears the day a flush failure stops being fatal.
+// An operator needs to see the depth before that day, not after.
+//
+// Optional, like MarkCommitter: a sink that buffers nothing reports nothing.
+type BufferedRowReporter interface {
+	BufferedRows() int
+}
+
 type Handler interface {
 	Init(ctx context.Context) error
 	Write(msg []byte) error
@@ -758,6 +772,18 @@ func (t *Turbine) SyncState(ctx context.Context) error {
 // processBatch invokes the handler on the buffered messages, writes the
 // result to the sink, commits the source, and resets the handler for the
 // next batch.
+// recordBufferedRows publishes the sink's buffer depth.
+//
+// A sink that does not report one is a sink that buffers nothing, so there is
+// nothing to publish and no branch for the caller.
+func (t *Turbine) recordBufferedRows(ctx context.Context) {
+	reporter, ok := t.sink.(BufferedRowReporter)
+	if !ok {
+		return
+	}
+	t.metrics.SinkBufferedRows.Record(ctx, int64(reporter.BufferedRows()))
+}
+
 func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error {
 	b0 := time.Now()
 
@@ -795,6 +821,11 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	if err := t.flush(ctx, batch); err != nil {
 		t.recordError(ctx, err, phaseSinkFlush, "error flushing sink")
 		t.metrics.SinkFlushCount.Add(ctx, 1, t.resultAttrs(resultError)...)
+		// Recorded on the failure path first, because this is the path where
+		// the number moves. A flush that keeps its batch leaves those rows
+		// buffered, and a rising gauge is what separates a sink retrying a
+		// destination from one that has stopped draining.
+		t.recordBufferedRows(ctx)
 		// The handler's writes are still uncommitted in the state
 		// transaction; discard them with the batch they belong to.
 		t.rollbackState(ctx)
@@ -806,6 +837,7 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 
 	b2 := time.Now()
 
+	t.recordBufferedRows(ctx)
 	t.metrics.SinkFlushLatency.Record(ctx, b2.Sub(b1).Seconds())
 	t.metrics.SinkFlushCount.Add(ctx, 1, t.resultAttrs(resultOK)...)
 	if batch != nil {

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -452,6 +453,7 @@ func TestLifecycleDrain_CancelDrainsTheBufferedBatch(t *testing.T) {
 	assert.Equal(t, int64(10), rows)
 	assert.Equal(t, 1, flushes)
 	assert.Equal(t, int64(10), stats.MessagesConsumed())
+	coverage.PipelineInvariant(t, "lifecycle.drain.on_cancel")
 }
 
 func TestCoreConsumeLoop_WritesEveryMessageAcrossManyBatches(t *testing.T) {
@@ -615,6 +617,7 @@ func TestCoreConsumeLoop_ProcessBatchFlushesSinkBeforeCommittingState(t *testing
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"flush", "save-offsets", "commit"}, events)
+	coverage.PipelineInvariant(t, "pipeline.commit.after_flush")
 }
 
 // A sink failure must roll the transaction back, so the offsets on disk stay
@@ -634,6 +637,7 @@ func TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails(t *testing.T) {
 	_, err := tb.ConsumeLoop(context.Background(), 0)
 	assert.Error(t, err)
 	assert.Equal(t, []string{"flush-failed", "rollback"}, events)
+	coverage.PipelineInvariant(t, "pipeline.commit.nothing_on_failure")
 }
 
 // A failure saving offsets must roll back too: state written by the handler
@@ -653,6 +657,9 @@ func TestCoreConsumeLoop_ProcessBatchRollsBackWhenOffsetSaveFails(t *testing.T) 
 	_, err := tb.ConsumeLoop(context.Background(), 0)
 	assert.Error(t, err)
 	assert.Equal(t, []string{"flush", "save-offsets-failed", "rollback"}, events)
+	// State the handler wrote and the offsets that describe it roll back
+	// together, which is what makes them one commit.
+	coverage.PipelineInvariant(t, "pipeline.state.with_offsets")
 }
 
 // A commit failure is fatal to the batch and must not be followed by a Kafka
@@ -674,6 +681,7 @@ func TestCoreConsumeLoop_ProcessBatchCommitFailureDoesNotCommitSource(t *testing
 	assert.Equal(t, []string{"flush", "save-offsets", "commit-failed", "rollback"}, events)
 	// Kafka must not have been told anything.
 	assert.Equal(t, 0, len(src.marks))
+	coverage.PipelineInvariant(t, "pipeline.commit.nothing_on_failure")
 }
 
 // The offsets handed to the store are the ones the pipeline processed, not

--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -38,3 +38,14 @@ func Invariant(t testing.TB, invariant, integration string) {
 	t.Helper()
 	t.Logf("COVERS invariant=%s integration=%s", invariant, integration)
 }
+
+// PipelineInvariant records that this test proved one invariant of the engine
+// itself.
+//
+// A pipeline invariant is a property of the consume loop rather than of
+// anything a config names, so there is no integration to credit. It carries
+// "pipeline" in that slot, and the generator gives it a single cell.
+func PipelineInvariant(t testing.TB, invariant string) {
+	t.Helper()
+	Invariant(t, invariant, "pipeline")
+}

--- a/internal/coverage/registry.go
+++ b/internal/coverage/registry.go
@@ -44,6 +44,101 @@ func Invariants() (map[string]bool, error) {
 	return out, nil
 }
 
+// IsTestOnly reports whether integrations.yml marks an integration as
+// existing only for tests.
+//
+// The conformance harness's doubles must name an integration, because a
+// marker carries one. Naming a real sink would credit that sink for what a
+// double did. A test-only id gets no cells, so a double's marker lands
+// nowhere.
+func IsTestOnly(integration string) (bool, error) {
+	raw, err := readRegistry("integrations.yml")
+	if err != nil {
+		return false, err
+	}
+
+	var doc struct {
+		Integrations []struct {
+			ID       string `yaml:"id"`
+			TestOnly bool   `yaml:"test_only"`
+		} `yaml:"integrations"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return false, fmt.Errorf("coverage: parse integrations.yml: %w", err)
+	}
+
+	for _, entry := range doc.Integrations {
+		if entry.ID == integration {
+			return entry.TestOnly, nil
+		}
+	}
+	return false, fmt.Errorf("coverage: integrations.yml declares no %q", integration)
+}
+
+// FeatureFor returns the features.yml id an integration attributes to, and
+// whether it has one.
+//
+// An integration id is not a feature id. sink.noop attributes to
+// sink.console, and a test_only integration attributes to nothing at all.
+// Emitting the integration id as a feature marker put
+// "marks sink.conformance_double" into the feature matrix's unknown list.
+func FeatureFor(integration string) (string, bool, error) {
+	raw, err := readRegistry("integrations.yml")
+	if err != nil {
+		return "", false, err
+	}
+
+	var doc struct {
+		Integrations []struct {
+			ID      string `yaml:"id"`
+			Feature string `yaml:"feature"`
+		} `yaml:"integrations"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return "", false, fmt.Errorf("coverage: parse integrations.yml: %w", err)
+	}
+
+	for _, entry := range doc.Integrations {
+		if entry.ID == integration {
+			return entry.Feature, entry.Feature != "", nil
+		}
+	}
+	return "", false, fmt.Errorf("coverage: integrations.yml declares no %q", integration)
+}
+
+// Exemptions returns the invariants integrations.yml excuses one integration
+// from, as a set.
+func Exemptions(integration string) (map[string]bool, error) {
+	raw, err := readRegistry("integrations.yml")
+	if err != nil {
+		return nil, err
+	}
+
+	var doc struct {
+		Integrations []struct {
+			ID     string `yaml:"id"`
+			Exempt []struct {
+				Invariant string `yaml:"invariant"`
+			} `yaml:"exempt"`
+		} `yaml:"integrations"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("coverage: parse integrations.yml: %w", err)
+	}
+
+	for _, entry := range doc.Integrations {
+		if entry.ID != integration {
+			continue
+		}
+		out := make(map[string]bool, len(entry.Exempt))
+		for _, ex := range entry.Exempt {
+			out[ex.Invariant] = true
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("coverage: integrations.yml declares no %q", integration)
+}
+
 // readRegistry reads one file from docs/coverage.
 //
 // Located relative to this source file, not the working directory: `go test
@@ -82,8 +177,9 @@ func Integrations(kind string) ([]string, error) {
 
 	var doc struct {
 		Integrations []struct {
-			ID   string `yaml:"id"`
-			Kind string `yaml:"kind"`
+			ID       string `yaml:"id"`
+			Kind     string `yaml:"kind"`
+			TestOnly bool   `yaml:"test_only"`
 		} `yaml:"integrations"`
 	}
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
@@ -92,6 +188,11 @@ func Integrations(kind string) ([]string, error) {
 
 	out := []string{}
 	for _, integration := range doc.Integrations {
+		// A test-only integration has no constructor case, so it must not
+		// appear in the list Kinds() is held equal to.
+		if integration.TestOnly {
+			continue
+		}
 		if integration.Kind == kind {
 			out = append(out, strings.TrimPrefix(integration.ID, kind+"."))
 		}

--- a/internal/sinks/clickhouse.go
+++ b/internal/sinks/clickhouse.go
@@ -478,3 +478,17 @@ func goElemType(dt arrow.DataType) reflect.Type {
 		return reflect.TypeOf("")
 	}
 }
+
+// BufferedRows reports the rows this sink is holding that no flush has
+// delivered. The pipeline publishes it as sink_buffered_rows, so an operator
+// can tell a sink retrying a destination from one that has stopped draining.
+func (s *ClickhouseSink) BufferedRows() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var rows int64
+	for _, t := range s.tables {
+		rows += t.NumRows()
+	}
+	return int(rows)
+}

--- a/internal/sinks/conformance_iceberg_test.go
+++ b/internal/sinks/conformance_iceberg_test.go
@@ -1,0 +1,144 @@
+package sinks
+
+// The Iceberg sink under the conformance harness.
+//
+// No container and no network: the catalog is sqlite and the warehouse is a
+// directory, so the fault is a warehouse the sink cannot write into -- a full
+// volume, a revoked credential, a read-only mount. The catalog lives outside
+// the warehouse so making the warehouse unwritable does not also break the
+// read-back; a broken destination must never be indistinguishable from an
+// empty one.
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/turbolytics/sql-flow/internal/conformance"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/zeebo/assert"
+)
+
+func TestSinkIceberg_Conformance(t *testing.T) {
+	isolateCatalogLookup(t)
+
+	// Two directories on purpose. Break makes the warehouse unwritable, and
+	// the catalog must stay readable and writable for the read-back to work.
+	warehouse := t.TempDir()
+	catalogDir := t.TempDir()
+
+	const catalogName = "conformance"
+	t.Setenv("PYICEBERG_CATALOG__CONFORMANCE__URI",
+		"sqlite:///"+filepath.Join(catalogDir, "catalog.db"))
+	t.Setenv("PYICEBERG_CATALOG__CONFORMANCE__WAREHOUSE", "file://"+warehouse)
+
+	ctx := context.Background()
+	props, err := icebergCatalogProperties(catalogName)
+	assert.NoError(t, err)
+
+	cat, err := catalog.Load(ctx, catalogName, props)
+	assert.NoError(t, err)
+	assert.NoError(t, cat.CreateNamespace(ctx, catalog.ToIdentifier("default"), nil))
+
+	// The harness writes a single int64 "id" column.
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+	)
+	_, err = cat.CreateTable(ctx, catalog.ToIdentifier("default", "rows"), schema)
+	assert.NoError(t, err)
+
+	conformance.Sinks(t, conformance.SinkSubject{
+		Integration: "sink.iceberg",
+
+		New: func(t *testing.T) core.Sink {
+			s, err := NewIcebergSink(ctx, catalogName, "default.rows")
+			assert.NoError(t, err)
+			return s
+		},
+
+		Break: func(t *testing.T) { chmodTree(t, warehouse, 0o500) },
+		Heal:  func(t *testing.T) { chmodTree(t, warehouse, 0o700) },
+
+		ReadBack: func(t *testing.T) []conformance.Row {
+			return icebergIDs(t, catalogName)
+		},
+
+		Table: func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+	})
+}
+
+// chmodTree sets the mode of every directory under root, and root itself.
+// Only directories: 0500 on a directory blocks creating a file in it while
+// leaving what is already there readable.
+func chmodTree(t *testing.T, root string, mode fs.FileMode) {
+	t.Helper()
+
+	var dirs []string
+	assert.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			dirs = append(dirs, path)
+		}
+		return nil
+	}))
+
+	// Deepest first when locking, so a parent turning read-only does not stop
+	// the walk from reaching its children.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		assert.NoError(t, os.Chmod(dirs[i], mode))
+	}
+	// The temp directory has to be writable again for t.TempDir cleanup.
+	if mode&0o200 == 0 {
+		t.Cleanup(func() { chmodTreeBestEffort(root, 0o700) })
+	}
+}
+
+func chmodTreeBestEffort(root string, mode fs.FileMode) {
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err == nil && d.IsDir() {
+			_ = os.Chmod(path, mode)
+		}
+		return nil
+	})
+}
+
+// icebergIDs reloads the table through the catalog and reads every committed
+// id. Reading through the sink's own handle would only prove the sink agrees
+// with itself.
+func icebergIDs(t *testing.T, catalogName string) []conformance.Row {
+	t.Helper()
+	ctx := context.Background()
+
+	props, err := icebergCatalogProperties(catalogName)
+	assert.NoError(t, err)
+
+	cat, err := catalog.Load(ctx, catalogName, props)
+	assert.NoError(t, err)
+
+	tbl, err := cat.LoadTable(ctx, catalog.ToIdentifier("default", "rows"))
+	assert.NoError(t, err)
+
+	result, err := tbl.Scan().ToArrowTable(ctx)
+	assert.NoError(t, err)
+	defer result.Release()
+
+	var out []conformance.Row
+	if result.NumRows() == 0 {
+		return out
+	}
+	for _, chunk := range result.Column(0).Data().Chunks() {
+		arr := chunk.(*array.Int64)
+		for i := 0; i < arr.Len(); i++ {
+			out = append(out, conformance.Row{"id": arr.Value(i)})
+		}
+	}
+	return out
+}

--- a/internal/sinks/conformance_kafka_test.go
+++ b/internal/sinks/conformance_kafka_test.go
@@ -1,0 +1,130 @@
+package sinks
+
+// The Kafka sink under the conformance harness, against a real broker behind
+// toxiproxy.
+//
+// The sink had both defects the harness judges. WriteTable produced every row
+// on the way in, so a flush failure could not hold anything back, and Flush
+// cleared its error list after reporting, so a second flush returned nil
+// having produced nothing new. The pipeline commits offsets on what Flush
+// reports, and both defects put the two out of step in the direction that
+// loses rows.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	tckafka "github.com/testcontainers/testcontainers-go/modules/kafka"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/conformance"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/zeebo/assert"
+)
+
+// brokerImage matches the one internal/kafka pins, so the two integration
+// passes do not pull two images.
+const sinkBrokerImage = "confluentinc/confluent-local:7.5.0"
+
+func TestIntegrationSinkKafka_Conformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: -short runs the unit pass only")
+	}
+	ctx := context.Background()
+
+	nw, err := network.New(ctx)
+	assert.NoError(t, err)
+	t.Cleanup(func() { _ = nw.Remove(context.Background()) })
+
+	broker, err := tckafka.Run(ctx, sinkBrokerImage,
+		network.WithNetwork([]string{"kafka"}, nw),
+	)
+	assert.NoError(t, err)
+	t.Cleanup(func() { _ = broker.Terminate(context.Background()) })
+
+	proxy := conformance.NewProxy(t, nw, "kafka:9093")
+
+	topic := fmt.Sprintf("conformance-%d", time.Now().UnixNano())
+
+	// Every connection the sink makes goes to the proxy, whatever address the
+	// broker advertises. Without this the sink reconnects around the fault on
+	// the first metadata response and Break does nothing.
+	viaProxy := kgo.Dialer(func(ctx context.Context, _, _ string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", proxy.Addr)
+	})
+
+	// The reader talks to the broker directly, so a broken destination is
+	// never mistaken for an empty one.
+	direct, err := broker.Brokers(ctx)
+	assert.NoError(t, err)
+
+	conformance.Sinks(t, conformance.SinkSubject{
+		Integration: "sink.kafka",
+
+		New: func(t *testing.T) core.Sink {
+			s, err := NewKafkaSink(config.KafkaSink{
+				Brokers: []string{proxy.Addr},
+				Topic:   topic,
+			}, viaProxy)
+			assert.NoError(t, err)
+			t.Cleanup(func() { s.Close() })
+			return s
+		},
+
+		Break: proxy.Break,
+		Heal:  proxy.Heal,
+
+		ReadBack: func(t *testing.T) []conformance.Row {
+			return consumeIDs(t, direct, topic)
+		},
+
+		Table: func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+	})
+}
+
+// consumeIDs reads the topic from the beginning and decodes the id of every
+// message. A fresh client per call keeps the read independent of anything the
+// sink's client is doing.
+func consumeIDs(t *testing.T, brokers []string, topic string) []conformance.Row {
+	t.Helper()
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(brokers...),
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+	)
+	assert.NoError(t, err)
+	defer client.Close()
+
+	// Short: the topic is either empty or holds what the sink just wrote, and
+	// waiting longer cannot change which.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var out []conformance.Row
+	for {
+		fetches := client.PollFetches(ctx)
+		if fetches.IsClientClosed() || ctx.Err() != nil {
+			return out
+		}
+		empty := true
+		fetches.EachRecord(func(rec *kgo.Record) {
+			empty = false
+			var row map[string]any
+			if err := json.Unmarshal(rec.Value, &row); err != nil {
+				t.Fatalf("kafka sink wrote something that is not JSON: %v", err)
+			}
+			out = append(out, conformance.Row{"id": int64(row["id"].(float64))})
+		})
+		if empty {
+			return out
+		}
+	}
+}

--- a/internal/sinks/conformance_local_test.go
+++ b/internal/sinks/conformance_local_test.go
@@ -1,0 +1,145 @@
+package sinks
+
+// The two sinks that need no container: console writes to an io.Writer, and
+// sqlcommand writes through the pipeline's own DuckDB connection. Both run
+// the same harness the ClickHouse subject does, at unit level.
+//
+// Both were exempt from sink.flush.keeps_batch until this commit, on the
+// grounds that nothing crosses a network. That is the argument for skipping a
+// retry ladder. The invariant is about whether the pipeline may commit
+// offsets for rows that never landed, and it applies to any sink that can
+// fail at all.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/conformance"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/zeebo/assert"
+)
+
+// breakableWriter is stdout redirected somewhere that can fail: a full disk,
+// a closed pipe, a detached terminal.
+type breakableWriter struct {
+	mu     sync.Mutex
+	broken bool
+	out    []byte
+}
+
+func (w *breakableWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.broken {
+		return 0, errors.New("write: no space left on device")
+	}
+	w.out = append(w.out, p...)
+	return len(p), nil
+}
+
+func (w *breakableWriter) set(broken bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.broken = broken
+}
+
+func (w *breakableWriter) rows(t *testing.T) []conformance.Row {
+	t.Helper()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	var out []conformance.Row
+	dec := json.NewDecoder(bytes.NewReader(w.out))
+	for {
+		var row map[string]any
+		if err := dec.Decode(&row); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("console sink wrote something that is not JSON: %v", err)
+		}
+		// Every value decodes as float64; the harness compares int64 ids.
+		out = append(out, conformance.Row{"id": int64(row["id"].(float64))})
+	}
+	return out
+}
+
+func TestSinkConsole_Conformance(t *testing.T) {
+	w := &breakableWriter{}
+
+	conformance.Sinks(t, conformance.SinkSubject{
+		Integration: "sink.console",
+		New:         func(*testing.T) core.Sink { return NewConsoleSinkTo(w) },
+		Break:       func(*testing.T) { w.set(true) },
+		Heal:        func(*testing.T) { w.set(false) },
+		ReadBack:    func(t *testing.T) []conformance.Row { return w.rows(t) },
+		Table:       func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+	})
+}
+
+func TestSinkSqlcommand_Conformance(t *testing.T) {
+	conn := newSinkTestConn(t)
+	stamp := time.Now().UnixNano()
+	target := fmt.Sprintf("conformance_target_%d", stamp)
+	gate := fmt.Sprintf("conformance_gate_%d", stamp)
+
+	exec(t, conn, "CREATE TABLE "+target+" (id BIGINT)")
+	exec(t, conn, "CREATE TABLE "+gate+" (open BOOLEAN)")
+	exec(t, conn, "INSERT INTO "+gate+" VALUES (true)")
+
+	// The fault is a gate table the sink's SQL joins against, not the
+	// destination itself. Dropping the destination would break ReadBack too,
+	// and the harness reads back while the fault is installed: a broken
+	// destination must not be indistinguishable from an empty one.
+	conformance.Sinks(t, conformance.SinkSubject{
+		Integration: "sink.sqlcommand",
+		New: func(t *testing.T) core.Sink {
+			s, err := NewSQLCommandSink(conn,
+				"INSERT INTO "+target+" SELECT b.id FROM "+sinkBatchTable+" b, "+gate, nil)
+			assert.NoError(t, err)
+			return s
+		},
+		Break: func(t *testing.T) { exec(t, conn, "DROP TABLE "+gate) },
+		Heal: func(t *testing.T) {
+			exec(t, conn, "CREATE TABLE "+gate+" (open BOOLEAN)")
+			exec(t, conn, "INSERT INTO "+gate+" VALUES (true)")
+		},
+		ReadBack: func(t *testing.T) []conformance.Row {
+			return queryIDs(t, conn, "SELECT id FROM "+target+" ORDER BY id")
+		},
+		Table: func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+	})
+}
+
+func queryIDs(t *testing.T, conn adbc.Connection, sql string) []conformance.Row {
+	t.Helper()
+
+	stmt, err := conn.NewStatement()
+	assert.NoError(t, err)
+	defer stmt.Close()
+	assert.NoError(t, stmt.SetSqlQuery(sql))
+
+	reader, _, err := stmt.ExecuteQuery(context.Background())
+	assert.NoError(t, err)
+	defer reader.Release()
+
+	var out []conformance.Row
+	for reader.Next() {
+		rec := reader.Record()
+		col := rec.Column(0)
+		for i := 0; i < int(rec.NumRows()); i++ {
+			out = append(out, conformance.Row{"id": col.(*array.Int64).Value(i)})
+		}
+	}
+	assert.NoError(t, reader.Err())
+	return out
+}

--- a/internal/sinks/console.go
+++ b/internal/sinks/console.go
@@ -1,6 +1,7 @@
 package sinks
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -84,4 +85,14 @@ func (s *ConsoleSink) Batch() (arrow.Table, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.batch, nil
+}
+
+// BufferedRows reports the rows this sink is holding that no flush has
+// written. Every row ends in a newline and a short write only removes a
+// prefix, so counting newlines counts the rows still owed, including a row
+// left half written.
+func (s *ConsoleSink) BufferedRows() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return bytes.Count(s.pending, []byte{'\n'})
 }

--- a/internal/sinks/console.go
+++ b/internal/sinks/console.go
@@ -1,7 +1,6 @@
 package sinks
 
 import (
-	"bufio"
 	"context"
 	"io"
 	"os"
@@ -11,10 +10,18 @@ import (
 )
 
 // ConsoleSink writes each result row to stdout as a JSON object.
+//
+// The rows are held here rather than in a bufio.Writer. bufio latches its
+// first error permanently: once a write failed, every later Flush returned
+// that same stale error and the bytes were gone, so the sink never recovered
+// even after the condition cleared. stdout is not immune to that -- redirect
+// it to a full disk or a pipe whose reader exits and the write fails -- and a
+// sink that cannot recover turns a transient failure into a dead pipeline.
 type ConsoleSink struct {
-	mu    sync.Mutex
-	out   *bufio.Writer
-	batch arrow.Table
+	mu      sync.Mutex
+	out     io.Writer
+	pending []byte
+	batch   arrow.Table
 }
 
 func NewConsoleSink() *ConsoleSink {
@@ -22,9 +29,12 @@ func NewConsoleSink() *ConsoleSink {
 }
 
 func NewConsoleSinkTo(w io.Writer) *ConsoleSink {
-	return &ConsoleSink{out: bufio.NewWriter(w)}
+	return &ConsoleSink{out: w}
 }
 
+// WriteTable buffers the rows. Nothing reaches the writer until Flush, so the
+// pipeline never commits offsets for a row that only got as far as this
+// process.
 func (s *ConsoleSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	rows, err := tableRowsAsJSON(batch)
 	if err != nil {
@@ -36,20 +46,38 @@ func (s *ConsoleSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 
 	s.batch = batch
 	for _, row := range rows {
-		if _, err := s.out.Write(row); err != nil {
-			return err
-		}
-		if err := s.out.WriteByte('\n'); err != nil {
-			return err
-		}
+		s.pending = append(s.pending, row...)
+		s.pending = append(s.pending, '\n')
 	}
 	return nil
 }
 
+// Flush writes the buffered rows, and keeps whatever it could not write.
+//
+// A short write leaves exactly the unwritten tail pending, so a retry sends
+// the remainder rather than the whole batch again: the reader must not see a
+// row twice because the tail of the batch failed.
 func (s *ConsoleSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.out.Flush()
+
+	if len(s.pending) == 0 {
+		return nil
+	}
+
+	n, err := s.out.Write(s.pending)
+	if n > 0 {
+		s.pending = s.pending[n:]
+	}
+	if err != nil {
+		return err
+	}
+	if len(s.pending) != 0 {
+		// io.Writer may return a short write with no error; the contract says
+		// that is still a failure, and the remainder stays pending.
+		return io.ErrShortWrite
+	}
+	return nil
 }
 
 func (s *ConsoleSink) Batch() (arrow.Table, error) {

--- a/internal/sinks/iceberg.go
+++ b/internal/sinks/iceberg.go
@@ -281,3 +281,17 @@ func pyicebergFileProperties(name string) (map[string]string, error) {
 
 	return map[string]string{}, nil
 }
+
+// BufferedRows reports the rows this sink is holding that no flush has
+// delivered. The pipeline publishes it as sink_buffered_rows, so an operator
+// can tell a sink retrying a destination from one that has stopped draining.
+func (s *IcebergSink) BufferedRows() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var rows int64
+	for _, t := range s.tables {
+		rows += t.NumRows()
+	}
+	return int(rows)
+}

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -2,6 +2,7 @@ package sinks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -17,12 +18,19 @@ type KafkaSink struct {
 	client *kgo.Client
 	topic  string
 
-	mu    sync.Mutex
-	batch arrow.Table
-	errs  []error
+	mu sync.Mutex
+	// pending holds the encoded rows that Flush has not yet had acknowledged.
+	pending [][]byte
+	batch   arrow.Table
 }
 
-func NewKafkaSink(conf config.KafkaSink) (*KafkaSink, error) {
+// NewKafkaSink builds the sink. Extra client options are appended last, so a
+// caller can override what this function set: the conformance test dials
+// every broker address through a proxy, which is the only way to fault the
+// connection from outside. A testcontainers broker advertises its own mapped
+// host port, so a client that merely bootstraps through a proxy reconnects
+// around it on the first metadata response.
+func NewKafkaSink(conf config.KafkaSink, extra ...kgo.Opt) (*KafkaSink, error) {
 	if conf.Topic == "" {
 		return nil, fmt.Errorf("kafka sink: topic is required")
 	}
@@ -41,6 +49,7 @@ func NewKafkaSink(conf config.KafkaSink) (*KafkaSink, error) {
 		return nil, fmt.Errorf("kafka sink security: %w", err)
 	}
 	opts = append(opts, securityOpts...)
+	opts = append(opts, extra...)
 
 	client, err := kgo.NewClient(opts...)
 	if err != nil {
@@ -50,6 +59,12 @@ func NewKafkaSink(conf config.KafkaSink) (*KafkaSink, error) {
 	return &KafkaSink{client: client, topic: conf.Topic}, nil
 }
 
+// WriteTable buffers the encoded rows. Nothing is produced here.
+//
+// It used to call Produce for every row, so records reached the broker before
+// any flush and a flush failure could not hold them back. The pipeline commits
+// offsets on what Flush reports, so a sink that delivers earlier than it
+// reports leaves the two out of step in the direction that loses rows.
 func (s *KafkaSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	rows, err := tableRowsAsJSON(batch)
 	if err != nil {
@@ -57,22 +72,9 @@ func (s *KafkaSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	}
 
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.batch = batch
-	s.mu.Unlock()
-
-	for _, row := range rows {
-		s.client.Produce(
-			ctx,
-			&kgo.Record{Topic: s.topic, Value: row},
-			func(_ *kgo.Record, err error) {
-				if err != nil {
-					s.mu.Lock()
-					s.errs = append(s.errs, err)
-					s.mu.Unlock()
-				}
-			},
-		)
-	}
+	s.pending = append(s.pending, rows...)
 	return nil
 }
 
@@ -87,18 +89,85 @@ func (s *KafkaSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 // hands the sink a context stripped of cancellation, so honouring the context
 // here cannot cut the final write short.
 func (s *KafkaSink) Flush(ctx context.Context) error {
-	if err := s.client.Flush(ctx); err != nil {
-		return err
+	s.mu.Lock()
+	pending := s.pending
+	s.pending = nil
+	s.mu.Unlock()
+
+	if len(pending) == 0 {
+		return nil
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if len(s.errs) > 0 {
-		err := fmt.Errorf("kafka sink: %d produce error(s), first: %w", len(s.errs), s.errs[0])
-		s.errs = nil
-		return err
+	// One promise per record, indexed so an unacknowledged row can be put back
+	// where it was. Results arrive in completion order, which is not the order
+	// the rows were written.
+	var (
+		mu     sync.Mutex
+		failed = make(map[int]error, 0)
+		acked  = make(map[int]bool, len(pending))
+	)
+	for i, row := range pending {
+		i := i
+		s.client.Produce(
+			ctx,
+			&kgo.Record{Topic: s.topic, Value: row},
+			func(_ *kgo.Record, err error) {
+				mu.Lock()
+				defer mu.Unlock()
+				acked[i] = true
+				if err != nil {
+					failed[i] = err
+				}
+			},
+		)
 	}
-	return nil
+
+	// Flush honours the context; Produce does not. franz-go retries a produce
+	// indefinitely by default, so against a broker that stopped answering only
+	// this call can end the wait -- an elapsed flush interval, a cancelled run
+	// and a SIGTERM all reach the sink through ctx. The pipeline's drain hands
+	// the sink a context stripped of cancellation, so honouring it here cannot
+	// cut the final write short.
+	flushErr := s.client.Flush(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// A record with no promise yet was still in flight when the context ended.
+	// It is not delivered, so it stays pending.
+	var (
+		keep     [][]byte
+		firstErr error
+	)
+	for i, row := range pending {
+		err, didFail := failed[i]
+		if !acked[i] || didFail {
+			keep = append(keep, row)
+			if firstErr == nil {
+				if err != nil {
+					firstErr = err
+				} else {
+					firstErr = flushErr
+				}
+			}
+		}
+	}
+
+	if len(keep) == 0 {
+		return nil
+	}
+
+	// At the head, ahead of anything written while the flush was in flight, so
+	// a retry produces them in the order they arrived.
+	s.mu.Lock()
+	s.pending = append(keep, s.pending...)
+	s.mu.Unlock()
+
+	if firstErr == nil {
+		firstErr = errors.New("not acknowledged")
+	}
+	return fmt.Errorf("kafka sink: %d of %d rows not acknowledged, first: %w",
+		len(keep), len(pending), firstErr)
 }
 
 func (s *KafkaSink) Batch() (arrow.Table, error) {

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -180,3 +180,13 @@ func (s *KafkaSink) Close() error {
 	s.client.Close()
 	return nil
 }
+
+// BufferedRows reports the rows this sink is holding that no flush has had
+// acknowledged. The pipeline publishes it as sink_buffered_rows, so an
+// operator can tell a sink retrying a broker from one that has stopped
+// draining.
+func (s *KafkaSink) BufferedRows() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.pending)
+}

--- a/internal/sinks/kafka_test.go
+++ b/internal/sinks/kafka_test.go
@@ -92,12 +92,23 @@ func TestSinkKafka_FlushHonoursItsContext(t *testing.T) {
 	err := flushWithin(t, s, ctx, 10*time.Second)
 	assert.Error(t, err)
 	assert.That(t, errors.Is(err, context.DeadlineExceeded))
+
+	// And the row is still there for the next attempt. A flush that gives up
+	// must not also discard what it failed to send.
+	s.mu.Lock()
+	pending := len(s.pending)
+	s.mu.Unlock()
+	assert.Equal(t, 1, pending)
 }
 
-// A write whose context is already done must fail rather than buffer. The
-// records would otherwise sit in the client until some later flush, and be
-// reported against a batch that has nothing to do with them.
-func TestSinkKafka_WriteTableHonoursItsContext(t *testing.T) {
+// WriteTable reaches nothing, so its context governs nothing.
+//
+// This replaces a test asserting that a cancelled write context failed those
+// records. It passed for the wrong reason: franz-go watches a Produce context
+// only while a topic is unresolved, and the topic could never resolve against
+// 127.0.0.1:1. The sink now buffers on the way in, so no context can fail a
+// write, and the guarantee that matters moved to Flush.
+func TestSinkKafka_WriteTableBuffersWhateverItsContextSays(t *testing.T) {
 	s := newUnreachableKafkaSink(t)
 
 	table := newTestTable(t, []string{"nyc"}, []int64{1})
@@ -108,12 +119,10 @@ func TestSinkKafka_WriteTableHonoursItsContext(t *testing.T) {
 
 	assert.NoError(t, s.WriteTable(ctx, table))
 
-	// Produce is asynchronous, so the context error arrives at the promise and
-	// Flush is what reports it. The flush context is deliberately live: what
-	// is being asserted is that the *write's* context failed these records.
-	err := flushWithin(t, s, context.Background(), 10*time.Second)
-	assert.Error(t, err)
-	assert.That(t, errors.Is(err, context.Canceled))
+	s.mu.Lock()
+	pending := len(s.pending)
+	s.mu.Unlock()
+	assert.Equal(t, 1, pending)
 }
 
 // Produce errors must not be swallowed. The pipeline commits its offsets only

--- a/internal/sinks/sqlcommand.go
+++ b/internal/sinks/sqlcommand.go
@@ -193,3 +193,17 @@ func (s *SQLCommandSink) applySubstitutions() (string, error) {
 	}
 	return sql, nil
 }
+
+// BufferedRows reports the rows this sink is holding that no flush has
+// delivered. The pipeline publishes it as sink_buffered_rows, so an operator
+// can tell a sink retrying a destination from one that has stopped draining.
+func (s *SQLCommandSink) BufferedRows() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var rows int64
+	for _, t := range s.tables {
+		rows += t.NumRows()
+	}
+	return int(rows)
+}

--- a/internal/sinks/sqlcommand.go
+++ b/internal/sinks/sqlcommand.go
@@ -56,6 +56,20 @@ func (s *SQLCommandSink) Batch() (arrow.Table, error) {
 	return s.tables[len(s.tables)-1], nil
 }
 
+// Flush runs the sink SQL over the buffered rows, and keeps them buffered if
+// it cannot.
+//
+// Every batch used to be released on the way out whatever the outcome, so a
+// failed flush left nothing to retry. Nothing calls Flush twice on this sink
+// today -- retriesHelp excludes it, and processBatch calls it once and lets
+// the error stop the pipeline -- so the rows replayed from the source rather
+// than vanishing. That made it correct by accident of the call pattern, and
+// the accident ends the day anything retries a sqlcommand sink, or an error
+// policy makes a failed flush non-fatal.
+//
+// Keeping the batch is the invariant. Whether a retry ladder is wrapped
+// around this sink is a different question with a different answer, and
+// retriesHelp answers only that one.
 func (s *SQLCommandSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	tables := s.tables
@@ -65,12 +79,30 @@ func (s *SQLCommandSink) Flush(ctx context.Context) error {
 	if len(tables) == 0 {
 		return nil
 	}
-	defer func() {
-		for _, t := range tables {
-			t.Release()
-		}
-	}()
 
+	if err := s.send(ctx, tables); err != nil {
+		s.requeue(tables)
+		return err
+	}
+
+	for _, t := range tables {
+		t.Release()
+	}
+	return nil
+}
+
+// requeue returns undelivered batches to the head of the buffer, ahead of
+// anything written while the failed flush was in flight, so a retry runs them
+// in the order they arrived.
+func (s *SQLCommandSink) requeue(tables []arrow.Table) {
+	s.mu.Lock()
+	s.tables = append(tables, s.tables...)
+	s.mu.Unlock()
+}
+
+// send is one delivery attempt. It releases nothing: whether these batches can
+// be dropped is the caller's decision, and it depends on this error.
+func (s *SQLCommandSink) send(ctx context.Context, tables []arrow.Table) error {
 	if err := s.materialize(ctx, tables); err != nil {
 		return err
 	}

--- a/internal/sinks/structural_test.go
+++ b/internal/sinks/structural_test.go
@@ -1,0 +1,84 @@
+package sinks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/zeebo/assert"
+)
+
+// The premises behind every sink exemption in integrations.yml.
+//
+// An exemption says an invariant cannot apply. Left as prose that is an
+// excuse, and two such excuses hid live batch-loss bugs: sqlcommand and
+// console were both exempted from sink.flush.keeps_batch on the grounds that
+// nothing crosses a network. That is the argument for skipping a retry
+// ladder, not for skipping the invariant a ladder depends on. Each exemption
+// now names one of these tests, and the generator rejects one that does not.
+
+func TestSinkConsole_ImplementsNoProber(t *testing.T) {
+	var s core.Sink = NewConsoleSink()
+	_, ok := s.(Prober)
+	assert.That(t, !ok)
+}
+
+func TestSinkSqlcommand_ImplementsNoProber(t *testing.T) {
+	conn := newSinkTestConn(t)
+	built, err := NewSQLCommandSink(conn, "SELECT 1", nil)
+	assert.NoError(t, err)
+
+	var s core.Sink = built
+	_, ok := s.(Prober)
+	assert.That(t, !ok)
+}
+
+func TestSinkNoop_ImplementsNoProber(t *testing.T) {
+	var s core.Sink = &NoopSink{}
+	_, ok := s.(Prober)
+	assert.That(t, !ok)
+}
+
+// The noop sink's contract, stated once rather than argued eight times.
+//
+// It exists so a benchmark can measure the engine without a sink, so every
+// invariant about delivering rows is vacuous for it. That is only a
+// legitimate exemption if discarding is deliberate and total, which is what
+// this asserts.
+func TestSinkNoop_DeliversNothingAndSaysSo(t *testing.T) {
+	s := &NoopSink{}
+	ctx := context.Background()
+
+	table := oneRowTable(t, 1)
+	defer table.Release()
+
+	assert.NoError(t, s.WriteTable(ctx, table))
+	assert.NoError(t, s.Flush(ctx))
+
+	// Nothing buffered, nothing reported, nothing to lose.
+	batch, err := s.Batch()
+	assert.NoError(t, err)
+	assert.Nil(t, batch)
+
+	// And it cannot fail, so there is never a batch to keep.
+	assert.NoError(t, s.Flush(ctx))
+}
+
+func oneRowTable(t *testing.T, id int64) arrow.Table {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	b := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer b.Release()
+	b.Field(0).(*array.Int64Builder).Append(id)
+
+	rec := b.NewRecord()
+	defer rec.Release()
+	return array.NewTableFromRecords(schema, []arrow.Record{rec})
+}

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -122,7 +122,10 @@ def validate_registries(invariants, integrations, features):
         if integ.get("kind") not in INTEGRATION_KINDS:
             problems.append(
                 f"integrations.yml: {iid} kind {integ.get('kind')!r} is not one of {INTEGRATION_KINDS}")
-        if integ.get("feature") not in feature_ids:
+        # A test-only integration ships to nobody, so it has no feature and no
+        # cells. It exists so the conformance harness's doubles have an id
+        # that is not a real sink's.
+        if not integ.get("test_only") and integ.get("feature") not in feature_ids:
             problems.append(
                 f"integrations.yml: {iid} names feature {integ.get('feature')!r}, "
                 "which features.yml does not declare")
@@ -346,6 +349,11 @@ def snapshot_invariants(invariants, integrations, built):
     """
     by_kind = {}
     for integ in integrations:
+        # test_only integrations get no cells. Their markers are known, so the
+        # harness's doubles are not reported as unknown, and they credit
+        # nothing.
+        if integ.get("test_only"):
+            continue
         by_kind.setdefault(integ["kind"], []).append(integ)
 
     exemptions = {

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -367,6 +367,7 @@ def snapshot_invariants(invariants, integrations, built):
             "claim": " ".join(inv["claim"].split()),
             "verified_by": inv["verified_by"],
             "requires": sorted(required),
+            "enforced": bool(inv.get("enforced")),
             "integrations": {},
         }
         if inv.get("tracked_by"):
@@ -377,6 +378,7 @@ def snapshot_invariants(invariants, integrations, built):
         # A pipeline invariant attaches to core, so it has no subjects.
         for integ in by_kind.get(inv["applies_to"], []):
             exemption = exemptions.get((inv["id"], integ["id"]))
+            reason = exemption  # None when the integration must prove it
             levels = {}
             for level in LEVELS:
                 if exemption is not None:
@@ -410,6 +412,21 @@ def snapshot_invariants(invariants, integrations, built):
                         "level": level,
                         "status": state,
                     })
+
+            # An enforced invariant must be proven somewhere, and the level is
+            # not the claim's business: ClickHouse and Kafka need a container,
+            # console and sqlcommand fail in-process. Demanding a named level
+            # would force a container on a sink that needs none, or accept a
+            # fake for one that does.
+            if inv.get("enforced") and reason is None:
+                if not any(c["status"] == "covered" for c in levels.values()):
+                    out["invariant_gaps"].append({
+                        "invariant": inv["id"],
+                        "integration": integ["id"],
+                        "level": "any",
+                        "status": cell_state(levels),
+                    })
+
             entry["integrations"][integ["id"]] = levels
 
         out["invariants"].append(entry)

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -56,10 +56,19 @@ INTEGRATION_PREFIX = "TestIntegration"
 # is a typo, and a typo must not reach the matrix as a missing cell.
 FAMILIES = ("resilience", "checkpoint", "types", "lifecycle", "errors")
 KINDS = ("sink", "source", "handler", "pipeline")
-VERIFIERS = ("harness", "typetable", "named")
+# How an invariant collects evidence. Both are explicit markers: a test says
+# what it proves. `named` used to mean "a test whose name matches the id",
+# which was declared, never implemented, and would have been a third way to
+# attribute the same claim.
+VERIFIERS = ("harness", "typetable")
 
-# pipeline invariants attach to core, not to a constructor case, so no entry
-# in integrations.yml carries that kind.
+# A pipeline invariant is a property of the engine, not of anything a config
+# names, so its marker carries this in place of an integration id and it gets
+# one cell rather than a column per integration.
+PIPELINE = "pipeline"
+
+# pipeline is not among them: no constructor switch builds a pipeline, so no
+# entry in integrations.yml carries that kind.
 INTEGRATION_KINDS = ("sink", "source", "handler")
 
 
@@ -318,8 +327,18 @@ def build_invariants(invariants, integrations, results, evidence):
     one `go test` reports. The outcome recorded here is the test's, not the
     marker's presence.
     """
-    known_inv = {i["id"] for i in invariants}
-    known_integ = {i["id"] for i in integrations}
+    # The integrations each invariant may be proven on. A marker outside this
+    # set is a typo, and crediting it would invent a cell: a sink invariant
+    # "proven on source.kafka" says nothing about either.
+    kinds = {i["id"]: i["kind"] for i in integrations}
+    allowed = {}
+    for inv in invariants:
+        if inv["applies_to"] == PIPELINE:
+            allowed[inv["id"]] = {PIPELINE}
+            continue
+        allowed[inv["id"]] = {
+            iid for iid, kind in kinds.items() if kind == inv["applies_to"]
+        }
 
     cells = {}   # (invariant, integration, level) -> [(test, outcome)]
     unknown = []  # (test, invariant, integration)
@@ -332,7 +351,7 @@ def build_invariants(invariants, integrations, results, evidence):
             # Treat that as a failure rather than as coverage.
             outcome = results.get(level, {}).get(test, FAIL)
             for inv, integ in pairs:
-                if inv not in known_inv or integ not in known_integ:
+                if integ not in allowed.get(inv, set()):
                     unknown.append((test, inv, integ))
                     continue
                 cells.setdefault((inv, integ, level), []).append((test, outcome))
@@ -383,8 +402,14 @@ def snapshot_invariants(invariants, integrations, built):
         if inv.get("violated_once"):
             entry["violated_once"] = list(inv["violated_once"])
 
-        # A pipeline invariant attaches to core, so it has no subjects.
-        for integ in by_kind.get(inv["applies_to"], []):
+        # A pipeline invariant is a property of the engine rather than of
+        # anything a config names, so it gets one cell instead of a column per
+        # integration.
+        subjects = by_kind.get(inv["applies_to"], [])
+        if inv["applies_to"] == PIPELINE:
+            subjects = [{"id": PIPELINE}]
+
+        for integ in subjects:
             exemption = exemptions.get((inv["id"], integ["id"]))
             reason = exemption  # None when the integration must prove it
             levels = {}
@@ -607,10 +632,9 @@ def render(snap):
         ]
         if unwired:
             lines += [
-                f"A further {unwired} invariants attach to the pipeline rather than",
-                "to any one integration. Nothing collects evidence for them yet, so",
-                "they show no cells at all, which is worse than missing rather than",
-                "better.",
+                f"A further {unwired} invariants carry no cell at all, so nothing",
+                "can prove them. That is a declaration with no path to evidence,",
+                "and it is worse than missing rather than better.",
                 "",
             ]
 
@@ -755,10 +779,9 @@ def describe_claim(inv):
 def invariant_tally(snap):
     """Count every (invariant, integration) cell by state.
 
-    `cells` counts only invariants that have integrations. A pipeline
-    invariant attaches to core rather than to a constructor case, so it has
-    none, and `unwired` counts those separately rather than letting them read
-    as zero work.
+    A pipeline invariant carries one cell, so it counts once. `unwired` counts
+    invariants that carry no cell at all, which should be none: an invariant
+    nothing can prove is a declaration with no path to evidence.
     """
     tally = {s: 0 for s in ("covered", "missing", "skipped", "failing", "exempt")}
     unwired = 0
@@ -871,17 +894,18 @@ def render_invariants(snap):
 
     for family in families:
         rows = [i for i in snap["invariants"] if i["family"] == family]
+
+        # Split on what the invariant applies to. A pipeline row in a table of
+        # sink columns renders as a line of dots, which reads as "not
+        # applicable" when the truth is "unproven".
+        per_integration = [i for i in rows if i["applies_to"] != PIPELINE]
+        per_pipeline = [i for i in rows if i["applies_to"] == PIPELINE]
+
         columns = []
-        for inv in rows:
+        for inv in per_integration:
             for integ in inv["integrations"]:
                 if integ not in columns:
                     columns.append(integ)
-
-        # Split by whether the invariant has integrations. A pipeline row in a
-        # table of sink columns renders as a line of dots, which reads as "not
-        # applicable" when the truth is "nothing collects this yet".
-        per_integration = [i for i in rows if i["integrations"]]
-        per_pipeline = [i for i in rows if not i["integrations"]]
 
         lines += [f"## Invariants: {family}", ""]
 
@@ -900,19 +924,17 @@ def render_invariants(snap):
 
         if per_pipeline:
             lines += [
-                f"These {family} invariants are properties of the pipeline, not",
-                "of any one integration, so they have no column. **No evidence is",
-                "collected for them yet**: `verified_by: named` is declared and",
-                "not wired, so an empty cell here means unmeasured, not passing.",
-                "The feature table above may show the same ground as covered,",
-                "and where the two disagree this one is the weaker claim.",
+                f"These {family} invariants are properties of the engine rather",
+                "than of anything a config names, so they carry one cell instead",
+                "of a column per integration. A test proves one by calling",
+                "`coverage.PipelineInvariant`.",
                 "",
-                "| Invariant | Claim | Evidence |",
+                "| Invariant | Claim | Proven |",
                 "| --- | --- | --- |",
             ]
             for inv in per_pipeline:
-                lines.append(f"| `{inv['id']}` | {describe_claim(inv)} | "
-                             f"❌ none collected (`{inv['verified_by']}`) |")
+                cell = invariant_cell(inv["integrations"][PIPELINE], inv["requires"])
+                lines.append(f"| `{inv['id']}` | {describe_claim(inv)} | {cell} |")
             lines.append("")
 
     if snap["invariant_gaps"]:

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -137,6 +137,15 @@ def validate_registries(invariants, integrations, features):
             if not ex.get("reason"):
                 problems.append(
                     f"integrations.yml: {iid} exemption from {inv['id']} has no reason")
+            # An exemption left as prose is an excuse. Two of them hid live
+            # batch-loss bugs: sink.sqlcommand and sink.console were both
+            # excused because nothing crosses a network, which is the argument
+            # for skipping a retry ladder, not the invariant a ladder depends
+            # on. A test must prove the premise.
+            if not ex.get("proven_by"):
+                problems.append(
+                    f"integrations.yml: {iid} exemption from {inv['id']} has no "
+                    "proven_by naming a test that proves the premise")
             if inv.get("applies_to") != integ.get("kind"):
                 problems.append(
                     f"integrations.yml: {iid} is a {integ.get('kind')} but "
@@ -340,7 +349,7 @@ def snapshot_invariants(invariants, integrations, built):
         by_kind.setdefault(integ["kind"], []).append(integ)
 
     exemptions = {
-        (ex["invariant"], integ["id"]): ex["reason"]
+        (ex["invariant"], integ["id"]): ex
         for integ in integrations
         for ex in integ.get("exempt", [])
     }
@@ -367,11 +376,15 @@ def snapshot_invariants(invariants, integrations, built):
 
         # A pipeline invariant attaches to core, so it has no subjects.
         for integ in by_kind.get(inv["applies_to"], []):
-            reason = exemptions.get((inv["id"], integ["id"]))
+            exemption = exemptions.get((inv["id"], integ["id"]))
             levels = {}
             for level in LEVELS:
-                if reason is not None:
-                    levels[level] = {"status": "exempt", "reason": reason}
+                if exemption is not None:
+                    levels[level] = {
+                        "status": "exempt",
+                        "reason": exemption["reason"],
+                        "proven_by": exemption.get("proven_by", ""),
+                    }
                     continue
 
                 # No not_required here, unlike the feature half. Every

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -1300,3 +1300,48 @@ def test_a_claim_carries_the_defect_that_proves_it_matters():
     """violated_once is the difference between a rule and a scar."""
     s = inv_snap(invariants=[dict(INVARIANTS[0], violated_once=["#221"])])
     assert "violated once: #221" in cm.render_invariants(s)
+
+
+# --- Exemptions must be proven, not argued ---------------------------------
+#
+# An exemption is a claim that an invariant cannot apply. Left as prose it is
+# an excuse, and two of them hid live batch-loss bugs in sink.sqlcommand and
+# sink.console: both were excused on the grounds that nothing crosses a
+# network, which is the argument for skipping a *retry ladder*, not for
+# skipping the invariant a ladder depends on. An exemption now names a test
+# that proves its premise.
+
+def test_the_committed_exemptions_all_name_a_test():
+    for integ in cm.load_integrations():
+        for ex in integ.get("exempt", []):
+            assert ex.get("proven_by"), \
+                f"{integ['id']} is exempt from {ex['invariant']} with no proven_by"
+
+
+def test_validate_rejects_an_exemption_with_no_proven_by():
+    bad = [dict(INTEGRATIONS[1], exempt=[
+        {"invariant": "sink.flush.keeps_batch", "reason": "stdout is reliable"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("proven_by" in p for p in problems)
+
+
+def test_validate_still_requires_a_reason_beside_the_proof():
+    """The test says what is true; the reason says why that makes the
+    invariant inapplicable. A reader needs both."""
+    bad = [dict(INTEGRATIONS[1], exempt=[
+        {"invariant": "sink.flush.keeps_batch", "proven_by": "TestX"}])]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("reason" in p for p in problems)
+
+
+def test_the_snapshot_carries_the_proof_beside_the_exemption():
+    """A reader looking at an exempt cell can go straight to the test."""
+    integrations = [dict(INTEGRATIONS[1], exempt=[{
+        "invariant": "sink.flush.keeps_batch",
+        "reason": "implements no Prober",
+        "proven_by": "TestSinkConsole_ImplementsNoProber"}])]
+    s = inv_snap(integrations=integrations)
+    c = cell(s, "sink.flush.keeps_batch", "sink.console", "unit")
+
+    assert c["status"] == "exempt"
+    assert c["proven_by"] == "TestSinkConsole_ImplementsNoProber"

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -919,13 +919,11 @@ def test_snapshot_an_exempt_cell_carries_no_tests_even_with_evidence():
     assert "tests" not in c
 
 
-def test_snapshot_a_pipeline_invariant_has_no_integration_cells():
-    """It attaches to core, and no constructor case is a pipeline."""
-    pipeline = [{"id": "pipeline.commit.after_flush", "family": "checkpoint",
-                 "applies_to": "pipeline", "claim": "c", "verified_by": "named",
-                 "requires": []}]
-    s = inv_snap(invariants=pipeline)
-    assert s["invariants"][0]["integrations"] == {}
+def test_snapshot_a_pipeline_invariant_carries_exactly_one_cell():
+    """It is a property of the engine, not of anything a config names, so it
+    gets one cell rather than a column per integration."""
+    s = inv_snap(invariants=PIPELINE)
+    assert list(s["invariants"][0]["integrations"]) == ["pipeline"]
 
 
 def test_snapshot_orders_tests_stably_whatever_order_they_arrived_in():
@@ -1096,35 +1094,37 @@ def test_render_omits_the_gap_section_when_there_are_none():
     assert "## Invariant gaps" not in cm.render_invariants(inv_snap())
 
 
-def test_render_says_a_pipeline_invariant_has_no_evidence_rather_than_a_dot():
-    """A pipeline row among sink columns rendered as a line of dots, which
-    reads as "not applicable" when the truth is "nothing collects this yet".
-    verified_by: named is declared and not wired."""
-    pipeline = [{"id": "pipeline.commit.after_flush", "family": "checkpoint",
-                 "applies_to": "pipeline", "claim": "c", "verified_by": "named",
-                 "requires": []}]
-    md = cm.render_invariants(inv_snap(invariants=pipeline))
+def test_render_shows_a_pipeline_invariant_as_missing_when_nothing_proves_it():
+    """A pipeline row among sink columns used to render as a line of dots,
+    which reads as "not applicable" when the truth is "unproven"."""
+    md = cm.render_invariants(inv_snap(invariants=PIPELINE))
 
-    assert "| Invariant | Claim | Evidence |" in md
-    assert "| `pipeline.commit.after_flush` | c | ❌ none collected (`named`) |" in md
-    assert "unmeasured, not passing" in md
+    assert "| Invariant | Claim | Proven |" in md
+    assert "| `pipeline.commit.after_flush` | c | ❌ missing |" in md
+
+
+def test_render_shows_a_pipeline_invariant_as_covered_once_proven():
+    s = inv_snap(
+        invariants=PIPELINE,
+        evidence={"unit": {"TestA": [("pipeline.commit.after_flush", "pipeline")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert "| `pipeline.commit.after_flush` | c | ✅ u |" in cm.render_invariants(s)
 
 
 def test_render_separates_pipeline_rows_from_integration_rows_in_one_family():
     """checkpoint holds both. Mixing them puts dots in a table of real cells."""
     mixed = [
         dict(INVARIANTS[1], family="checkpoint"),           # applies_to source
-        {"id": "pipeline.commit.after_flush", "family": "checkpoint",
-         "applies_to": "pipeline", "claim": "c", "verified_by": "named",
-         "requires": []},
+        PIPELINE[0],
     ]
     md = cm.render_invariants(inv_snap(invariants=mixed))
 
     assert md.count("## Invariants: checkpoint") == 1
     assert "| Invariant | Claim | `source.kafka` |" in md
-    assert "| Invariant | Claim | Evidence |" in md
+    assert "| Invariant | Claim | Proven |" in md
     # The pipeline row never appears in the integration table.
-    integration_table = md.split("| Invariant | Claim | Evidence |")[0]
+    integration_table = md.split("| Invariant | Claim | Proven |")[0]
     assert "pipeline.commit.after_flush" not in integration_table
 
 
@@ -1172,14 +1172,24 @@ def test_the_tally_counts_every_cell_by_state():
     assert unwired == 0
 
 
-def test_the_tally_counts_a_pipeline_invariant_as_unwired_not_as_zero():
-    pipeline = [{"id": "pipeline.commit.after_flush", "family": "checkpoint",
-                 "applies_to": "pipeline", "claim": "c", "verified_by": "named",
-                 "requires": []}]
-    tally, unwired = cm.invariant_tally(inv_snap(invariants=pipeline))
+def test_the_tally_counts_a_pipeline_invariant_once():
+    """One cell, counted like any other. It used to carry none and be tallied
+    separately as unwired."""
+    tally, unwired = cm.invariant_tally(inv_snap(invariants=PIPELINE))
 
-    assert unwired == 1
-    assert sum(tally.values()) == 0
+    assert unwired == 0
+    assert tally["missing"] == 1
+    assert sum(tally.values()) == 1
+
+
+def test_no_committed_invariant_is_unwired():
+    """An invariant nothing can prove is a declaration with no path to
+    evidence."""
+    m = json.load(open(os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "docs", "coverage", "matrix.json")))
+    _, unwired = cm.invariant_tally(m)
+    assert unwired == 0
 
 
 def test_the_page_pairs_the_most_tested_feature_with_the_least_proven_invariant():
@@ -1468,3 +1478,75 @@ def test_a_shipped_integration_still_needs_a_feature():
 def test_the_committed_registry_marks_the_double_test_only():
     doubles = [i for i in cm.load_integrations() if i.get("test_only")]
     assert [i["id"] for i in doubles] == ["sink.conformance_double"]
+
+
+# --- Pipeline invariants prove themselves by marker -------------------------
+#
+# `named` was a third attribution mechanism: a test whose name matched the
+# invariant id. It was declared and never implemented, so eight invariants
+# collected nothing while six tests in internal/core proved three of them.
+# Markers replace it. Every invariant is now proven the same way, and a test
+# says what it covers instead of being read for it.
+
+PIPELINE = [
+    {"id": "pipeline.commit.after_flush", "family": "checkpoint",
+     "applies_to": "pipeline", "claim": "c", "verified_by": "harness",
+     "requires": []},
+]
+
+
+def test_a_pipeline_invariant_is_proven_by_a_marker():
+    s = inv_snap(
+        invariants=PIPELINE,
+        evidence={"unit": {"TestA": [("pipeline.commit.after_flush", "pipeline")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    inv = s["invariants"][0]
+    assert inv["integrations"]["pipeline"]["unit"]["status"] == "covered"
+
+
+def test_a_pipeline_invariant_with_no_marker_is_missing_not_absent():
+    """It used to render "none collected", which reads as "not applicable"."""
+    s = inv_snap(invariants=PIPELINE)
+    inv = s["invariants"][0]
+    assert inv["integrations"]["pipeline"]["unit"]["status"] == "missing"
+
+
+def test_a_pipeline_marker_naming_a_sink_is_unknown():
+    """applies_to is the guard. A pipeline invariant proven "on sink.kafka"
+    is a typo, and crediting it would invent a cell."""
+    s = inv_snap(
+        invariants=PIPELINE,
+        evidence={"unit": {"TestA": [("pipeline.commit.after_flush", "sink.kafka")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert {"test": "TestA", "invariant": "pipeline.commit.after_flush",
+            "integration": "sink.kafka"} in s["unknown_invariant_markers"]
+
+
+def test_a_sink_marker_naming_the_pipeline_is_unknown():
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "pipeline")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert {"test": "TestA", "invariant": "sink.flush.keeps_batch",
+            "integration": "pipeline"} in s["unknown_invariant_markers"]
+
+
+def test_a_sink_marker_naming_a_source_is_unknown():
+    """The same guard catches a sink invariant credited to a source."""
+    s = inv_snap(
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "source.kafka")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert {"test": "TestA", "invariant": "sink.flush.keeps_batch",
+            "integration": "source.kafka"} in s["unknown_invariant_markers"]
+
+
+def test_named_is_no_longer_a_verifier():
+    assert "named" not in cm.VERIFIERS
+
+
+def test_no_committed_invariant_uses_named():
+    for inv in cm.load_invariants():
+        assert inv["verified_by"] != "named", inv["id"]

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -495,7 +495,8 @@ INTEGRATIONS = [
      "feature": "sink.clickhouse", "exempt": []},
     {"id": "sink.console", "kind": "sink", "implements": ["Sink"],
      "feature": "sink.console",
-     "exempt": [{"invariant": "sink.flush.keeps_batch", "reason": "stdout"}]},
+     "exempt": [{"invariant": "sink.flush.keeps_batch", "reason": "stdout",
+                 "proven_by": "TestSinkConsole_ImplementsNoProber"}]},
     {"id": "source.kafka", "kind": "source", "implements": ["Source"],
      "feature": "source.kafka", "exempt": []},
 ]
@@ -1414,3 +1415,56 @@ def test_the_committed_registry_enforces_the_two_proven_invariants():
     enforced = {i["id"] for i in cm.load_invariants() if i.get("enforced")}
     assert "sink.write.buffers_only" in enforced
     assert "sink.flush.keeps_batch" in enforced
+
+
+# --- Test-only integrations ------------------------------------------------
+#
+# The conformance harness runs doubles, and a marker names an integration. A
+# double that names a shipped sink credits that sink for what the double did:
+# sink.buffer.reports_depth read green for sink.noop on the strength of an
+# in-memory fake. It would also force exemptions onto a shipped sink for
+# reasons unrelated to its contract.
+
+def test_a_test_only_integration_gets_no_cells():
+    integrations = INTEGRATIONS + [
+        {"id": "sink.conformance_double", "kind": "sink", "test_only": True,
+         "implements": ["Sink"], "exempt": []}]
+    s = inv_snap(integrations=integrations)
+    inv = next(i for i in s["invariants"] if i["id"] == "sink.flush.keeps_batch")
+
+    assert "sink.conformance_double" not in inv["integrations"]
+
+
+def test_a_double_marker_credits_nothing():
+    """The whole point: a passing double changes no cell."""
+    integrations = INTEGRATIONS + [
+        {"id": "sink.conformance_double", "kind": "sink", "test_only": True,
+         "implements": ["Sink"], "exempt": []}]
+    s = inv_snap(
+        integrations=integrations,
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.conformance_double")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    assert cell(s, "sink.flush.keeps_batch", "sink.clickhouse",
+                "unit")["status"] == "missing"
+    assert s["unknown_invariant_markers"] == []
+
+
+def test_a_test_only_integration_needs_no_feature():
+    """It ships to nobody, so features.yml never names it."""
+    integrations = INTEGRATIONS + [
+        {"id": "sink.conformance_double", "kind": "sink", "test_only": True,
+         "implements": ["Sink"], "exempt": []}]
+    assert cm.validate_registries(INVARIANTS, integrations, FEATURES) == []
+
+
+def test_a_shipped_integration_still_needs_a_feature():
+    bad = INTEGRATIONS + [
+        {"id": "sink.mystery", "kind": "sink", "implements": ["Sink"], "exempt": []}]
+    problems = cm.validate_registries(INVARIANTS, bad, FEATURES)
+    assert any("sink.mystery" in p for p in problems)
+
+
+def test_the_committed_registry_marks_the_double_test_only():
+    doubles = [i for i in cm.load_integrations() if i.get("test_only")]
+    assert [i["id"] for i in doubles] == ["sink.conformance_double"]

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -1345,3 +1345,72 @@ def test_the_snapshot_carries_the_proof_beside_the_exemption():
 
     assert c["status"] == "exempt"
     assert c["proven_by"] == "TestSinkConsole_ImplementsNoProber"
+
+
+# --- Enforcement: proven somewhere -----------------------------------------
+#
+# `requires` names levels, and the level an invariant can be proven at is a
+# property of the integration rather than of the claim: ClickHouse and Kafka
+# need a container, console and sqlcommand fail in-process. Demanding a
+# specific level would force a container on a sink that needs none, or accept
+# a fake for one that does. `enforced` demands evidence at some level.
+
+def test_an_enforced_invariant_needs_evidence_at_some_level():
+    enforced = [dict(INVARIANTS[0], enforced=True)]
+    s = inv_snap(
+        invariants=enforced,
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    # clickhouse is proven at unit, which is enough; console is exempt.
+    assert s["invariant_gaps"] == []
+
+
+def test_an_enforced_invariant_with_no_evidence_anywhere_is_a_gap():
+    enforced = [dict(INVARIANTS[0], enforced=True)]
+    s = inv_snap(invariants=enforced)
+
+    assert {"invariant": "sink.flush.keeps_batch", "integration": "sink.clickhouse",
+            "level": "any", "status": "missing"} in s["invariant_gaps"]
+    assert not any(g["integration"] == "sink.console" for g in s["invariant_gaps"])
+
+
+def test_an_enforced_invariant_proven_at_integration_only_is_covered():
+    """A sink that needs a container is not penalised for needing one."""
+    enforced = [dict(INVARIANTS[0], enforced=True)]
+    s = inv_snap(
+        invariants=enforced,
+        evidence={"integration": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"integration": {"TestA": cm.PASS}},
+    )
+    assert s["invariant_gaps"] == []
+
+
+def test_an_enforced_invariant_whose_only_evidence_is_a_skip_is_a_gap():
+    enforced = [dict(INVARIANTS[0], enforced=True)]
+    s = inv_snap(
+        invariants=enforced,
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.SKIP}},
+    )
+    assert any(g["integration"] == "sink.clickhouse" for g in s["invariant_gaps"])
+
+
+def test_requires_and_enforced_are_independent():
+    """requires still demands a named level when a claim genuinely needs one."""
+    both = [dict(INVARIANTS[0], enforced=True, requires=["release"])]
+    s = inv_snap(
+        invariants=both,
+        evidence={"unit": {"TestA": [("sink.flush.keeps_batch", "sink.clickhouse")]}},
+        results={"unit": {"TestA": cm.PASS}},
+    )
+    levels = {g["level"] for g in s["invariant_gaps"]}
+    assert levels == {"release"}
+
+
+def test_the_committed_registry_enforces_the_two_proven_invariants():
+    """Every sink now proves both, so both are enforced. A new sink cannot
+    merge without a conformance subject."""
+    enforced = {i["id"] for i in cm.load_invariants() if i.get("enforced")}
+    assert "sink.write.buffers_only" in enforced
+    assert "sink.flush.keeps_batch" in enforced


### PR DESCRIPTION
Three sinks dropped rows they failed to deliver. This PR fixes all three and enforces the invariant.

## Why the defects stayed invisible

`sink.flush.keeps_batch` was proven on one sink and excused on two. Both exemptions gave the same reason: nothing crosses a network, so `retriesHelp` already excludes the sink.

That reason answers the wrong question. `retriesHelp` decides whether a retry ladder helps. The invariant asks whether the pipeline may commit offsets for rows that never landed. Every sink that can fail must answer it.

Removing both exemptions let the harness judge all six sinks. It found three defects.

## The defects

Each sink lost its batch for a different reason:

| Sink | Defect | Severity |
|---|---|---|
| `console` | `bufio.Writer` latches its first error. Every later `Flush` returns that stale error, and the bytes are gone. The sink never recovers. | Live |
| `kafka` | `WriteTable` produced every row on the way in, so a failed flush held nothing back. `Flush` then cleared its error list, so a second flush returned nil having produced nothing. | Live |
| `sqlcommand` | `Flush` released every batch on the way out, whatever the outcome. A failed flush left nothing to retry. | Latent |

The order the pipeline runs matters here. `WriteTable` buffers, `Flush` delivers, and only then do offsets and state commit. `internal/core/turbine.go` says why: "Committing first would move the offsets past rows the sink never wrote." A sink that loses its batch on a failed flush breaks the guarantee that commit depends on.

Console and Kafka fail loudly. Sink errors bypass `on_error`, so the pipeline stops and the batch replays on restart. A transient full disk becomes a dead pipeline.

sqlcommand is latent. Nothing calls `Flush` twice on it today, so rows replay from the source. It is correct by accident of the call pattern.

## The fixes

A failed `Flush` now leaves every undelivered row buffered, in every sink:

- `console` buffers the rows itself. A short write leaves the unwritten tail pending.
- `kafka` buffers on write. `Flush` produces, waits on its context, then returns every unacknowledged row to the head in order. A record still in flight when the context ends counts as unacknowledged.
- `sqlcommand` requeues on failure, as ClickHouse does.

## Exemptions now carry evidence

An exemption must name a test. The generator rejects one without `proven_by`.

Eighteen exemptions remain, and each is structural. The sink implements no `Prober`, the source implements no `MarkCommitter`, or noop discards by design. Each names a test that asserts the premise.

## Visibility on the buffer

This PR makes Kafka buffer where it produced immediately, so it creates memory growth that did not exist before. Nothing bounds a sink buffer. Today a failed flush stops the pipeline and the buffer dies with the process, which is a property of the call pattern rather than of the design.

`sink_buffered_rows` is a gauge recorded on both flush paths, the failure path first. That is where the number moves. Sinks report through `core.BufferedRowReporter`, optional like `MarkCommitter`.

A gauge nobody checks is a gauge that lies quietly, so the harness judges it. `sink.buffer.reports_depth` is enforced: one row after a write, still one after a failed flush, none after a success.

## Every invariant is proven by an explicit marker

`verified_by: named` meant "a test whose name matches the invariant id". It was declared and never implemented, so eight invariants collected nothing while six tests in `internal/core` already proved three of them. The matrix reported "no evidence" for a guarantee the suite enforces on every batch.

Implementing it would have added a mechanism. Deleting it removes one. `verified_by` now has two values, and both are explicit markers.

Four claims move from unmeasured to enforced, each naming the test that already asserted it:

| Invariant | What the test asserts |
|---|---|
| `pipeline.commit.after_flush` | `flush`, `save-offsets`, `commit`, in that order |
| `pipeline.commit.nothing_on_failure` | a failed flush rolls back and the source is never told |
| `pipeline.state.with_offsets` | a failed offset save rolls back the state written with it |
| `lifecycle.drain.on_cancel` | a cancelled run writes its buffered batch before returning |

A marker is now checked against what the invariant applies to. A sink invariant credited to a source reports as unknown instead of inventing a cell.

## Two false positives, both doubles crediting real sinks

The harness runs test doubles, and a marker names an integration. They ran under `sink.noop`, so `sink.buffer.reports_depth` read green for `NoopSink` on the strength of an in-memory fake. Worse, the guard against that forced every invariant the harness judges to be exempt for `sink.noop` — so the first invariant `NoopSink` genuinely satisfied would have been exempted anyway, hiding real coverage of a shipped sink.

The doubles now run under `sink.conformance_double`, declared `test_only`. It gets no cells and its markers land nowhere.

The second: the harness emitted the integration id as a *feature* marker. An integration id is not a feature id. It now emits what the registry declares, and `sink.noop` gained its own feature row rather than borrowing `sink.console`'s.

## Enforcement

Seven invariants are now `enforced: true`, up from zero. A new sink cannot merge without a conformance subject.

`enforced` demands evidence at some level. `requires` names specific levels, and no single level fits. ClickHouse and Kafka need a container. Console, sqlcommand and Iceberg fail in-process. Naming a level would force a container on a sink that needs none.

## Evidence

Reverting the Kafka fix makes its subject fail against a real broker behind toxiproxy:

```
sink.write.buffers_only  the destination holds rows [id=1] after WriteTable and before any
                         Flush; only Flush may deliver, because the pipeline commits offsets
                         on what Flush reports
sink.flush.keeps_batch   Flush returned nil while the destination was broken, because the rows
                         had already been delivered by WriteTable; there was nothing left to keep
```

Restoring the fix makes both pass in 50s.

Console and sqlcommand run the same harness at unit level. Both passed only after their fixes.

Deleting the Iceberg subject makes the gate report `sink.iceberg: any is missing`.

The gate exits 0 on the real reports: no feature gaps, no invariant gaps, no unattributed tests and no unknown markers. 16 Go packages and 149 tooling tests pass.

## A harness bug the fakes missed

A write-through sink returns nil from `Flush` while its destination is broken. The rows already went out, so nothing remains to fail on. The harness read that as a broken fault and blamed the subject. It discarded the `buffers_only` verdict it had already reached.

The `writeThroughSink` fake returned an error instead of nil. A real broker exposed the difference. The fake now matches franz-go.

## A test that passed for the wrong reason

`TestSinkKafka_WriteTableHonoursItsContext` is gone. It asserted that a cancelled write context failed those records. franz-go watches a `Produce` context only while a topic is unresolved, and the topic never resolved against `127.0.0.1:1`.

`WriteTable` now reaches nothing, so no context can fail a write. The guarantee moved to `Flush`. A new test asserts it, and asserts that the rows stay pending.

## Out of scope

Three follow-ups, each its own PR or issue:

- **Kafka green across the board.** `no_hollow_success`, `preserves_order`, `honours_context` and `error.classifies` are missing on every sink.
- **A pipeline harness.** These four invariants are proven by markers on existing tests, not by a harness. The pipeline has configurations — with durable state and without — and only one is proven. Making configurations into subjects changes what an integration is in the matrix, which is a schema decision and wants its own review.
- **`retry:` is parsed and discarded** for kafka, console, sqlcommand and noop, documented for Kafka only. Now that every sink keeps its batch, revisit which sinks `retriesHelp` excludes, and reject or warn on a `retry:` block the sink ignores.
