### PR TITLE
The consume loop is a conformance subject, and attribution is explicit

### DIFF
--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -152,6 +152,31 @@ integrations:
         reason: implements no MarkCommitter; at-most-once by construction
         proven_by: TestSourceWebhook_ImplementsNoMarkCommitter
 
+  # --- Pipelines -------------------------------------------------------------
+  # Configurations of the consume loop. Nothing in a config file names one, so
+  # `constructed: false`: no constructor switch lists them and Kinds() must not
+  # be held equal to them.
+  #
+  # They are subjects because the loop behaves differently with durable state
+  # than without, and because four paths reach processBatch. One cell per
+  # configuration is what shows which of those combinations is proven.
+  - id: pipeline.stateful
+    kind: pipeline
+    constructed: false
+    implements: [Source, Sink, Handler]
+    feature: state.durability
+    exempt: []
+
+  - id: pipeline.stateless
+    kind: pipeline
+    constructed: false
+    implements: [Source, Sink, Handler]
+    feature: core.consume_loop
+    exempt:
+      - invariant: pipeline.state.with_offsets
+        reason: keeps no durable state, so there is nothing to commit with the offsets
+        proven_by: TestPipelineStateless_KeepsNoDurableState
+
   # --- Handlers --------------------------------------------------------------
   - id: handler.structured
     kind: handler

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -621,6 +621,11 @@
         "unit": {
           "status": "covered",
           "tests": [
+            "TestPipelineStateful_Conformance",
+            "TestPipelineStateful_Conformance/lifecycle.drain.on_cancel",
+            "TestPipelineStateful_Conformance/pipeline.commit.after_flush",
+            "TestPipelineStateful_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateful_Conformance/pipeline.state.with_offsets",
             "TestStateDurability_DBSecondConnectionSeesOnlyCommittedState",
             "TestStateDurability_OpenPathEmptyPathIsInMemory",
             "TestStateDurability_OpenPathPersistsAcrossProcesses",
@@ -631,6 +636,13 @@
             "TestStateDurability_Stats_ExcludesTheBatchTable",
             "TestStateDurability_Stats_IsDeterministicallyOrdered",
             "TestStateDurability_Stats_TableNamesSurviveReaderRelease"
+          ],
+          "by_marker": [
+            "TestPipelineStateful_Conformance",
+            "TestPipelineStateful_Conformance/lifecycle.drain.on_cancel",
+            "TestPipelineStateful_Conformance/pipeline.commit.after_flush",
+            "TestPipelineStateful_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateful_Conformance/pipeline.state.with_offsets"
           ]
         },
         "integration": {
@@ -803,7 +815,24 @@
             "TestCoreConsumeLoop_ProcessBatchRollsBackWhenOffsetSaveFails",
             "TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails",
             "TestCoreConsumeLoop_ProcessBatchSavesTheProcessedOffsets",
-            "TestCoreConsumeLoop_WritesEveryMessageAcrossManyBatches"
+            "TestCoreConsumeLoop_WritesEveryMessageAcrossManyBatches",
+            "TestPipelineStateless_Conformance",
+            "TestPipelineStateless_Conformance/lifecycle.drain.on_cancel",
+            "TestPipelineStateless_Conformance/pipeline.commit.after_flush",
+            "TestPipelineStateless_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateless_Conformance/pipeline.state.with_offsets",
+            "TestPipelineStateless_KeepsNoDurableState"
+          ],
+          "skipped": [
+            "TestPipelineStateless_Conformance/pipeline.state.with_offsets"
+          ],
+          "by_marker": [
+            "TestPipelineStateless_Conformance",
+            "TestPipelineStateless_Conformance/lifecycle.drain.on_cancel",
+            "TestPipelineStateless_Conformance/pipeline.commit.after_flush",
+            "TestPipelineStateless_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateless_Conformance/pipeline.state.with_offsets",
+            "TestPipelineStateless_KeepsNoDurableState"
           ]
         },
         "integration": {
@@ -1296,6 +1325,10 @@
           "status": "covered",
           "tests": [
             "TestToolingConformanceDescribe_NamesTheRowsItFound",
+            "TestToolingConformancePipelines_AStatelessSubjectSkipsStateInvariants",
+            "TestToolingConformancePipelines_CatchesACommitBeforeTheFlush",
+            "TestToolingConformancePipelines_JudgeOnlyDeclaredInvariants",
+            "TestToolingConformancePipelines_RunsEveryTrigger",
             "TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink",
             "TestToolingConformanceSinks_ACorrectSinkPasses",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.buffer.reports_depth",
@@ -2399,11 +2432,27 @@
       "requires": [],
       "enforced": true,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
           "unit": {
             "status": "covered",
             "tests": [
-              "TestCoreConsumeLoop_ProcessBatchFlushesSinkBeforeCommittingState"
+              "TestPipelineStateful_Conformance/pipeline.commit.after_flush"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestPipelineStateless_Conformance/pipeline.commit.after_flush"
             ]
           },
           "integration": {
@@ -2426,12 +2475,27 @@
       "requires": [],
       "enforced": true,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
           "unit": {
             "status": "covered",
             "tests": [
-              "TestCoreConsumeLoop_ProcessBatchCommitFailureDoesNotCommitSource",
-              "TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails"
+              "TestPipelineStateful_Conformance/pipeline.commit.nothing_on_failure"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestPipelineStateless_Conformance/pipeline.commit.nothing_on_failure"
             ]
           },
           "integration": {
@@ -2454,11 +2518,11 @@
       "requires": [],
       "enforced": true,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
           "unit": {
             "status": "covered",
             "tests": [
-              "TestCoreConsumeLoop_ProcessBatchRollsBackWhenOffsetSaveFails"
+              "TestPipelineStateful_Conformance/pipeline.state.with_offsets"
             ]
           },
           "integration": {
@@ -2468,6 +2532,23 @@
           "release": {
             "status": "missing",
             "tests": []
+          }
+        },
+        "pipeline.stateless": {
+          "unit": {
+            "status": "exempt",
+            "reason": "keeps no durable state, so there is nothing to commit with the offsets",
+            "proven_by": "TestPipelineStateless_KeepsNoDurableState"
+          },
+          "integration": {
+            "status": "exempt",
+            "reason": "keeps no durable state, so there is nothing to commit with the offsets",
+            "proven_by": "TestPipelineStateless_KeepsNoDurableState"
+          },
+          "release": {
+            "status": "exempt",
+            "reason": "keeps no durable state, so there is nothing to commit with the offsets",
+            "proven_by": "TestPipelineStateless_KeepsNoDurableState"
           }
         }
       }
@@ -3302,11 +3383,27 @@
       "requires": [],
       "enforced": true,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
           "unit": {
             "status": "covered",
             "tests": [
-              "TestLifecycleDrain_CancelDrainsTheBufferedBatch"
+              "TestPipelineStateful_Conformance/lifecycle.drain.on_cancel"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestPipelineStateless_Conformance/lifecycle.drain.on_cancel"
             ]
           },
           "integration": {
@@ -3329,7 +3426,21 @@
       "requires": [],
       "enforced": false,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
           "unit": {
             "status": "missing",
             "tests": []
@@ -3450,7 +3561,21 @@
       "requires": [],
       "enforced": false,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
           "unit": {
             "status": "missing",
             "tests": []
@@ -3476,7 +3601,21 @@
       "requires": [],
       "enforced": false,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
           "unit": {
             "status": "missing",
             "tests": []
@@ -3502,7 +3641,21 @@
       "requires": [],
       "enforced": false,
       "integrations": {
-        "pipeline": {
+        "pipeline.stateful": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
           "unit": {
             "status": "missing",
             "tests": []

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -543,6 +543,9 @@
             "test_handler_inferred_mem_invoke_renders_rows",
             "test_handler_inferred_mem_joins_against_a_csv",
             "test_handler_inferred_mem_preserves_arrays_and_unioned_fields"
+          ],
+          "by_marker": [
+            "test_handler_inferred_mem_invoke_renders_rows"
           ]
         }
       }
@@ -636,13 +639,6 @@
             "TestStateDurability_Stats_ExcludesTheBatchTable",
             "TestStateDurability_Stats_IsDeterministicallyOrdered",
             "TestStateDurability_Stats_TableNamesSurviveReaderRelease"
-          ],
-          "by_marker": [
-            "TestPipelineStateful_Conformance",
-            "TestPipelineStateful_Conformance/lifecycle.drain.on_cancel",
-            "TestPipelineStateful_Conformance/pipeline.commit.after_flush",
-            "TestPipelineStateful_Conformance/pipeline.commit.nothing_on_failure",
-            "TestPipelineStateful_Conformance/pipeline.state.with_offsets"
           ]
         },
         "integration": {
@@ -651,6 +647,9 @@
         "release": {
           "status": "covered",
           "tests": [
+            "test_state_durability_survives_a_restart"
+          ],
+          "by_marker": [
             "test_state_durability_survives_a_restart"
           ]
         }
@@ -825,14 +824,6 @@
           ],
           "skipped": [
             "TestPipelineStateless_Conformance/pipeline.state.with_offsets"
-          ],
-          "by_marker": [
-            "TestPipelineStateless_Conformance",
-            "TestPipelineStateless_Conformance/lifecycle.drain.on_cancel",
-            "TestPipelineStateless_Conformance/pipeline.commit.after_flush",
-            "TestPipelineStateless_Conformance/pipeline.commit.nothing_on_failure",
-            "TestPipelineStateless_Conformance/pipeline.state.with_offsets",
-            "TestPipelineStateless_KeepsNoDurableState"
           ]
         },
         "integration": {
@@ -990,9 +981,6 @@
           "status": "covered",
           "tests": [
             "test_state_durability_survives_a_restart"
-          ],
-          "by_marker": [
-            "test_state_durability_survives_a_restart"
           ]
         }
       }
@@ -1059,9 +1047,6 @@
         "release": {
           "status": "covered",
           "tests": [
-            "test_config_validation_accepts_a_shipped_example"
-          ],
-          "by_marker": [
             "test_config_validation_accepts_a_shipped_example"
           ]
         }
@@ -1166,6 +1151,9 @@
         "release": {
           "status": "covered",
           "tests": [
+            "test_config_validation_accepts_a_shipped_example"
+          ],
+          "by_marker": [
             "test_config_validation_accepts_a_shipped_example"
           ]
         }
@@ -1285,9 +1273,6 @@
         "release": {
           "status": "covered",
           "tests": [
-            "test_handler_inferred_mem_invoke_renders_rows"
-          ],
-          "by_marker": [
             "test_handler_inferred_mem_invoke_renders_rows"
           ]
         }

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -35,12 +35,12 @@ names every one of them.
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
 | `handler.structured` | Binds a declared schema, ingesting through Arrow. | ✅ | — | ✅ | 8 |
-| `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 11 |
+| `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 16 |
 | `state.offsets` | Kafka positions are stored in DuckDB and resumed on restart. | ✅ | — | ✅ | 22 |
 | `state.corruption` | A damaged state file fails the start rather than silently resetting. | ✅ | — | ✅ | 6 |
 | `lifecycle.drain` | SIGTERM writes the buffered batch before exiting. | ✅ | — | ✅ | 2 |
 | `lifecycle.exit_codes` | The process exit status carries the error code a supervisor reads. | ✅ | — | ✅ | 8 |
-| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 14 |
+| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 20 |
 | `error.taxonomy` | Every failure carries a class.domain.reason code. | ✅ | — | — | 16 |
 | `error.raise` | Policy RAISE stops the pipeline on a bad record. | ✅ | — | — | 1 |
 | `error.ignore` | Policy IGNORE drops a bad record and keeps the pipeline running. | ✅ | — | ✅ | 5 |
@@ -53,7 +53,7 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
-| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 22 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 26 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
 **34 features declared. 34 have at least one passing test attributed at every level they require, so 0 gap(s).**
@@ -64,7 +64,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**29 invariants declared. Of 122 (invariant, integration) cells: 19 proven, 84 missing, 0 skipped, 0 failing, 19 exempt. 0 gap(s), because no invariant requires a level yet.**
+**29 invariants declared. Of 130 (invariant, integration) cells: 22 proven, 88 missing, 0 skipped, 0 failing, 20 exempt. 0 gap(s), because no invariant requires a level yet.**
 
 ## Why invariants, and not the test count
 
@@ -141,16 +141,18 @@ invariant's `requires` is filled in, and none is yet.
 | `source.marks.never_regress` | A committed position never moves backwards. | ❌ missing | — exempt | — exempt |
 | `source.commit.on_revoke` | Marks commit when a partition is revoked, before the rebalance completes. *(declared, tracked by #183)* | ❌ missing | — exempt | — exempt |
 
-These checkpoint invariants are properties of the engine rather
-than of anything a config names, so they carry one cell instead
-of a column per integration. A test proves one by calling
-`coverage.PipelineInvariant`.
+These checkpoint invariants are properties of the consume loop
+rather than of anything a config file names. The columns are
+its configurations, and `internal/conformance` runs each one
+through every path that reaches a batch: the batch filling, the
+flush interval elapsing, the source closing, and a cancel that
+drains. An invariant holds only if it holds on all four.
 
-| Invariant | Claim | Proven |
-| --- | --- | --- |
-| `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | ✅ u |
-| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | ✅ u |
-| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | ✅ u |
+| Invariant | Claim | `pipeline.stateful` | `pipeline.stateless` |
+| --- | --- | --- | --- |
+| `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | ✅ u | ✅ u |
+| `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | ✅ u | ✅ u |
+| `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | ✅ u | — exempt |
 
 ## Invariants: types
 
@@ -169,26 +171,30 @@ of a column per integration. A test proves one by calling
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `lifecycle.close.idempotent` | Close twice is safe. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 
-These lifecycle invariants are properties of the engine rather
-than of anything a config names, so they carry one cell instead
-of a column per integration. A test proves one by calling
-`coverage.PipelineInvariant`.
+These lifecycle invariants are properties of the consume loop
+rather than of anything a config file names. The columns are
+its configurations, and `internal/conformance` runs each one
+through every path that reaches a batch: the batch filling, the
+flush interval elapsing, the source closing, and a cancel that
+drains. An invariant holds only if it holds on all four.
 
-| Invariant | Claim | Proven |
-| --- | --- | --- |
-| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | ✅ u |
-| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ missing |
-| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ missing |
+| Invariant | Claim | `pipeline.stateful` | `pipeline.stateless` |
+| --- | --- | --- | --- |
+| `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | ✅ u | ✅ u |
+| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ missing | ❌ missing |
+| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ missing | ❌ missing |
 
 ## Invariants: errors
 
-These errors invariants are properties of the engine rather
-than of anything a config names, so they carry one cell instead
-of a column per integration. A test proves one by calling
-`coverage.PipelineInvariant`.
+These errors invariants are properties of the consume loop
+rather than of anything a config file names. The columns are
+its configurations, and `internal/conformance` runs each one
+through every path that reaches a batch: the batch filling, the
+flush interval elapsing, the source closing, and a cancel that
+drains. An invariant holds only if it holds on all four.
 
-| Invariant | Claim | Proven |
-| --- | --- | --- |
-| `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | ❌ missing |
-| `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | ❌ missing |
+| Invariant | Claim | `pipeline.stateful` | `pipeline.stateless` |
+| --- | --- | --- | --- |
+| `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | ❌ missing | ❌ missing |
+| `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | ❌ missing | ❌ missing |
 

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -4,9 +4,10 @@ Generated from `docs/coverage/matrix.json` by `make coverage-matrix`.
 Do not edit by hand.
 
 Features are declared in `docs/coverage/features.yml`. A test attaches
-to one by name -- `sink.clickhouse` is covered by `TestSinkClickhouse*`
-or `test_sink_clickhouse*` -- and that is the cheap default: rename a
-test and it is attributed, with no import and no marker.
+to one by saying so: `coverage.Covers(t, "sink.clickhouse")` in Go, or
+the `covers` marker in pytest. A test used to attach by the shape of
+its name, which credited a test whose name merely started the same way
+and credited nothing when a name drifted.
 
 Levels are derived from where a test ran, never declared, so they
 cannot drift. `unit` is `go test -short`, `integration` is the Go
@@ -83,20 +84,19 @@ covered. This one does not.
 
 ## Covered only by another test's marker
 
-These features have no test named for them. That is legitimate for a
-capability an end-to-end run proves in passing, and a smell for one
-that deserves its own test.
+Every test that covers these claims something else first. That is
+legitimate for a capability an end-to-end run proves in passing, and
+a smell for one that deserves a test of its own.
 
 - `source.kafka` (release) — via `test_handler_inferred_mem_aggregates_every_message`, `test_state_durability_survives_a_restart`
 - `source.websocket` (release) — via `test_handler_inferred_mem_preserves_arrays_and_unioned_fields`
 - `sink.kafka` (release) — via `test_handler_inferred_mem_aggregates_every_message`
 - `sink.console` (release) — via `test_handler_inferred_mem_invoke_renders_rows`
 - `handler.structured` (release) — via `test_handler_inferred_mem_preserves_arrays_and_unioned_fields`
+- `state.durability` (release) — via `test_state_durability_survives_a_restart`
 - `state.offsets` (release) — via `test_state_durability_survives_a_restart`
 - `state.corruption` (release) — via `test_lifecycle_exit_codes_carry_the_error_code`
-- `manager.tumbling_window` (release) — via `test_state_durability_survives_a_restart`
-- `config.templating` (release) — via `test_config_validation_accepts_a_shipped_example`
-- `cli.dev_invoke` (release) — via `test_handler_inferred_mem_invoke_renders_rows`
+- `config.validation` (release) — via `test_config_validation_accepts_a_shipped_example`
 
 
 # Invariant matrix

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -16,6 +17,7 @@ import (
 // edit somewhere else.
 
 func TestConfigValidation_ExampleMatchesPythonOutput(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	golden, err := os.ReadFile("testdata/config_example.golden")
 	assert.NoError(t, err)
 
@@ -31,6 +33,7 @@ func TestConfigValidation_ExampleMatchesPythonOutput(t *testing.T) {
 // that is how `type: webhook` came to be rejected by `config validate` while
 // `run` accepted it.
 func TestConfigValidation_Examples(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	for _, path := range exampleConfigs(t) {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			assert.NoError(t, validateConfig(path))
@@ -39,6 +42,7 @@ func TestConfigValidation_Examples(t *testing.T) {
 }
 
 func TestConfigValidation_RendersTemplateBeforeValidating(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	// batch_size arrives only through the Jinja2 default filter; validating
 	// the raw file would see a template expression where an integer is required.
 	path := writeTempConfig(t, `
@@ -61,6 +65,7 @@ pipeline:
 }
 
 func TestConfigValidation_RejectsMissingPipeline(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	path := writeTempConfig(t, "commands: []\n")
 
 	err := validateConfig(path)
@@ -69,6 +74,7 @@ func TestConfigValidation_RejectsMissingPipeline(t *testing.T) {
 }
 
 func TestConfigValidation_RejectsBadEnum(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	path := writeTempConfig(t, `
 pipeline:
   batch_size: 1
@@ -87,6 +93,7 @@ pipeline:
 }
 
 func TestConfigValidation_RejectsMissingRequiredHandlerSQL(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	path := writeTempConfig(t, `
 pipeline:
   batch_size: 1
@@ -109,11 +116,13 @@ pipeline:
 }
 
 func TestConfigValidation_ReportsMissingFile(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	err := validateConfig(filepath.Join(t.TempDir(), "nope.yml"))
 	assert.Error(t, err)
 }
 
 func TestConfigValidation_AcceptsStatePath(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	path := writeTempConfig(t, `
 pipeline:
   batch_size: 10

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-adbc/go/adbc/drivermgr"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -40,6 +41,7 @@ func newTestADBCConn(t *testing.T) (adbc.Connection, func()) {
 // TestCliDevInvoke_InferredMemBatch mirrors the Python suite's basic.agg.mem
 // invoke case: two messages in, one aggregated row per city out.
 func TestCliDevInvoke_InferredMemBatch(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -65,6 +67,7 @@ func TestCliDevInvoke_InferredMemBatch(t *testing.T) {
 // and none of the other invoke tests has an array anywhere in its fixture,
 // which is how "unsupported json array value" reached a release.
 func TestCliDevInvoke_BlueskyFirehose(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -106,6 +109,7 @@ func TestCliDevInvoke_BlueskyFirehose(t *testing.T) {
 // TestCliDevInvoke_StructuredBatch covers the path where the handler's table is
 // created by a config command, which must run before the handler is built.
 func TestCliDevInvoke_StructuredBatch(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -129,6 +133,7 @@ func TestCliDevInvoke_StructuredBatch(t *testing.T) {
 // TestCliDevInvoke_SkipsBlankLines matches the Python invoke, which strips each
 // fixture line and writes only the non-empty ones.
 func TestCliDevInvoke_SkipsBlankLines(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -161,6 +166,7 @@ func TestCliDevInvoke_SkipsBlankLines(t *testing.T) {
 // bytes of lines already handed to the handler; a handler keeps those slices
 // until invoke, so any that were not copied out decode as garbage.
 func TestCliDevInvoke_LargeFixture(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -182,6 +188,7 @@ func TestCliDevInvoke_LargeFixture(t *testing.T) {
 }
 
 func TestCliDevInvoke_ReportsMissingFixture(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -201,6 +208,7 @@ func TestCliDevInvoke_ReportsMissingFixture(t *testing.T) {
 // users meet it first. It must report no rows rather than crash on the nil
 // table an empty batch produces.
 func TestCliDevInvoke_EmptyFixture(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -223,6 +231,7 @@ func TestCliDevInvoke_EmptyFixture(t *testing.T) {
 // A fixture of nothing but blank lines reaches the handler with no messages
 // by the same route.
 func TestCliDevInvoke_FixtureOfOnlyBlankLines(t *testing.T) {
+	coverage.Covers(t, "cli.dev_invoke")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 

--- a/internal/cli/examples_test.go
+++ b/internal/cli/examples_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"github.com/turbolytics/sql-flow/internal/handlers"
 	"github.com/turbolytics/sql-flow/internal/sinks"
@@ -76,6 +77,7 @@ func denyExternalAccess(conn adbc.Connection) error {
 // the only symptom would be a CI job three minutes slower than it should be.
 // So assert the block directly.
 func TestConfigValidation_ExternalAccessIsDenied(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	conn, err := duckdb.Open(context.Background())
 	if err != nil {
 		t.Fatalf("open duckdb: %v", err)
@@ -111,6 +113,7 @@ func TestConfigValidation_ExternalAccessIsDenied(t *testing.T) {
 // Nothing here reaches the network, and that is load-bearing rather than
 // tidiness. This test is in the job whose contract is "unit tests only".
 func TestConfigValidation_ExampleConfigsBuildRealComponents(t *testing.T) {
+	coverage.Covers(t, "config.validation")
 	// Values the release tests supply. Every example now names its variables
 	// with the SQLFLOW_ prefix, which is the only form an environment can
 	// reach -- these are passed as overrides here only because this test never

--- a/internal/cli/exit_test.go
+++ b/internal/cli/exit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/zeebo/assert"
 )
@@ -41,6 +42,7 @@ func runWithCorruptState(t *testing.T) (error, string) {
 // reads. Exiting 1 marks the failure retryable, so the supervisor restarts
 // forever into the same bytes.
 func TestLifecycleExitCodes_CorruptStateFileExitsTerminal(t *testing.T) {
+	coverage.Covers(t, "lifecycle.exit_codes")
 	cmd, _ := corruptStateCommand(t)
 
 	code := execute(cmd)
@@ -51,6 +53,7 @@ func TestLifecycleExitCodes_CorruptStateFileExitsTerminal(t *testing.T) {
 
 // A successful command exits zero.
 func TestLifecycleExitCodes_SuccessExitsZero(t *testing.T) {
+	coverage.Covers(t, "lifecycle.exit_codes")
 	cmd := NewRootCommand()
 	cmd.SetArgs([]string{"version"})
 	cmd.SetOut(&bytes.Buffer{})
@@ -62,6 +65,7 @@ func TestLifecycleExitCodes_SuccessExitsZero(t *testing.T) {
 // Guards propagation rather than driving it: the code has to survive cobra's
 // error path to reach execute at all.
 func TestLifecycleExitCodes_SurvivesCobra(t *testing.T) {
+	coverage.Covers(t, "lifecycle.exit_codes")
 	err, _ := runWithCorruptState(t)
 
 	assert.Error(t, err)
@@ -72,6 +76,7 @@ func TestLifecycleExitCodes_SurvivesCobra(t *testing.T) {
 // list for any error a command returns, which buries the one line that says
 // what went wrong.
 func TestLifecycleExitCodes_NoFlagList(t *testing.T) {
+	coverage.Covers(t, "lifecycle.exit_codes")
 	_, output := runWithCorruptState(t)
 
 	if strings.Contains(output, "Flags:") {
@@ -93,6 +98,7 @@ func runArgs(t *testing.T, args ...string) (int, string) {
 // A config path that does not exist is the user's to fix. Exiting retryable
 // would have a supervisor restart until someone notices.
 func TestLifecycleExitCodes_MissingConfigIsTerminal(t *testing.T) {
+	coverage.Covers(t, "lifecycle.exit_codes")
 	code, output := runArgs(t, "run", "/nope/does-not-exist.yml")
 
 	assert.Equal(t, errs.ExitUserError, code)
@@ -102,6 +108,7 @@ func TestLifecycleExitCodes_MissingConfigIsTerminal(t *testing.T) {
 
 // Unparseable YAML does not become parseable on a retry.
 func TestLifecycleExitCodes_MalformedConfigIsTerminal(t *testing.T) {
+	coverage.Covers(t, "lifecycle.exit_codes")
 	path := filepath.Join(t.TempDir(), "bad.yml")
 	assert.NoError(t, os.WriteFile(path, []byte("pipeline:\n  name: [unclosed\n"), 0o644))
 
@@ -115,6 +122,7 @@ func TestLifecycleExitCodes_MalformedConfigIsTerminal(t *testing.T) {
 // Suppressing usage for runtime errors must not suppress it for the errors
 // usage actually answers.
 func TestLifecycleExitCodes_UsageErrorStillPrintsUsage(t *testing.T) {
+	coverage.Covers(t, "lifecycle.exit_codes")
 	_, output := runArgs(t, "run", "--not-a-real-flag")
 
 	if !strings.Contains(output, "Flags:") {

--- a/internal/cli/run/args_test.go
+++ b/internal/cli/run/args_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -12,12 +13,14 @@ import (
 // caps with --max-msgs-to-process, Go took -c and --max-msgs. Both spellings
 // have to work, or swapping the image breaks every existing invocation.
 func TestCliInvocation_ResolveConfigPathPythonPositionalForm(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	got, err := resolveConfigPath("", []string{"pipeline.yml"})
 	assert.NoError(t, err)
 	assert.Equal(t, "pipeline.yml", got)
 }
 
 func TestCliInvocation_ResolveConfigPathGoFlagForm(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	got, err := resolveConfigPath("pipeline.yml", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "pipeline.yml", got)
@@ -26,46 +29,54 @@ func TestCliInvocation_ResolveConfigPathGoFlagForm(t *testing.T) {
 // Passing the same path both ways is redundant but unambiguous, so it is
 // allowed; two different paths is a mistake worth reporting.
 func TestCliInvocation_ResolveConfigPathBothFormsAgreeing(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	got, err := resolveConfigPath("pipeline.yml", []string{"pipeline.yml"})
 	assert.NoError(t, err)
 	assert.Equal(t, "pipeline.yml", got)
 }
 
 func TestCliInvocation_ResolveConfigPathConflictingFormsError(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	_, err := resolveConfigPath("a.yml", []string{"b.yml"})
 	assert.Error(t, err)
 }
 
 func TestCliInvocation_ResolveConfigPathMissingConfigErrors(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	_, err := resolveConfigPath("", nil)
 	assert.Error(t, err)
 }
 
 func TestCliInvocation_ResolveMaxMsgsPythonFlag(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	got, err := resolveMaxMsgs(0, 500)
 	assert.NoError(t, err)
 	assert.Equal(t, 500, got)
 }
 
 func TestCliInvocation_ResolveMaxMsgsGoFlag(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	got, err := resolveMaxMsgs(500, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 500, got)
 }
 
 func TestCliInvocation_ResolveMaxMsgsBothFormsAgreeing(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	got, err := resolveMaxMsgs(500, 500)
 	assert.NoError(t, err)
 	assert.Equal(t, 500, got)
 }
 
 func TestCliInvocation_ResolveMaxMsgsConflictingFormsError(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	_, err := resolveMaxMsgs(500, 900)
 	assert.Error(t, err)
 }
 
 // Neither given means no cap, which is the documented default.
 func TestCliInvocation_ResolveMaxMsgsUnsetIsUnlimited(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	got, err := resolveMaxMsgs(0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, got)
@@ -74,6 +85,7 @@ func TestCliInvocation_ResolveMaxMsgsUnsetIsUnlimited(t *testing.T) {
 // The command must accept zero or one positional argument: zero for the -c
 // form, one for the Python form. A second is a typo, not a config.
 func TestCliInvocation_NewCommandRejectsTwoPositionalArgs(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	cmd := NewCommand()
 	assert.Error(t, cmd.Args(cmd, []string{"a.yml", "b.yml"}))
 	assert.NoError(t, cmd.Args(cmd, []string{"a.yml"}))
@@ -83,6 +95,7 @@ func TestCliInvocation_NewCommandRejectsTwoPositionalArgs(t *testing.T) {
 // --config must not be marked required, or the positional form fails before
 // RunE is ever reached.
 func TestCliInvocation_NewCommandConfigFlagIsNotRequired(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	cmd := NewCommand()
 	flag := cmd.Flags().Lookup("config")
 	assert.NotNil(t, flag)
@@ -90,6 +103,7 @@ func TestCliInvocation_NewCommandConfigFlagIsNotRequired(t *testing.T) {
 }
 
 func TestCliInvocation_NewCommandHasPythonMaxMsgsFlag(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
 	cmd := NewCommand()
 	assert.NotNil(t, cmd.Flags().Lookup("max-msgs-to-process"))
 	assert.NotNil(t, cmd.Flags().Lookup("max-msgs"))

--- a/internal/cli/run/debug_test.go
+++ b/internal/cli/run/debug_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"github.com/zeebo/assert"
 )
@@ -53,6 +54,7 @@ func debugGet(t *testing.T, h http.Handler, sql string) *httptest.ResponseRecord
 // The Python endpoint jsonifies duckdb's fetchall(), a list of row tuples, so
 // rows arrive as arrays rather than objects.
 func TestObservabilityDebugApi_HandlerReturnsRowsAsJSON(t *testing.T) {
+	coverage.Covers(t, "observability.debug_api")
 	conn := newTestConn(t)
 	execSQL(t, conn, "CREATE TABLE t (id BIGINT, name VARCHAR)")
 	execSQL(t, conn, "INSERT INTO t VALUES (1, 'a'), (2, 'b')")
@@ -66,6 +68,7 @@ func TestObservabilityDebugApi_HandlerReturnsRowsAsJSON(t *testing.T) {
 }
 
 func TestObservabilityDebugApi_HandlerReturnsEmptyArrayForNoRows(t *testing.T) {
+	coverage.Covers(t, "observability.debug_api")
 	conn := newTestConn(t)
 	execSQL(t, conn, "CREATE TABLE empty (id BIGINT)")
 
@@ -77,6 +80,7 @@ func TestObservabilityDebugApi_HandlerReturnsEmptyArrayForNoRows(t *testing.T) {
 }
 
 func TestObservabilityDebugApi_HandlerRejectsMissingQuery(t *testing.T) {
+	coverage.Covers(t, "observability.debug_api")
 	h := newDebugHandler(newTestConn(t), &sync.Mutex{})
 	w := debugGet(t, h, "")
 
@@ -85,6 +89,7 @@ func TestObservabilityDebugApi_HandlerRejectsMissingQuery(t *testing.T) {
 }
 
 func TestObservabilityDebugApi_HandlerReportsQueryErrors(t *testing.T) {
+	coverage.Covers(t, "observability.debug_api")
 	h := newDebugHandler(newTestConn(t), &sync.Mutex{})
 	w := debugGet(t, h, "SELECT * FROM does_not_exist")
 
@@ -97,6 +102,7 @@ func TestObservabilityDebugApi_HandlerReportsQueryErrors(t *testing.T) {
 // The endpoint shares the pipeline's connection, so it must not touch it while
 // a handler holds the lock.
 func TestObservabilityDebugApi_HandlerWaitsForThePipelineLock(t *testing.T) {
+	coverage.Covers(t, "observability.debug_api")
 	conn := newTestConn(t)
 	execSQL(t, conn, "CREATE TABLE t (id BIGINT)")
 
@@ -126,10 +132,12 @@ func TestObservabilityDebugApi_HandlerWaitsForThePipelineLock(t *testing.T) {
 
 // Python serves the endpoint from Flask's default 127.0.0.1:5000.
 func TestObservabilityDebugApi_ServerServesOnPythonPort(t *testing.T) {
+	coverage.Covers(t, "observability.debug_api")
 	assert.Equal(t, "127.0.0.1:5000", debugAddr)
 }
 
 func TestObservabilityDebugApi_ServerServesTheDebugRoute(t *testing.T) {
+	coverage.Covers(t, "observability.debug_api")
 	conn := newTestConn(t)
 	execSQL(t, conn, "CREATE TABLE t (id BIGINT)")
 	execSQL(t, conn, "INSERT INTO t VALUES (7)")

--- a/internal/cli/run/metrics_test.go
+++ b/internal/cli/run/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -15,6 +16,7 @@ import (
 // cannot read it while the pipeline holds it -- not even read-only. A running
 // pipeline therefore has to serve its own stats.
 func TestObservabilityMetrics_StatsHandler_ReportsState(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
 	want := &core.StateStats{
 		Path:      "/state/state.db",
 		SizeBytes: 4096,
@@ -48,6 +50,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsState(t *testing.T) {
 // A pipeline with no state path still answers, with a null state block. The
 // endpoint stays useful for the counters even when nothing is durable.
 func TestObservabilityMetrics_StatsHandler_NullStateWithoutAStateDatabase(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
 	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return nil, nil })
 
 	rec := httptest.NewRecorder()
@@ -63,6 +66,7 @@ func TestObservabilityMetrics_StatsHandler_NullStateWithoutAStateDatabase(t *tes
 // success, so a monitoring system sees the problem instead of a healthy-looking
 // blank.
 func TestObservabilityMetrics_StatsHandler_ReportsCollectionFailure(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
 	mux := newHTTPMux(nil, func() (*core.StateStats, error) {
 		return nil, errors.New("state database unreadable")
 	})
@@ -75,6 +79,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsCollectionFailure(t *testing.T
 // With no stats provider at all -- metrics enabled but state unwired -- the
 // endpoint must not be registered as a half-working route.
 func TestObservabilityMetrics_StatsHandler_AbsentWithoutAProvider(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
 	mux := newHTTPMux(nil, nil)
 
 	rec := httptest.NewRecorder()

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -45,6 +46,7 @@ func loadString(t *testing.T, body string) *Conf {
 // The config spec is Jinja2: filter arguments are parenthesized. pongo2's
 // colon syntax is not interchangeable, and every example config uses Jinja.
 func TestConfigTemplating_Render_JinjaDefaultFilter(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	tests := []struct {
 		name      string
 		body      string
@@ -90,6 +92,7 @@ func TestConfigTemplating_Render_JinjaDefaultFilter(t *testing.T) {
 // The Python engine seeds the context with these, and configs reference them
 // unqualified.
 func TestConfigTemplating_Render_ProvidesSettingsVars(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	out := renderString(t, `root: {{ STATIC_ROOT }}/x.csv`, nil)
 	assert.Equal(t, "root: /tmp/sqlflow/static/x.csv", out)
 
@@ -98,6 +101,7 @@ func TestConfigTemplating_Render_ProvidesSettingsVars(t *testing.T) {
 }
 
 func TestConfigTemplating_Render_SettingsVarsHonorEnvOverrides(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	t.Setenv("SQLFLOW_STATIC_ROOT", "/data/static")
 	out := renderString(t, `root: {{ STATIC_ROOT }}`, nil)
 	assert.Equal(t, "root: /data/static", out)
@@ -106,6 +110,7 @@ func TestConfigTemplating_Render_SettingsVarsHonorEnvOverrides(t *testing.T) {
 // Every shipped config must render and parse, so a config written for the
 // Python engine runs on turbine unmodified.
 func TestConfigTemplating_Load_AllExampleConfigs(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	// Walked rather than globbed: a plain *.yml glob is not recursive, so it
 	// silently skipped every config under examples/bluesky/ -- the shipped
 	// configs least like the others, and the ones this test most needed to
@@ -142,6 +147,7 @@ func TestConfigTemplating_Load_AllExampleConfigs(t *testing.T) {
 // The webhook block's keys are the Python engine's, see the WebhookSource and
 // HMACConfig dataclasses in sqlflow/config.py.
 func TestConfigTemplating_Load_WebhookSourceKeys(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	dir := t.TempDir()
 	path := filepath.Join(dir, "webhook.yml")
 	body := `
@@ -178,6 +184,7 @@ pipeline:
 // An unrecognized key is a typo, not a setting to drop silently: the config
 // schema sets additionalProperties: false.
 func TestConfigTemplating_Load_RejectsUnknownKeys(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yml")
 
@@ -205,6 +212,7 @@ pipeline:
 // A pipeline may name a file for its DuckDB state. Absent, state stays in
 // memory and is lost on a crash.
 func TestConfigTemplating_Load_StatePath(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	conf := loadString(t, `
 pipeline:
   batch_size: 10
@@ -227,6 +235,7 @@ pipeline:
 }
 
 func TestConfigTemplating_Load_StateAbsentIsNil(t *testing.T) {
+	coverage.Covers(t, "config.templating")
 	conf := loadString(t, `
 pipeline:
   batch_size: 10

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -73,8 +73,29 @@ func Sinks(t *testing.T, s SinkSubject) {
 	t.Helper()
 	requireSubject(t, s)
 
+	// Every subtest is its own entry in `go test -json`, so each one carries
+	// both markers. The sink subtests happened to match a feature prefix --
+	// TestIntegrationSinkClickhouse_Conformance/... reads as
+	// TestSinkClickhouse* once the level prefix is stripped -- and that
+	// accident is exactly what an explicit marker replaces.
+	//
+	// The feature comes from the registry rather than from the integration
+	// id: sink.noop attributes to sink.noop, and a test_only integration
+	// attributes to nothing.
+	feature, hasFeature, err := coverage.FeatureFor(s.Integration)
+	if err != nil {
+		t.Fatalf("conformance: %v", err)
+	}
+
 	for _, v := range sinkVerdicts(t, s) {
 		t.Run(v.invariant, func(t *testing.T) {
+			// Emitted before the outcome, because it says which feature this
+			// test touched rather than that it passed. A skipped or failing
+			// subtest records as a skip or a failure against the feature,
+			// which status() already refuses to count as coverage.
+			if hasFeature {
+				coverage.Covers(t, feature)
+			}
 			if v.skipped != "" {
 				t.Skip(v.skipped)
 			}
@@ -85,15 +106,7 @@ func Sinks(t *testing.T, s SinkSubject) {
 		})
 	}
 
-	// The feature axis credits the run too, so a conformance test is not
-	// invisible to features.yml. The feature comes from the registry rather
-	// than from the integration id: sink.noop attributes to sink.console, and
-	// a test_only integration attributes to nothing.
-	feature, has, err := coverage.FeatureFor(s.Integration)
-	if err != nil {
-		t.Fatalf("conformance: %v", err)
-	}
-	if has {
+	if hasFeature {
 		coverage.Covers(t, feature)
 	}
 }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -451,3 +451,80 @@ func TestToolingConformanceSinks_TheDoublesIntegrationIsNotAShippedSink(t *testi
 		assert.That(t, "sink."+kind != fakeIntegration)
 	}
 }
+
+// --- The pipeline harness --------------------------------------------------
+
+// A pipeline that commits before it flushes moves the position past rows the
+// sink never took. The harness must catch that on every path, so this runs a
+// subject whose recorder reports the wrong order and holds that the verdict
+// names it.
+func TestToolingConformancePipelines_CatchesACommitBeforeTheFlush(t *testing.T) {
+	vs := pipelineVerdictsFor(t, PipelineSubject{
+		Integration: "pipeline.stateful",
+		KeepsState:  true,
+		Options: func(r *Recorder) []core.TurbineOption {
+			// A store that records its save before the sink has flushed is
+			// the defect: the events come out in the wrong order.
+			r.record("save-offsets")
+			return []core.TurbineOption{core.WithStateStore(r.Offsets(), r.Tx())}
+		},
+	})
+
+	assert.True(t, vs[commitAfterFlush].failure != "")
+	assert.True(t, strings.Contains(vs[commitAfterFlush].failure, "want"))
+}
+
+// A configuration that keeps no state cannot prove the invariant about
+// committing state with the offsets. It must skip rather than fail, and the
+// registry must exempt it: two statements that have to agree.
+func TestToolingConformancePipelines_AStatelessSubjectSkipsStateInvariants(t *testing.T) {
+	vs := pipelineVerdictsFor(t, PipelineSubject{
+		Integration: "pipeline.stateless",
+		KeepsState:  false,
+		Options:     func(*Recorder) []core.TurbineOption { return nil },
+	})
+
+	assert.True(t, strings.Contains(vs[stateWithOffsets].skipped, "no durable state"))
+	assert.Equal(t, "", vs[stateWithOffsets].failure)
+
+	// The other three still apply to a stateless pipeline.
+	assert.Equal(t, "", vs[commitAfterFlush].failure)
+	assert.Equal(t, "", vs[commitNothingOnFail].failure)
+	assert.Equal(t, "", vs[drainOnCancel].failure)
+}
+
+// Every invariant the pipeline harness judges must be declared, or its marker
+// reports as unknown and the cell never appears.
+func TestToolingConformancePipelines_JudgeOnlyDeclaredInvariants(t *testing.T) {
+	declared, err := coverage.Invariants()
+	assert.NoError(t, err)
+
+	for id := range pipelineVerdictsFor(t, PipelineSubject{
+		Integration: "pipeline.stateful",
+		KeepsState:  true,
+		Options: func(r *Recorder) []core.TurbineOption {
+			return []core.TurbineOption{core.WithStateStore(r.Offsets(), r.Tx())}
+		},
+	}) {
+		assert.True(t, declared[id])
+	}
+}
+
+// The harness must exercise every path that reaches a batch. A trigger that
+// stopped firing would leave its path unproven while the matrix stayed green.
+func TestToolingConformancePipelines_RunsEveryTrigger(t *testing.T) {
+	assert.DeepEqual(t, []Trigger{
+		TriggerBatchFull, TriggerInterval, TriggerSourceClosed, TriggerDrain,
+	}, Triggers)
+}
+
+func pipelineVerdictsFor(t *testing.T, s PipelineSubject) map[string]verdict {
+	t.Helper()
+
+	out := map[string]verdict{}
+	for _, v := range pipelineVerdicts(t, s) {
+		out[v.invariant] = v
+	}
+	assert.Equal(t, 4, len(out))
+	return out
+}

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -21,12 +21,14 @@ import (
 // break it in the ways real sinks have.
 
 func TestToolingConformanceSinks_ACorrectSinkPasses(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	Sinks(t, subject(newMemSink()))
 }
 
 // #221's defect: a failed Flush discards the buffer, so the retry finds
 // nothing to send and reports a success that delivered no rows.
 func TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	v := verdicts(t, subject(&dropSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, v.failure != "")
@@ -38,6 +40,7 @@ func TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught(t *testing.T) {
 // after the retry finds the row and every downstream check passes for the
 // wrong reason. Only a read-back before the first Flush catches it.
 func TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	vs := verdicts(t, subject(&writeThroughSink{memSink: newMemSink()}))
 
 	assert.True(t, vs[buffersOnly].failure != "")
@@ -51,6 +54,7 @@ func TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught(t *testing.T) {
 // The two invariants are independent: a sink can buffer correctly and still
 // lose the batch, and the matrix must show which one broke.
 func TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	vs := verdicts(t, subject(&dropSink{memSink: newMemSink()}))
 
 	assert.Equal(t, "", vs[buffersOnly].failure)
@@ -59,6 +63,7 @@ func TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
 
 // A sink that keeps the batch but never clears it delivers the row twice.
 func TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	v := verdicts(t, subject(&neverClearSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, strings.Contains(v.failure, "id=1, id=1"))
@@ -67,12 +72,14 @@ func TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught(t *testing.T) {
 // A retry that fails is not the same defect, and the message must not blame
 // the buffer for it.
 func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	v := verdicts(t, subject(&staysDownSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
 }
 
 func TestToolingConformanceSinks_ASinkThatMisreportsItsDepthIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	vs := verdicts(t, subject(&lyingSink{memSink: newMemSink()}))
 
 	// It keeps its batch, so the other two hold. Only the gauge lies.
@@ -85,6 +92,7 @@ func TestToolingConformanceSinks_ASinkThatMisreportsItsDepthIsCaught(t *testing.
 // A sink that reports no depth at all is skipped rather than failed, and the
 // registry must then exempt it. Two statements that have to agree.
 func TestToolingConformanceSinks_ASinkThatReportsNoDepthIsSkipped(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	vs := verdicts(t, subject(&noDepthSink{inner: newMemSink()}))
 
 	assert.Equal(t, "", vs[keepsBatch].failure)
@@ -93,6 +101,7 @@ func TestToolingConformanceSinks_ASinkThatReportsNoDepthIsSkipped(t *testing.T) 
 }
 
 func TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	s := subject(newMemSink())
 	s.Break, s.Heal = nil, nil
 
@@ -108,6 +117,7 @@ func TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped(t *testing.
 // matrix would otherwise read a subject that exercises nothing as covered,
 // which is the sink.iceberg failure.
 func TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	s := subject(newMemSink())
 	s.Break, s.Heal = nil, nil
 
@@ -118,6 +128,7 @@ func TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker(t *testing.T) {
 }
 
 func TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	s := subject(newMemSink())
 	s.Integration = ""
 
@@ -127,6 +138,7 @@ func TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected(t *tes
 // Break without Heal would leave the destination broken for whatever runs
 // next, which is a fault the next subject cannot explain.
 func TestToolingConformanceSinks_ASubjectWithBreakAndNoHealIsRejected(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	s := subject(newMemSink())
 	s.Heal = nil
 
@@ -134,6 +146,7 @@ func TestToolingConformanceSinks_ASubjectWithBreakAndNoHealIsRejected(t *testing
 }
 
 func TestToolingConformanceSinks_ASubjectMissingReadBackIsRejected(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	s := subject(newMemSink())
 	s.ReadBack = nil
 
@@ -143,6 +156,7 @@ func TestToolingConformanceSinks_ASubjectMissingReadBackIsRejected(t *testing.T)
 // The harness must not report a sink defect when the subject's own fault
 // injection did nothing: that sends the reader to the wrong file.
 func TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	s := subject(newMemSink())
 	s.Break = func(*testing.T) {} // does nothing
 	s.Heal = func(*testing.T) {}
@@ -154,6 +168,7 @@ func TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink
 // not be reported as a broken fault: buffers_only already showed that the
 // rows went out early, so the sink is at fault and the subject is not.
 func TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	vs := verdicts(t, subject(&writeThroughSink{memSink: newMemSink()}))
 
 	assert.True(t, vs[buffersOnly].failure != "")
@@ -161,6 +176,7 @@ func TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject(t *tes
 }
 
 func TestToolingConformanceDescribe_NamesTheRowsItFound(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	assert.Equal(t, "no rows", describe(nil))
 	assert.Equal(t, "rows [id=1]", describe([]Row{{"id": int64(1)}}))
 	assert.Equal(t, "rows [id=1, id=2]",
@@ -370,6 +386,7 @@ func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
 // Every invariant the harness judges must be declared, or its marker reports
 // as unknown and the cell never appears.
 func TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	declared, err := coverage.Invariants()
 	assert.NoError(t, err)
 
@@ -435,6 +452,7 @@ func oneRow(t *testing.T, id int64) arrow.Table {
 // in-memory double that never touched NoopSink. The id the doubles use has to
 // be test_only, which is what keeps its markers off every cell.
 func TestToolingConformanceSinks_TheDoublesRunUnderATestOnlyIntegration(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	testOnly, err := coverage.IsTestOnly(fakeIntegration)
 	assert.NoError(t, err)
 	assert.True(t, testOnly)
@@ -444,6 +462,7 @@ func TestToolingConformanceSinks_TheDoublesRunUnderATestOnlyIntegration(t *testi
 // constructor switch also names would put a double's marker on a real sink
 // after all.
 func TestToolingConformanceSinks_TheDoublesIntegrationIsNotAShippedSink(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	shipped, err := coverage.Integrations("sink")
 	assert.NoError(t, err)
 
@@ -459,6 +478,7 @@ func TestToolingConformanceSinks_TheDoublesIntegrationIsNotAShippedSink(t *testi
 // subject whose recorder reports the wrong order and holds that the verdict
 // names it.
 func TestToolingConformancePipelines_CatchesACommitBeforeTheFlush(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	vs := pipelineVerdictsFor(t, PipelineSubject{
 		Integration: "pipeline.stateful",
 		KeepsState:  true,
@@ -478,6 +498,7 @@ func TestToolingConformancePipelines_CatchesACommitBeforeTheFlush(t *testing.T) 
 // committing state with the offsets. It must skip rather than fail, and the
 // registry must exempt it: two statements that have to agree.
 func TestToolingConformancePipelines_AStatelessSubjectSkipsStateInvariants(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	vs := pipelineVerdictsFor(t, PipelineSubject{
 		Integration: "pipeline.stateless",
 		KeepsState:  false,
@@ -496,6 +517,7 @@ func TestToolingConformancePipelines_AStatelessSubjectSkipsStateInvariants(t *te
 // Every invariant the pipeline harness judges must be declared, or its marker
 // reports as unknown and the cell never appears.
 func TestToolingConformancePipelines_JudgeOnlyDeclaredInvariants(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	declared, err := coverage.Invariants()
 	assert.NoError(t, err)
 
@@ -513,6 +535,7 @@ func TestToolingConformancePipelines_JudgeOnlyDeclaredInvariants(t *testing.T) {
 // The harness must exercise every path that reaches a batch. A trigger that
 // stopped firing would leave its path unproven while the matrix stayed green.
 func TestToolingConformancePipelines_RunsEveryTrigger(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
 	assert.DeepEqual(t, []Trigger{
 		TriggerBatchFull, TriggerInterval, TriggerSourceClosed, TriggerDrain,
 	}, Triggers)

--- a/internal/conformance/pipeline.go
+++ b/internal/conformance/pipeline.go
@@ -1,0 +1,610 @@
+package conformance
+
+// The pipeline half of the harness.
+//
+// A sink invariant has six subjects, one per sink the engine can build. A
+// pipeline invariant looked like it had one, which is why these claims were
+// first proven by markers on hand-written tests. That was wrong twice over.
+//
+// The consume loop has two configurations that change what a commit means,
+// durable state or none, and four paths that reach processBatch: the batch
+// filled, the flush interval elapsed, the source closed, and a cancel that
+// drains. Eight combinations. Two were tested.
+//
+// So the subject is a configuration, the harness runs every trigger against
+// it, and each combination that goes unproven says so in the matrix instead
+// of being upheld by inspection.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+)
+
+// Trigger is what makes the consume loop process a batch.
+//
+// Every one of them ends in the same three steps, and a pipeline that commits
+// correctly on one path and not another loses rows on that path alone.
+type Trigger string
+
+const (
+	// TriggerBatchFull is the common path: the batch reached batchSize.
+	TriggerBatchFull Trigger = "batch-full"
+	// TriggerInterval is the flush interval elapsing with a partial batch.
+	TriggerInterval Trigger = "flush-interval"
+	// TriggerSourceClosed is the source's stream closing with rows buffered.
+	TriggerSourceClosed Trigger = "source-closed"
+	// TriggerDrain is a cancelled context, which a SIGTERM arrives as. The
+	// loop drains through a context stripped of cancellation, so this is the
+	// one path whose flush must run after the caller gave up.
+	TriggerDrain Trigger = "drain"
+)
+
+// Triggers is every path in the order the harness runs them.
+var Triggers = []Trigger{
+	TriggerBatchFull,
+	TriggerInterval,
+	TriggerSourceClosed,
+	TriggerDrain,
+}
+
+// PipelineSubject is one configuration of the consume loop.
+type PipelineSubject struct {
+	// Integration is the integrations.yml id, e.g. "pipeline.stateful".
+	Integration string
+
+	// KeepsState says whether this configuration commits durable state and
+	// offsets alongside the source position. A configuration that keeps none
+	// cannot prove the invariants about committing them together, and the
+	// registry must exempt it.
+	KeepsState bool
+
+	// Options builds the pipeline's options from the harness's recorder. A
+	// stateful configuration returns core.WithStateStore(r.Offsets(), r.Tx()).
+	Options func(r *Recorder) []core.TurbineOption
+}
+
+// Pipelines proves every pipeline invariant the subject can exercise.
+func Pipelines(t *testing.T, s PipelineSubject) {
+	t.Helper()
+	if s.Integration == "" {
+		t.Fatal("conformance: PipelineSubject.Integration is required")
+	}
+	if s.Options == nil {
+		t.Fatal("conformance: PipelineSubject.Options is required")
+	}
+
+	// Every subtest is its own entry in `go test -json`, so each one carries
+	// both markers. Nothing here is attributed by its name.
+	feature, hasFeature, err := coverage.FeatureFor(s.Integration)
+	if err != nil {
+		t.Fatalf("conformance: %v", err)
+	}
+
+	for _, v := range pipelineVerdicts(t, s) {
+		t.Run(v.invariant, func(t *testing.T) {
+			// Emitted before the outcome, because it says which feature this
+			// test touched rather than that it passed. A skipped or failing
+			// subtest records as a skip or a failure against the feature,
+			// which status() already refuses to count as coverage.
+			if hasFeature {
+				coverage.Covers(t, feature)
+			}
+			if v.skipped != "" {
+				t.Skip(v.skipped)
+			}
+			if v.failure != "" {
+				t.Fatal(v.failure)
+			}
+			coverage.Invariant(t, v.invariant, s.Integration)
+		})
+	}
+
+	if hasFeature {
+		coverage.Covers(t, feature)
+	}
+}
+
+const (
+	commitAfterFlush    = "pipeline.commit.after_flush"
+	commitNothingOnFail = "pipeline.commit.nothing_on_failure"
+	stateWithOffsets    = "pipeline.state.with_offsets"
+	drainOnCancel       = "lifecycle.drain.on_cancel"
+)
+
+// pipelineVerdicts runs every trigger against the subject and judges each
+// invariant across all of them.
+//
+// An invariant holds only if it holds on every path. A pipeline that commits
+// after flushing when the batch fills, and before flushing when the interval
+// elapses, loses rows on the second path and the matrix must not call it
+// covered.
+func pipelineVerdicts(t *testing.T, s PipelineSubject) []verdict {
+	t.Helper()
+
+	afterFlush := verdict{invariant: commitAfterFlush}
+	onFailure := verdict{invariant: commitNothingOnFail}
+	withOffsets := verdict{invariant: stateWithOffsets}
+	drain := verdict{invariant: drainOnCancel}
+
+	if !s.KeepsState {
+		withOffsets.skipped = s.Integration + " keeps no durable state, so " +
+			"there is nothing to commit with the offsets; exempt it in " +
+			"integrations.yml"
+	}
+
+	for _, trigger := range Triggers {
+		// The happy path: every trigger must flush before it commits.
+		if afterFlush.failure == "" {
+			if err := checkCommitAfterFlush(t, s, trigger); err != nil {
+				afterFlush.failure = err.Error()
+			}
+		}
+
+		// A sink that cannot deliver must leave every position where it was.
+		if onFailure.failure == "" {
+			if err := checkNothingOnFailure(t, s, trigger); err != nil {
+				onFailure.failure = err.Error()
+			}
+		}
+
+		// State and offsets are one commit, so a failure saving one must roll
+		// back the other.
+		if s.KeepsState && withOffsets.failure == "" {
+			if err := checkStateWithOffsets(t, s, trigger); err != nil {
+				withOffsets.failure = err.Error()
+			}
+		}
+	}
+
+	// Drain is one path rather than a property of all of them: the claim is
+	// that a cancelled run writes what it buffered.
+	if err := checkDrain(t, s); err != nil {
+		drain.failure = err.Error()
+	}
+
+	return []verdict{afterFlush, onFailure, withOffsets, drain}
+}
+
+// checkCommitAfterFlush runs one trigger and holds the event order.
+func checkCommitAfterFlush(t *testing.T, s PipelineSubject, trigger Trigger) error {
+	t.Helper()
+	run := runPipeline(t, s, trigger, faults{})
+	if run.err != nil {
+		return fmt.Errorf("%s: the pipeline failed with no fault injected: %v",
+			trigger, run.err)
+	}
+
+	want := []string{"flush"}
+	if s.KeepsState {
+		want = append(want, "save-offsets", "commit")
+	}
+	if !sameOrder(run.events, want) {
+		return fmt.Errorf(
+			"%s: the pipeline did %s; want %s. Committing before the flush "+
+				"moves the position past rows the sink never took, and the "+
+				"consumer group reports no lag while they are gone",
+			trigger, list(run.events), list(want))
+	}
+	return nil
+}
+
+// checkNothingOnFailure fails the flush and holds every position still.
+func checkNothingOnFailure(t *testing.T, s PipelineSubject, trigger Trigger) error {
+	t.Helper()
+	run := runPipeline(t, s, trigger, faults{flush: true})
+	if run.err == nil {
+		return fmt.Errorf("%s: the flush failed and the pipeline did not", trigger)
+	}
+
+	if s.KeepsState {
+		if !sameOrder(run.events, []string{"flush-failed", "rollback"}) {
+			return fmt.Errorf(
+				"%s: after a failed flush the pipeline did %s; want a rollback "+
+					"and nothing else",
+				trigger, list(run.events))
+		}
+	}
+	if run.sourceCommits != 0 {
+		return fmt.Errorf(
+			"%s: the flush failed and the source was still told to commit %d "+
+				"time(s); the rows never landed, so the position must not move",
+			trigger, run.sourceCommits)
+	}
+	return nil
+}
+
+// checkStateWithOffsets fails the offset save and holds that the handler's
+// state went back with it.
+func checkStateWithOffsets(t *testing.T, s PipelineSubject, trigger Trigger) error {
+	t.Helper()
+	run := runPipeline(t, s, trigger, faults{offsets: true})
+	if run.err == nil {
+		return fmt.Errorf("%s: saving offsets failed and the pipeline did not",
+			trigger)
+	}
+	if !sameOrder(run.events, []string{"flush", "save-offsets-failed", "rollback"}) {
+		return fmt.Errorf(
+			"%s: after a failed offset save the pipeline did %s; want a "+
+				"rollback, so the state this batch wrote goes back with the "+
+				"offsets that describe it",
+			trigger, list(run.events))
+	}
+	if run.sourceCommits != 0 {
+		return fmt.Errorf(
+			"%s: the offset save failed and the source was still told to "+
+				"commit", trigger)
+	}
+	return nil
+}
+
+// checkDrain cancels mid-run and holds that the buffered rows were written.
+func checkDrain(t *testing.T, s PipelineSubject) error {
+	t.Helper()
+	run := runPipeline(t, s, TriggerDrain, faults{})
+	if run.err != nil {
+		return fmt.Errorf("drain: the pipeline failed on a cancel: %v", run.err)
+	}
+	if run.rows != drainRows {
+		return fmt.Errorf(
+			"drain: a cancelled run wrote %d of %d buffered rows; returning "+
+				"without them drops the tail of every graceful shutdown",
+			run.rows, drainRows)
+	}
+	if run.flushes != 1 {
+		return fmt.Errorf("drain: the buffered batch was flushed %d times; want 1",
+			run.flushes)
+	}
+	return nil
+}
+
+func sameOrder(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func list(events []string) string {
+	if len(events) == 0 {
+		return "nothing"
+	}
+	return "[" + strings.Join(events, ", ") + "]"
+}
+
+// faults says what the harness breaks on a given run.
+type faults struct {
+	flush   bool
+	offsets bool
+}
+
+// outcome is what one run produced.
+type outcome struct {
+	events        []string
+	rows          int64
+	flushes       int
+	sourceCommits int
+	err           error
+}
+
+// drainRows is the number of messages the drain scenario buffers. Small, and
+// larger than one, so a drain that writes a partial batch is visible.
+const drainRows = 10
+
+// runPipeline builds the subject's pipeline over the harness's instrumented
+// parts and runs it until the trigger fires.
+func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) outcome {
+	t.Helper()
+
+	rec := &Recorder{failOffsets: f.offsets}
+	src := &recordingSource{rec: rec}
+	sink := &recordingSink{rec: rec, fail: f.flush}
+
+	// Sized so only the intended trigger can fire. A batch size above the
+	// message count keeps the batch from filling; an hour-long interval keeps
+	// the ticker quiet.
+	batchSize, interval := 4, time.Hour
+	switch trigger {
+	case TriggerBatchFull:
+		src.batch = messages(4)
+	case TriggerInterval:
+		// The stream stays open so the select blocks on it and the ticker
+		// wins. Closing it here instead would end the run through the
+		// source-closed path, which is a different branch: an earlier version
+		// did exactly that and tested one path twice.
+		src.batch = messages(2)
+		src.block = true
+		batchSize, interval = 1000, 100*time.Millisecond
+
+		// Close as soon as the interval's flush lands, so the run ends
+		// deterministically and no second tick can fire.
+		var once sync.Once
+		rec.onEvent = func(event string) {
+			if event == "flush" || event == "flush-failed" {
+				once.Do(func() { go src.Close() })
+			}
+		}
+	case TriggerSourceClosed:
+		src.batch = messages(2)
+		batchSize = 1000
+	case TriggerDrain:
+		src.batch = messages(drainRows)
+		batchSize, src.block = 1000, true
+	}
+
+	if trigger != TriggerInterval {
+		// Only the interval scenario needs a ticker it can win.
+		interval = time.Hour
+	}
+
+	tb := core.NewTurbine(src, &passthroughHandler{}, sink, batchSize, interval,
+		&sync.Mutex{}, core.PipelineErrorPolicies{}, s.Options(rec)...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if trigger == TriggerDrain {
+		go func() {
+			src.wrote.Wait()
+			cancel()
+		}()
+	}
+
+	_, err := tb.ConsumeLoop(ctx, 0)
+
+	return outcome{
+		events:        rec.Events(),
+		rows:          sink.Rows(),
+		flushes:       sink.Flushes(),
+		sourceCommits: src.Commits(),
+		err:           err,
+	}
+}
+
+func messages(n int) []core.Message {
+	out := make([]core.Message, n)
+	for i := range out {
+		out[i] = core.Message{
+			Value:     []byte(`{"id":1}`),
+			Topic:     "events",
+			Partition: 0,
+			Offset:    int64(i),
+		}
+	}
+	return out
+}
+
+// Recorder is the shared event log. Every instrumented part appends to it, so
+// the order the pipeline did things is what the harness asserts on.
+type Recorder struct {
+	mu          sync.Mutex
+	events      []string
+	failOffsets bool
+
+	// onEvent lets a scenario react to what the pipeline did. The flush
+	// interval scenario uses it to close the source the moment the interval's
+	// flush lands, so the run ends without a sleep and without a second tick.
+	onEvent func(event string)
+}
+
+func (r *Recorder) record(event string) {
+	r.mu.Lock()
+	r.events = append(r.events, event)
+	notify := r.onEvent
+	r.mu.Unlock()
+
+	if notify != nil {
+		notify(event)
+	}
+}
+
+// Events returns what happened, in order.
+func (r *Recorder) Events() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
+}
+
+// Offsets returns the offset store to hand core.WithStateStore.
+func (r *Recorder) Offsets() *RecordingOffsets { return &RecordingOffsets{rec: r} }
+
+// Tx returns the state transaction to hand core.WithStateStore.
+func (r *Recorder) Tx() *RecordingTx { return &RecordingTx{rec: r} }
+
+// RecordingOffsets logs every offset save and can fail one.
+type RecordingOffsets struct{ rec *Recorder }
+
+func (o *RecordingOffsets) Save(ctx context.Context, marks *core.Marks) error {
+	if o.rec.failOffsets {
+		o.rec.record("save-offsets-failed")
+		return errors.New("conformance: offset store is down")
+	}
+	o.rec.record("save-offsets")
+	return nil
+}
+
+// RecordingTx logs the commit and the rollback.
+type RecordingTx struct{ rec *Recorder }
+
+func (x *RecordingTx) Commit(ctx context.Context) error {
+	x.rec.record("commit")
+	return nil
+}
+
+func (x *RecordingTx) Rollback(ctx context.Context) error {
+	x.rec.record("rollback")
+	return nil
+}
+
+// recordingSource yields one batch and counts what it was told to commit.
+type recordingSource struct {
+	rec   *Recorder
+	batch []core.Message
+	block bool
+
+	// wrote fires once every message has been handed to the pipeline, so the
+	// drain scenario cancels at a point where rows are buffered.
+	wrote sync.WaitGroup
+
+	mu      sync.Mutex
+	commits int
+	ch      chan []core.Message
+	once    sync.Once
+}
+
+func (s *recordingSource) Start() error {
+	s.ch = make(chan []core.Message, 1)
+	s.wrote.Add(1)
+
+	go func() {
+		s.ch <- s.batch
+		s.wrote.Done()
+		if !s.block {
+			close(s.ch)
+			return
+		}
+		// The drain scenario needs the loop still running when the cancel
+		// lands, so the stream stays open.
+	}()
+	return nil
+}
+
+func (s *recordingSource) Stream() <-chan []core.Message { return s.ch }
+
+func (s *recordingSource) Commit() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commits++
+	return nil
+}
+
+// CommitMarks is the path a Kafka-shaped source takes, and the one the
+// pipeline prefers.
+func (s *recordingSource) CommitMarks(marks *core.Marks) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commits++
+	return nil
+}
+
+func (s *recordingSource) Commits() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.commits
+}
+
+func (s *recordingSource) Close() error {
+	s.once.Do(func() {
+		if s.block && s.ch != nil {
+			close(s.ch)
+		}
+	})
+	return nil
+}
+
+// recordingSink logs its flushes and can fail them.
+type recordingSink struct {
+	rec  *Recorder
+	fail bool
+
+	mu      sync.Mutex
+	rows    int64
+	flushes int
+}
+
+func (s *recordingSink) WriteTable(_ context.Context, batch arrow.Table) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if batch != nil {
+		s.rows += batch.NumRows()
+	}
+	return nil
+}
+
+func (s *recordingSink) Flush(context.Context) error {
+	s.mu.Lock()
+	s.flushes++
+	s.mu.Unlock()
+
+	if s.fail {
+		s.rec.record("flush-failed")
+		return errors.New("conformance: sink is down")
+	}
+	s.rec.record("flush")
+	return nil
+}
+
+func (s *recordingSink) Batch() (arrow.Table, error) { return nil, nil }
+
+func (s *recordingSink) Rows() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rows
+}
+
+func (s *recordingSink) Flushes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.flushes
+}
+
+// passthroughHandler turns each message into a one-row table, which is the
+// smallest handler that produces something a sink can be given. What the
+// handler does is not what these invariants are about.
+type passthroughHandler struct {
+	mu   sync.Mutex
+	rows int
+}
+
+func (h *passthroughHandler) Init(context.Context) error { return nil }
+
+func (h *passthroughHandler) Write([]byte) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.rows++
+	return nil
+}
+
+func (h *passthroughHandler) Invoke(context.Context) (arrow.Table, error) {
+	h.mu.Lock()
+	n := h.rows
+	h.rows = 0
+	h.mu.Unlock()
+
+	if n == 0 {
+		return nil, nil
+	}
+	return idTable(int64(n)), nil
+}
+
+// idTable builds an n-row table with a single int64 column.
+func idTable(n int64) arrow.Table {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	b := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer b.Release()
+	for i := int64(0); i < n; i++ {
+		b.Field(0).(*array.Int64Builder).Append(i)
+	}
+
+	rec := b.NewRecord()
+	defer rec.Release()
+	return array.NewTableFromRecords(schema, []arrow.Record{rec})
+}

--- a/internal/core/conformance_test.go
+++ b/internal/core/conformance_test.go
@@ -1,0 +1,53 @@
+// Package core_test is external on purpose. internal/conformance imports
+// internal/core, so an in-package test importing the harness would be a cycle.
+package core_test
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/conformance"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// The consume loop under the conformance harness, once per configuration.
+//
+// These invariants were first proven by markers on hand-written tests, on the
+// grounds that the pipeline is one implementation. It is not. Durable state
+// changes what a commit means, and four paths reach a batch: the batch
+// filling, the flush interval elapsing, the source closing, and a cancel that
+// drains. Eight combinations, of which the hand-written tests covered two.
+
+func TestPipelineStateful_Conformance(t *testing.T) {
+	conformance.Pipelines(t, conformance.PipelineSubject{
+		Integration: "pipeline.stateful",
+		KeepsState:  true,
+		Options: func(r *conformance.Recorder) []core.TurbineOption {
+			return []core.TurbineOption{core.WithStateStore(r.Offsets(), r.Tx())}
+		},
+	})
+}
+
+func TestPipelineStateless_Conformance(t *testing.T) {
+	conformance.Pipelines(t, conformance.PipelineSubject{
+		Integration: "pipeline.stateless",
+		KeepsState:  false,
+		Options:     func(*conformance.Recorder) []core.TurbineOption { return nil },
+	})
+}
+
+// The premise behind the stateless configuration's exemption in
+// integrations.yml. It commits no durable state, so there is nothing to
+// commit alongside the offsets, and pipeline.state.with_offsets is vacuous
+// rather than unproven.
+func TestPipelineStateless_KeepsNoDurableState(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+
+	rec := &conformance.Recorder{}
+	tb := core.NewTurbine(nil, nil, nil, 1, 0, nil, core.PipelineErrorPolicies{})
+
+	assert.That(t, tb != nil)
+	// No state store was configured, so nothing the recorder watches can fire.
+	assert.Equal(t, 0, len(rec.Events()))
+}

--- a/internal/core/marks_test.go
+++ b/internal/core/marks_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -12,6 +13,7 @@ import (
 // committed. The rule used to live inline in Turbine.mark; it belongs with
 // the data it constrains.
 func TestStateOffsets_MarksAdvanceNeverGoesBackwards(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	m := NewMarks()
 	m.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 1})
 	m.Advance("events", 0, Mark{Offset: 4, LeaderEpoch: 1})
@@ -22,6 +24,7 @@ func TestStateOffsets_MarksAdvanceNeverGoesBackwards(t *testing.T) {
 }
 
 func TestStateOffsets_MarksAdvanceMovesForward(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	m := NewMarks()
 	m.Advance("events", 0, Mark{Offset: 4, LeaderEpoch: 1})
 	m.Advance("events", 0, Mark{Offset: 10, LeaderEpoch: 2})
@@ -32,6 +35,7 @@ func TestStateOffsets_MarksAdvanceMovesForward(t *testing.T) {
 }
 
 func TestStateOffsets_MarksTracksPartitionsIndependently(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	m := NewMarks()
 	m.Advance("events", 0, Mark{Offset: 5})
 	m.Advance("events", 1, Mark{Offset: 99})
@@ -48,6 +52,7 @@ func TestStateOffsets_MarksTracksPartitionsIndependently(t *testing.T) {
 }
 
 func TestStateOffsets_MarksEmptyAndMissing(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	m := NewMarks()
 	assert.That(t, m.Empty())
 	assert.Equal(t, 0, m.Len())
@@ -63,6 +68,7 @@ func TestStateOffsets_MarksEmptyAndMissing(t *testing.T) {
 // Offset 0 is a real position, not "unset": a mark at 0 means the first
 // message was processed, and Advance must not treat it as absent.
 func TestStateOffsets_MarksZeroOffsetIsAPosition(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	m := NewMarks()
 	m.Advance("events", 0, Mark{Offset: 0, LeaderEpoch: 3})
 
@@ -76,6 +82,7 @@ func TestStateOffsets_MarksZeroOffsetIsAPosition(t *testing.T) {
 // Sorted iteration keeps /stats output and CLI diffs stable between runs; map
 // order would shuffle them for no reason.
 func TestStateOffsets_MarksEachIteratesInSortedOrder(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	m := NewMarks()
 	m.Advance("zeta", 0, Mark{Offset: 1})
 	m.Advance("alpha", 2, Mark{Offset: 2})
@@ -91,6 +98,7 @@ func TestStateOffsets_MarksEachIteratesInSortedOrder(t *testing.T) {
 }
 
 func TestStateOffsets_MarksEachOverEmptyIsANoop(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	m := NewMarks()
 	called := 0
 	m.Each(func(string, int32, Mark) { called++ })

--- a/internal/core/offsets_test.go
+++ b/internal/core/offsets_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"github.com/zeebo/assert"
 )
@@ -27,6 +28,7 @@ func newStateConn(t *testing.T, path string) adbc.Connection {
 // Offsets round-trip through DuckDB, which is what lets a restart resume from
 // the position that produced the state currently in the database.
 func TestStateOffsets_RoundTrip(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	s := NewOffsetStore(conn)
 	assert.NoError(t, s.Init(context.Background()))
@@ -48,6 +50,7 @@ func TestStateOffsets_RoundTrip(t *testing.T) {
 
 // Saving the same partition again advances it rather than duplicating it.
 func TestStateOffsets_SaveIsAnUpsert(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	s := NewOffsetStore(conn)
 	assert.NoError(t, s.Init(context.Background()))
@@ -70,6 +73,7 @@ func TestStateOffsets_SaveIsAnUpsert(t *testing.T) {
 // A fresh state file has no offsets; the caller must treat that as "start
 // where auto_offset_reset says", not as offset zero.
 func TestStateOffsets_LoadEmptyIsEmptyNotZero(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	s := NewOffsetStore(conn)
 	assert.NoError(t, s.Init(context.Background()))
@@ -81,6 +85,7 @@ func TestStateOffsets_LoadEmptyIsEmptyNotZero(t *testing.T) {
 
 // Init runs on every start, including against an existing state file.
 func TestStateOffsets_InitIsIdempotent(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	path := filepath.Join(t.TempDir(), "state.db")
 	conn := newStateConn(t, path)
 	s := NewOffsetStore(conn)

--- a/internal/core/state_test.go
+++ b/internal/core/state_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/zeebo/assert"
 )
@@ -57,6 +58,7 @@ func columnsOf(t *testing.T, conn adbc.Connection) []string {
 // this build can read. Creating it fresh would restart from the beginning and
 // call that healthy.
 func TestStateOffsets_InitRejectsWrongColumns(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	exec(t, conn, `CREATE TABLE `+offsetsTable+` (topic VARCHAR, partition INTEGER)`)
 
@@ -69,6 +71,7 @@ func TestStateOffsets_InitRejectsWrongColumns(t *testing.T) {
 // Right names, wrong types. Load only notices this when the table happens to
 // hold rows, so the check has to happen at open.
 func TestStateOffsets_InitRejectsWrongTypes(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	exec(t, conn, `CREATE TABLE `+offsetsTable+` (
 		topic VARCHAR, partition VARCHAR, "offset" VARCHAR, leader_epoch VARCHAR)`)
@@ -82,6 +85,7 @@ func TestStateOffsets_InitRejectsWrongTypes(t *testing.T) {
 // The error has to name the table and say what was wrong, or an operator
 // cannot tell a damaged state file from any other startup failure.
 func TestStateOffsets_InitNamesWhatIsWrong(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	exec(t, conn, `CREATE TABLE `+offsetsTable+` (topic VARCHAR, partition INTEGER)`)
 
@@ -99,6 +103,7 @@ func TestStateOffsets_InitNamesWhatIsWrong(t *testing.T) {
 // Never truncate, recreate, or silently repair. A damaged table is evidence an
 // operator needs, and it is the only copy of the positions.
 func TestStateOffsets_InitLeavesADamagedTableUntouched(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	exec(t, conn, `CREATE TABLE `+offsetsTable+` (topic VARCHAR, partition INTEGER)`)
 	exec(t, conn, `INSERT INTO `+offsetsTable+` VALUES ('events', 3)`)
@@ -114,6 +119,7 @@ func TestStateOffsets_InitLeavesADamagedTableUntouched(t *testing.T) {
 
 // A fresh database is the normal first run and must still work.
 func TestStateOffsets_InitAcceptsAFreshDatabase(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	conn := newStateConn(t, filepath.Join(t.TempDir(), "state.db"))
 	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
 
@@ -124,6 +130,7 @@ func TestStateOffsets_InitAcceptsAFreshDatabase(t *testing.T) {
 
 // A healthy file from a previous run resumes, and Init does not disturb it.
 func TestStateOffsets_InitAcceptsAPriorRunAndKeepsItsRows(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	path := filepath.Join(t.TempDir(), "state.db")
 	conn := newStateConn(t, path)
 	s := NewOffsetStore(conn)
@@ -145,6 +152,7 @@ func TestStateOffsets_InitAcceptsAPriorRunAndKeepsItsRows(t *testing.T) {
 // A path that exists but is not a DuckDB database is a damaged state file, not
 // a fresh one. Exit terminal so a supervisor stops rather than crash-looping.
 func TestStateCorruption_RejectsAFileThatIsNotADatabase(t *testing.T) {
+	coverage.Covers(t, "state.corruption")
 	path := filepath.Join(t.TempDir(), "state.db")
 	assert.NoError(t, os.WriteFile(path, []byte("not a duckdb database"), 0o644))
 
@@ -157,6 +165,7 @@ func TestStateCorruption_RejectsAFileThatIsNotADatabase(t *testing.T) {
 
 // A zero-byte file is the shape a crash between create and first write leaves.
 func TestStateCorruption_RejectsAZeroByteFile(t *testing.T) {
+	coverage.Covers(t, "state.corruption")
 	path := filepath.Join(t.TempDir(), "state.db")
 	assert.NoError(t, os.WriteFile(path, nil, 0o644))
 
@@ -169,6 +178,7 @@ func TestStateCorruption_RejectsAZeroByteFile(t *testing.T) {
 // A directory at the state path is a config mistake, not a damaged file. The
 // operator fixes the config, so it must not read as state corruption.
 func TestStateCorruption_ReportsADirectoryAsAConfigError(t *testing.T) {
+	coverage.Covers(t, "state.corruption")
 	path := filepath.Join(t.TempDir(), "state.db")
 	assert.NoError(t, os.MkdirAll(path, 0o755))
 
@@ -180,6 +190,7 @@ func TestStateCorruption_ReportsADirectoryAsAConfigError(t *testing.T) {
 
 // A missing file is the first run. It must open and create.
 func TestStateCorruption_CreatesAMissingFile(t *testing.T) {
+	coverage.Covers(t, "state.corruption")
 	path := filepath.Join(t.TempDir(), "nested", "state.db")
 
 	db, err := OpenState(context.Background(), path)
@@ -195,6 +206,7 @@ func TestStateCorruption_CreatesAMissingFile(t *testing.T) {
 // A damaged file must survive the failed start. It is the only copy of the
 // positions, and an operator needs it to recover them.
 func TestStateCorruption_LeavesADamagedFileOnDisk(t *testing.T) {
+	coverage.Covers(t, "state.corruption")
 	path := filepath.Join(t.TempDir(), "state.db")
 	content := []byte("not a duckdb database")
 	assert.NoError(t, os.WriteFile(path, content, 0o644))

--- a/internal/core/stats_test.go
+++ b/internal/core/stats_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"github.com/zeebo/assert"
 )
@@ -32,6 +33,7 @@ func execSQL(tb testing.TB, conn adbc.Connection, sql string) {
 // stream. It reports the user's tables and the stored offsets, and must not
 // leak the engine's own bookkeeping tables into either.
 func TestStateDurability_Stats(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 	conn := newStateConn(t, path)
 
@@ -65,6 +67,7 @@ func TestStateDurability_Stats(t *testing.T) {
 // A fresh state file reports zero tables rather than failing, so the endpoint
 // is useful on a pipeline that has not processed anything yet.
 func TestStateDurability_Stats_EmptyState(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 	conn := newStateConn(t, path)
 	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
@@ -80,6 +83,7 @@ func TestStateDurability_Stats_EmptyState(t *testing.T) {
 // machinery too; reporting it as user state would be noise that changes on
 // every batch.
 func TestStateDurability_Stats_ExcludesTheBatchTable(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 	conn := newStateConn(t, path)
 	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))
@@ -96,6 +100,7 @@ func TestStateDurability_Stats_ExcludesTheBatchTable(t *testing.T) {
 // Tables and offsets are sorted so /stats output and CLI diffs stay stable
 // between runs; DuckDB's row order and map iteration are not guaranteed.
 func TestStateDurability_Stats_IsDeterministicallyOrdered(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 	conn := newStateConn(t, path)
 
@@ -129,6 +134,7 @@ func TestStateDurability_Stats_IsDeterministicallyOrdered(t *testing.T) {
 // rollback then erased -- a durability feature reporting numbers that never
 // survived anything.
 func TestStateDurability_Stats_DoesNotSeeUncommittedWrites(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 
 	db, err := duckdb.OpenPath(context.Background(), path)
@@ -170,6 +176,7 @@ func TestStateDurability_Stats_DoesNotSeeUncommittedWrites(t *testing.T) {
 // when the reader is released. Returning a string that aliases it would hand
 // callers memory that can be reused underneath them.
 func TestStateDurability_Stats_TableNamesSurviveReaderRelease(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 	conn := newStateConn(t, path)
 	assert.NoError(t, NewOffsetStore(conn).Init(context.Background()))

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
-	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -453,7 +452,6 @@ func TestLifecycleDrain_CancelDrainsTheBufferedBatch(t *testing.T) {
 	assert.Equal(t, int64(10), rows)
 	assert.Equal(t, 1, flushes)
 	assert.Equal(t, int64(10), stats.MessagesConsumed())
-	coverage.PipelineInvariant(t, "lifecycle.drain.on_cancel")
 }
 
 func TestCoreConsumeLoop_WritesEveryMessageAcrossManyBatches(t *testing.T) {
@@ -617,7 +615,6 @@ func TestCoreConsumeLoop_ProcessBatchFlushesSinkBeforeCommittingState(t *testing
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"flush", "save-offsets", "commit"}, events)
-	coverage.PipelineInvariant(t, "pipeline.commit.after_flush")
 }
 
 // A sink failure must roll the transaction back, so the offsets on disk stay
@@ -637,7 +634,6 @@ func TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails(t *testing.T) {
 	_, err := tb.ConsumeLoop(context.Background(), 0)
 	assert.Error(t, err)
 	assert.Equal(t, []string{"flush-failed", "rollback"}, events)
-	coverage.PipelineInvariant(t, "pipeline.commit.nothing_on_failure")
 }
 
 // A failure saving offsets must roll back too: state written by the handler
@@ -657,9 +653,6 @@ func TestCoreConsumeLoop_ProcessBatchRollsBackWhenOffsetSaveFails(t *testing.T) 
 	_, err := tb.ConsumeLoop(context.Background(), 0)
 	assert.Error(t, err)
 	assert.Equal(t, []string{"flush", "save-offsets-failed", "rollback"}, events)
-	// State the handler wrote and the offsets that describe it roll back
-	// together, which is what makes them one commit.
-	coverage.PipelineInvariant(t, "pipeline.state.with_offsets")
 }
 
 // A commit failure is fatal to the batch and must not be followed by a Kafka
@@ -681,7 +674,6 @@ func TestCoreConsumeLoop_ProcessBatchCommitFailureDoesNotCommitSource(t *testing
 	assert.Equal(t, []string{"flush", "save-offsets", "commit-failed", "rollback"}, events)
 	// Kafka must not have been told anything.
 	assert.Equal(t, 0, len(src.marks))
-	coverage.PipelineInvariant(t, "pipeline.commit.nothing_on_failure")
 }
 
 // The offsets handed to the store are the ones the pipeline processed, not

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -136,6 +137,7 @@ func messages(n int) []Message {
 // Reaching --max-msgs must not cost the batch in flight: every message the
 // pipeline reports as consumed has to reach the sink.
 func TestCoreConsumeLoop_FlushesFinalBatchWhenMaxMsgsReached(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	src := &fakeSource{batches: [][]Message{messages(1000)}}
 	sink := &fakeSink{}
 
@@ -151,6 +153,7 @@ func TestCoreConsumeLoop_FlushesFinalBatchWhenMaxMsgsReached(t *testing.T) {
 // A batch that is still partial when the source ends must also be written,
 // otherwise the tail of a finite stream is silently dropped.
 func TestCoreConsumeLoop_FlushesPartialBatchWhenStreamEnds(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	src := &fakeSource{batches: [][]Message{messages(250)}}
 	sink := &fakeSink{}
 
@@ -227,6 +230,7 @@ func mixedMessages(bad string, good int) []Message {
 }
 
 func TestErrorRaise_ConsumeLoopStopsOnWriteError(t *testing.T) {
+	coverage.Covers(t, "error.raise")
 	src := &fakeSource{batches: [][]Message{mixedMessages("bad", 4)}}
 	h := &failingHandler{failWriteOn: "bad"}
 
@@ -236,6 +240,7 @@ func TestErrorRaise_ConsumeLoopStopsOnWriteError(t *testing.T) {
 }
 
 func TestErrorIgnore_ConsumeLoopSkipsBadMessage(t *testing.T) {
+	coverage.Covers(t, "error.ignore")
 	src := &fakeSource{batches: [][]Message{mixedMessages("bad", 4)}}
 	h := &failingHandler{failWriteOn: "bad"}
 	sink := &fakeSink{}
@@ -256,6 +261,7 @@ func TestErrorIgnore_ConsumeLoopSkipsBadMessage(t *testing.T) {
 // Python engine counts it, and --max-msgs has to account for it too or a
 // stream of bad messages never terminates.
 func TestErrorIgnore_CountsRejectedMessagesAsConsumed(t *testing.T) {
+	coverage.Covers(t, "error.ignore")
 	src := &fakeSource{batches: [][]Message{mixedMessages("bad", 4)}}
 	h := &failingHandler{failWriteOn: "bad"}
 
@@ -270,6 +276,7 @@ func TestErrorIgnore_CountsRejectedMessagesAsConsumed(t *testing.T) {
 }
 
 func TestErrorDlq_ConsumeLoopRoutesWriteError(t *testing.T) {
+	coverage.Covers(t, "error.dlq")
 	src := &fakeSource{batches: [][]Message{mixedMessages("bad", 4)}}
 	h := &failingHandler{failWriteOn: "bad"}
 	sink := &fakeSink{}
@@ -291,6 +298,7 @@ func TestErrorDlq_ConsumeLoopRoutesWriteError(t *testing.T) {
 }
 
 func TestErrorDlq_ConsumeLoopRoutesInvokeError(t *testing.T) {
+	coverage.Covers(t, "error.dlq")
 	src := &fakeSource{batches: [][]Message{messages(4)}}
 	h := &failingHandler{failInvokeOn: true}
 	sink := &fakeSink{}
@@ -311,6 +319,7 @@ func TestErrorDlq_ConsumeLoopRoutesInvokeError(t *testing.T) {
 }
 
 func TestErrorIgnore_ConsumeLoopContinuesAfterInvokeError(t *testing.T) {
+	coverage.Covers(t, "error.ignore")
 	src := &fakeSource{batches: [][]Message{messages(4)}}
 	h := &failingHandler{failInvokeOn: true}
 	sink := &fakeSink{}
@@ -358,6 +367,7 @@ func (s *blockingSource) Close() error  { return nil }
 // A batch that never reaches batch_size must still be flushed once the flush
 // interval elapses, otherwise a low-traffic topic stalls forever.
 func TestCoreConsumeLoop_FlushesPartialBatchOnFlushInterval(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	src := newBlockingSource(messages(10))
 	sink := &fakeSink{}
 
@@ -411,6 +421,7 @@ func (h *drainHandler) Write(msg []byte) error {
 // has written it. Returning without it drops the tail of every graceful
 // shutdown.
 func TestLifecycleDrain_CancelDrainsTheBufferedBatch(t *testing.T) {
+	coverage.Covers(t, "lifecycle.drain")
 	src := newBlockingSource(messages(10))
 	sink := &fakeSink{}
 	h := &drainHandler{wrote: make(chan struct{})}
@@ -455,6 +466,7 @@ func TestLifecycleDrain_CancelDrainsTheBufferedBatch(t *testing.T) {
 }
 
 func TestCoreConsumeLoop_WritesEveryMessageAcrossManyBatches(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	src := &fakeSource{batches: [][]Message{messages(500), messages(500), messages(250)}}
 	sink := &fakeSink{}
 
@@ -471,6 +483,7 @@ func TestCoreConsumeLoop_WritesEveryMessageAcrossManyBatches(t *testing.T) {
 // buffered, which is a batch with no rows -- not a second error on top of the
 // per-message ones the policy already handled.
 func TestErrorIgnore_BatchOfOnlyBadMessagesIsNotAHandlerError(t *testing.T) {
+	coverage.Covers(t, "error.ignore")
 	src := &fakeSource{batches: [][]Message{{{Value: []byte("bad")}, {Value: []byte("bad")}}}}
 	h := &failingHandler{failWriteOn: "bad"}
 	sink := &fakeSink{}
@@ -492,6 +505,7 @@ func TestErrorIgnore_BatchOfOnlyBadMessagesIsNotAHandlerError(t *testing.T) {
 // the difference with the consumer group showing no lag. The pipeline must
 // instead hand the source the exact position it has finished with.
 func TestCoreConsumeLoop_CommitsOnlyProcessedMarks(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	src := &markingSource{fakeSource: fakeSource{
 		// One fetch delivers 30 messages; batch_size is 20, so the first
 		// commit must name offset 19 and the final one 29 -- never 29 twice.
@@ -514,6 +528,7 @@ func TestCoreConsumeLoop_CommitsOnlyProcessedMarks(t *testing.T) {
 }
 
 func TestCoreConsumeLoop_MarksTrackEachPartition(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	p0 := kafkaMessages("events", 0, 100, 3)
 	p1 := kafkaMessages("events", 1, 500, 2)
 	src := &markingSource{fakeSource: fakeSource{
@@ -600,6 +615,7 @@ func (c *txConn) Rollback(ctx context.Context) error {
 // than committing offsets for rows the sink never received, which loses them
 // with the consumer group reporting no lag.
 func TestCoreConsumeLoop_ProcessBatchFlushesSinkBeforeCommittingState(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	var events []string
 	src := &markingSource{fakeSource: fakeSource{
 		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
@@ -620,6 +636,7 @@ func TestCoreConsumeLoop_ProcessBatchFlushesSinkBeforeCommittingState(t *testing
 // A sink failure must roll the transaction back, so the offsets on disk stay
 // where they were and the batch is replayed on restart.
 func TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	var events []string
 	src := &markingSource{fakeSource: fakeSource{
 		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
@@ -639,6 +656,7 @@ func TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails(t *testing.T) {
 // A failure saving offsets must roll back too: state written by the handler
 // in this transaction has to go with the offsets that describe it.
 func TestCoreConsumeLoop_ProcessBatchRollsBackWhenOffsetSaveFails(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	var events []string
 	src := &markingSource{fakeSource: fakeSource{
 		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
@@ -658,6 +676,7 @@ func TestCoreConsumeLoop_ProcessBatchRollsBackWhenOffsetSaveFails(t *testing.T) 
 // A commit failure is fatal to the batch and must not be followed by a Kafka
 // commit: the durable offsets did not move, so Kafka's must not either.
 func TestCoreConsumeLoop_ProcessBatchCommitFailureDoesNotCommitSource(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	var events []string
 	src := &markingSource{fakeSource: fakeSource{
 		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
@@ -679,6 +698,7 @@ func TestCoreConsumeLoop_ProcessBatchCommitFailureDoesNotCommitSource(t *testing
 // The offsets handed to the store are the ones the pipeline processed, not
 // whatever the source has fetched ahead to.
 func TestCoreConsumeLoop_ProcessBatchSavesTheProcessedOffsets(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	var events []string
 	src := &markingSource{fakeSource: fakeSource{
 		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
@@ -701,6 +721,7 @@ func TestCoreConsumeLoop_ProcessBatchSavesTheProcessedOffsets(t *testing.T) {
 // Without a state store the pipeline behaves exactly as before: no
 // transaction calls at all, and the source is still committed.
 func TestCoreConsumeLoop_ProcessBatchNoStateStoreIsUnchanged(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	var events []string
 	src := &markingSource{fakeSource: fakeSource{
 		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
@@ -719,6 +740,7 @@ func TestCoreConsumeLoop_ProcessBatchNoStateStoreIsUnchanged(t *testing.T) {
 // dedicated reader connection -- not the pipeline's writer -- so a scrape can
 // never stall batch processing.
 func TestObservabilityMetrics_StateGaugesReportsSizeAndRows(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
 	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 4)
 
 	calls := 0
@@ -739,6 +761,7 @@ func TestObservabilityMetrics_StateGaugesReportsSizeAndRows(t *testing.T) {
 // zero: an absent series and a genuinely empty state are different facts, and
 // a dashboard should be able to tell them apart.
 func TestObservabilityMetrics_StateGaugesNoProviderRecordsNothing(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
 	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 4)
 	// stateStats is nil; this must not panic.
 	tb.recordStateGauges(context.Background())
@@ -747,6 +770,7 @@ func TestObservabilityMetrics_StateGaugesNoProviderRecordsNothing(t *testing.T) 
 // A failure collecting stats must not take the status loop down with it --
 // the pipeline keeps running and keeps serving its other metrics.
 func TestObservabilityMetrics_StateGaugesSurvivesCollectionFailure(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
 	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 4)
 	tb.stateStats = func() (*StateStats, error) {
 		return nil, errors.New("state database unreadable")
@@ -790,6 +814,7 @@ func (s *idleSource) Close() error  { return nil }
 // against, and a pipeline that stops receiving messages silently stops
 // closing windows.
 func TestCoreConsumeLoop_IdleTickCommitsTheStateTransaction(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	var events []string
 	src := newIdleSource()
 	store := &fakeOffsetStore{events: &events}
@@ -833,6 +858,7 @@ func TestCoreConsumeLoop_IdleTickCommitsTheStateTransaction(t *testing.T) {
 // The same tick on a pipeline with no state database must stay the no-op it
 // always was: no commit, no offset save, nothing.
 func TestCoreConsumeLoop_IdleTickIsANoopWithoutState(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
 	src := newIdleSource()
 	sink := &fakeSink{}
 

--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -38,14 +38,3 @@ func Invariant(t testing.TB, invariant, integration string) {
 	t.Helper()
 	t.Logf("COVERS invariant=%s integration=%s", invariant, integration)
 }
-
-// PipelineInvariant records that this test proved one invariant of the engine
-// itself.
-//
-// A pipeline invariant is a property of the consume loop rather than of
-// anything a config names, so there is no integration to credit. It carries
-// "pipeline" in that slot, and the generator gives it a single cell.
-func PipelineInvariant(t testing.TB, invariant string) {
-	t.Helper()
-	Invariant(t, invariant, "pipeline")
-}

--- a/internal/coverage/coverage_test.go
+++ b/internal/coverage/coverage_test.go
@@ -12,6 +12,7 @@ import (
 // silent loss of every cell the marker feeds, so the exact bytes are pinned
 // on this side too.
 func TestToolingCoverageInvariant_EmitsTheStructuredMarker(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	rec := &recorder{}
 	Invariant(rec, "sink.flush.keeps_batch", "sink.clickhouse")
 
@@ -21,6 +22,7 @@ func TestToolingCoverageInvariant_EmitsTheStructuredMarker(t *testing.T) {
 }
 
 func TestToolingCoverageCovers_EmitsOneLinePerFeature(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	rec := &recorder{}
 	Covers(rec, "sink.clickhouse", "source.kafka")
 
@@ -34,6 +36,7 @@ func TestToolingCoverageCovers_EmitsOneLinePerFeature(t *testing.T) {
 // the plain match when a structured one is present, and this is the other
 // half of that contract: the two lines cannot be confused for each other.
 func TestToolingCoverageInvariant_DoesNotLookLikeAFeatureMarker(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	rec := &recorder{}
 	Invariant(rec, "sink.flush.keeps_batch", "sink.clickhouse")
 

--- a/internal/coverage/registry.go
+++ b/internal/coverage/registry.go
@@ -177,9 +177,10 @@ func Integrations(kind string) ([]string, error) {
 
 	var doc struct {
 		Integrations []struct {
-			ID       string `yaml:"id"`
-			Kind     string `yaml:"kind"`
-			TestOnly bool   `yaml:"test_only"`
+			ID          string `yaml:"id"`
+			Kind        string `yaml:"kind"`
+			TestOnly    bool   `yaml:"test_only"`
+			Constructed *bool  `yaml:"constructed"`
 		} `yaml:"integrations"`
 	}
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
@@ -188,9 +189,13 @@ func Integrations(kind string) ([]string, error) {
 
 	out := []string{}
 	for _, integration := range doc.Integrations {
-		// A test-only integration has no constructor case, so it must not
-		// appear in the list Kinds() is held equal to.
+		// Neither a test-only integration nor an unconstructed one has a case
+		// in a constructor switch, so neither may appear in the list Kinds()
+		// is held equal to.
 		if integration.TestOnly {
+			continue
+		}
+		if integration.Constructed != nil && !*integration.Constructed {
 			continue
 		}
 		if integration.Kind == kind {

--- a/internal/coverage/registry_test.go
+++ b/internal/coverage/registry_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestToolingCoverageRegistry_ListsSinksByBareName(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	got, err := Integrations("sink")
 	assert.NoError(t, err)
 
@@ -18,12 +19,14 @@ func TestToolingCoverageRegistry_ListsSinksByBareName(t *testing.T) {
 }
 
 func TestToolingCoverageRegistry_ListsSources(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	got, err := Integrations("source")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, []string{"kafka", "webhook", "websocket"}, got)
 }
 
 func TestToolingCoverageRegistry_ListsHandlers(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	got, err := Integrations("handler")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, []string{"inferred_disk", "inferred_mem", "structured"}, got)
@@ -32,11 +35,13 @@ func TestToolingCoverageRegistry_ListsHandlers(t *testing.T) {
 // pipeline is a kind an invariant can apply to, but no constructor builds
 // one. Asking for its integrations is a mistake worth naming.
 func TestToolingCoverageRegistry_RejectsAKindNothingConstructs(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	_, err := Integrations("pipeline")
 	assert.Error(t, err)
 }
 
 func TestToolingCoverageRegistry_RejectsAnUnknownKind(t *testing.T) {
+	Covers(t, "tooling.coverage")
 	_, err := Integrations("router")
 	assert.Error(t, err)
 }

--- a/internal/duckdb/open_test.go
+++ b/internal/duckdb/open_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -65,6 +66,7 @@ func queryInt64(tb testing.TB, conn adbc.Connection, sql string) int64 {
 // while its offsets are already committed -- silently, with the consumer group
 // reporting no lag.
 func TestStateDurability_OpenPathPersistsAcrossProcesses(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 
 	db, err := OpenPath(context.Background(), path)
@@ -94,6 +96,7 @@ func TestStateDurability_OpenPathPersistsAcrossProcesses(t *testing.T) {
 // An empty path keeps today's in-memory behaviour, so a config without a state
 // path is unaffected.
 func TestStateDurability_OpenPathEmptyPathIsInMemory(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	db, err := OpenPath(context.Background(), "")
 	assert.NoError(t, err)
 	defer db.Close()
@@ -110,6 +113,7 @@ func TestStateDurability_OpenPathEmptyPathIsInMemory(t *testing.T) {
 // is what lets stats be read without disturbing the writer. Each connection
 // has its own transaction state, so an uncommitted batch stays invisible.
 func TestStateDurability_DBSecondConnectionSeesOnlyCommittedState(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	path := filepath.Join(t.TempDir(), "state.db")
 
 	db, err := OpenPath(context.Background(), path)
@@ -146,6 +150,7 @@ func TestStateDurability_DBSecondConnectionSeesOnlyCommittedState(t *testing.T) 
 
 // Open keeps working for callers that want one connection and no handle.
 func TestStateDurability_OpenReturnsAConnection(t *testing.T) {
+	coverage.Covers(t, "state.durability")
 	conn, err := Open(context.Background())
 	assert.NoError(t, err)
 	defer conn.Close()

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
 const goldenPath = "testdata/codes.golden"
 
 func TestErrorTaxonomy_CodeSplitsIntoThreeParts(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	c := Code("user.sql.bind_failed")
 	assert.Equal(t, ClassUser, c.Class())
 	assert.Equal(t, "sql", c.Domain())
@@ -25,6 +27,7 @@ func TestErrorTaxonomy_CodeSplitsIntoThreeParts(t *testing.T) {
 // A malformed code must not report a class. Guessing one would route a
 // failure to the wrong audience.
 func TestErrorTaxonomy_MalformedCodeHasNoClass(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	for _, bad := range []Code{"", "nonsense", "user", "user.sql", "other.sql.x", "USER.sql.x"} {
 		assert.Equal(t, Class(""), bad.Class())
 		assert.False(t, bad.IsUser())
@@ -33,6 +36,7 @@ func TestErrorTaxonomy_MalformedCodeHasNoClass(t *testing.T) {
 }
 
 func TestErrorTaxonomy_EveryCodeIsWellFormed(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	for _, d := range All() {
 		if d.Code.Class() == "" {
 			t.Errorf("%q has no valid class", d.Code)
@@ -55,6 +59,7 @@ func TestErrorTaxonomy_EveryCodeIsWellFormed(t *testing.T) {
 // gives it a specific code. Without this, the next issue that adds an error
 // invents a code in a hurry and the space fragments.
 func TestErrorTaxonomy_EveryDomainHasACatchAll(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	catchAllReason := map[Class]string{ClassUser: "invalid", ClassSystem: "internal"}
 
 	seen := map[string]bool{}
@@ -79,6 +84,7 @@ func TestErrorTaxonomy_EveryDomainHasACatchAll(t *testing.T) {
 // class prefix. Removing one, or changing what it means, breaks a provider's
 // automation and the runbook their support team reads.
 func TestErrorTaxonomy_RegistryIsAppendOnly(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	current := map[Code]bool{}
 	lines := make([]string, 0, len(registry))
 	for _, d := range All() {
@@ -111,6 +117,7 @@ func TestErrorTaxonomy_RegistryIsAppendOnly(t *testing.T) {
 }
 
 func TestErrorTaxonomy_ErrorPrefixesTheCode(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	e := New(CodeConfigNotFound, "config file not found: %s", "/nope.yml")
 	assert.Equal(t, "[user.config.not_found] config file not found: /nope.yml", e.Error())
 
@@ -124,6 +131,7 @@ func TestErrorTaxonomy_ErrorPrefixesTheCode(t *testing.T) {
 // A multi-line cause is the normal case for YAML and SQL. The code has to
 // survive on the first line, where an operator actually sees it.
 func TestErrorTaxonomy_CodeStaysOnTheFirstLineOfAMultiLineCause(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	cause := errors.New("yaml: unmarshal errors:\n  line 3: field bad_key not found")
 	got := Wrap(CodeConfigParseFailed, cause, "parsing YAML failed").Error()
 
@@ -135,6 +143,7 @@ func TestErrorTaxonomy_CodeStaysOnTheFirstLineOfAMultiLineCause(t *testing.T) {
 // already does, or converting the codebase would mean touching all 220 raise
 // sites instead of the ~30 boundaries.
 func TestErrorTaxonomy_CodeSurvivesWrapping(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	base := New(CodeStateCorrupt, "state file has no offsets table")
 	wrapped := fmt.Errorf("opening state: %w", fmt.Errorf("loading offsets: %w", base))
 
@@ -147,6 +156,7 @@ func TestErrorTaxonomy_CodeSurvivesWrapping(t *testing.T) {
 // An uncoded error is ours until proven otherwise. Defaulting to a user error
 // would blame a customer for our bug.
 func TestErrorTaxonomy_UncodedIsInternal(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	assert.Equal(t, CodeInternalUnexpected, CodeOf(errors.New("bare")))
 	assert.Equal(t, ClassSystem, ClassOf(errors.New("bare")))
 	assert.Equal(t, Code(""), CodeOf(nil))
@@ -155,12 +165,14 @@ func TestErrorTaxonomy_UncodedIsInternal(t *testing.T) {
 // The boundary nearest the user decides how to describe the failure, so the
 // outermost code wins.
 func TestErrorTaxonomy_OutermostCodeWins(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	inner := New(CodeSinkWriteFailed, "rejected")
 	outer := Wrap(CodeSinkUnreachable, inner, "after retries")
 	assert.Equal(t, CodeSinkUnreachable, CodeOf(outer))
 }
 
 func TestErrorTaxonomy_PositionSurvivesWrapping(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	base := New(CodeSQLBindFailed, "unknown column").At("sql", 3, 9)
 	wrapped := fmt.Errorf("invoking handler: %w", base)
 
@@ -175,6 +187,7 @@ func TestErrorTaxonomy_PositionSurvivesWrapping(t *testing.T) {
 }
 
 func TestErrorTaxonomy_LookupReportsUnknown(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	d, ok := Lookup(CodeConfigNotFound)
 	assert.True(t, ok)
 	assert.Equal(t, CodeConfigNotFound, d.Code)
@@ -187,6 +200,7 @@ func TestErrorTaxonomy_LookupReportsUnknown(t *testing.T) {
 }
 
 func TestErrorTaxonomy_ExitCodeMapsEveryCode(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	for _, d := range All() {
 		exit := ExitCode(New(d.Code, "x"))
 		if exit == 0 {
@@ -201,6 +215,7 @@ func TestErrorTaxonomy_ExitCodeMapsEveryCode(t *testing.T) {
 }
 
 func TestErrorTaxonomy_ExitCodeUsesTheSpecificRemedy(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	assert.Equal(t, ExitOK, ExitCode(nil))
 	assert.Equal(t, ExitStateCorrupt, ExitCode(New(CodeStateCorrupt, "x")))
 	assert.Equal(t, ExitSinkUnreachable, ExitCode(New(CodeSinkUnreachable, "x")))
@@ -216,6 +231,7 @@ func TestErrorTaxonomy_ExitCodeUsesTheSpecificRemedy(t *testing.T) {
 // A code this build has never seen still has to resolve, or a newer component
 // crashes the mapping instead of exiting usefully.
 func TestErrorTaxonomy_ExitCodeResolvesUnknown(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	assert.Equal(t, ExitUserError, ExitCode(New(Code("user.sql.from_the_future"), "x")))
 	assert.Equal(t, ExitResourceLimit, ExitCode(New(Code("system.limit.disk_exhausted"), "x")))
 	assert.Equal(t, ExitInternal, ExitCode(New(Code("system.mystery.thing"), "x")))
@@ -224,6 +240,7 @@ func TestErrorTaxonomy_ExitCodeResolvesUnknown(t *testing.T) {
 // 2 collides with cobra's usage error and with the Go runtime's exit when a
 // signal cannot kill PID 1, which #159 measured.
 func TestErrorTaxonomy_NoExitCodeUsesTwo(t *testing.T) {
+	coverage.Covers(t, "error.taxonomy")
 	for _, d := range All() {
 		assert.False(t, ExitCode(New(d.Code, "x")) == 2)
 	}

--- a/internal/handlers/inferred_disk_test.go
+++ b/internal/handlers/inferred_disk_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -66,6 +67,7 @@ func newTestDiskHandler(t *testing.T, sql string) (*InferredDiskBatchHandler, st
 }
 
 func TestHandlerInferredDisk_SingleRowReturn(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, _ := newTestDiskHandler(t, "SELECT COUNT(*) as num_rows FROM batch")
 
 	ctx := context.Background()
@@ -82,6 +84,7 @@ func TestHandlerInferredDisk_SingleRowReturn(t *testing.T) {
 }
 
 func TestHandlerInferredDisk_NestedReturn(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, _ := newTestDiskHandler(t, `
 SELECT
     {'city': city} as s1,
@@ -108,6 +111,7 @@ FROM batch`)
 // The cache dir is the handler's to manage: a fresh checkout has no
 // /tmp/sqlflow/resultscache, and the Python engine's open() would fail there.
 func TestHandlerInferredDisk_CreatesCacheDir(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, dir := newTestDiskHandler(t, "SELECT COUNT(*) as num_rows FROM batch")
 
 	info, err := os.Stat(dir)
@@ -127,6 +131,7 @@ func TestHandlerInferredDisk_CreatesCacheDir(t *testing.T) {
 // the second invoke sees only its own messages, and CREATE TABLE batch
 // would fail outright if the previous invoke had not dropped it.
 func TestHandlerInferredDisk_ResetsBetweenBatches(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, _ := newTestDiskHandler(t, "SELECT COUNT(*) as num_rows FROM batch")
 
 	ctx := context.Background()
@@ -149,6 +154,7 @@ func TestHandlerInferredDisk_ResetsBetweenBatches(t *testing.T) {
 }
 
 func TestHandlerInferredDisk_BatchTableDroppedAfterInvoke(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, _ := newTestDiskHandler(t, "SELECT COUNT(*) as num_rows FROM batch")
 
 	ctx := context.Background()
@@ -174,6 +180,7 @@ func TestHandlerInferredDisk_BatchTableDroppedAfterInvoke(t *testing.T) {
 // Malformed JSON is rejected per message, matching InferredMemBatch: a bad
 // line buffered to disk would otherwise fail the whole batch at read_json.
 func TestHandlerInferredDisk_RejectsInvalidJSON(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, _ := newTestDiskHandler(t, "SELECT COUNT(*) as num_rows FROM batch")
 
 	assert.NoError(t, h.Init(context.Background()))
@@ -184,6 +191,7 @@ func TestHandlerInferredDisk_RejectsInvalidJSON(t *testing.T) {
 // message it consumed even when the handler rejected it, so a batch of
 // entirely malformed messages reaches Invoke with nothing buffered.
 func TestHandlerInferredDisk_EmptyBatchIsNoOp(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, _ := newTestDiskHandler(t, "SELECT COUNT(*) as num_rows FROM batch")
 
 	ctx := context.Background()
@@ -198,6 +206,7 @@ func TestHandlerInferredDisk_EmptyBatchIsNoOp(t *testing.T) {
 // empty file, which must come back as an empty table rather than a read
 // failure that would fail the batch and stall the source offset.
 func TestHandlerInferredDisk_EmptyResult(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, _ := newTestDiskHandler(t, "SELECT city FROM batch WHERE city = 'Nowhere'")
 
 	ctx := context.Background()
@@ -215,6 +224,7 @@ func TestHandlerInferredDisk_EmptyResult(t *testing.T) {
 // Close removes the staged files; leaving a many-MB consumer_batch.json in
 // the cache dir after shutdown is a leak.
 func TestHandlerInferredDisk_CloseRemovesFiles(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_disk")
 	h, dir := newTestDiskHandler(t, "SELECT COUNT(*) as num_rows FROM batch")
 
 	ctx := context.Background()

--- a/internal/handlers/inferred_test.go
+++ b/internal/handlers/inferred_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -24,6 +25,7 @@ func invokeRows(t *testing.T, h *InferredMemBatchHandler, messages []string) arr
 }
 
 func TestHandlerInferredMem_NestedStructAggregation(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -43,6 +45,7 @@ func TestHandlerInferredMem_NestedStructAggregation(t *testing.T) {
 }
 
 func TestHandlerInferredMem_InfersNumericAndBoolTypes(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -70,6 +73,7 @@ func TestHandlerInferredMem_InfersNumericAndBoolTypes(t *testing.T) {
 // the same contract.
 
 func TestHandlerInferredMem_ColumnsComeFromFirstRow(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -89,6 +93,7 @@ func TestHandlerInferredMem_ColumnsComeFromFirstRow(t *testing.T) {
 }
 
 func TestHandlerInferredMem_FieldMissingFromLaterRowIsNull(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -109,6 +114,7 @@ func TestHandlerInferredMem_FieldMissingFromLaterRowIsNull(t *testing.T) {
 }
 
 func TestHandlerInferredMem_PromotesIntToFloat(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -123,6 +129,7 @@ func TestHandlerInferredMem_PromotesIntToFloat(t *testing.T) {
 }
 
 func TestHandlerInferredMem_ConflictingTypesError(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -140,6 +147,7 @@ func TestHandlerInferredMem_ConflictingTypesError(t *testing.T) {
 }
 
 func TestHandlerInferredMem_InvalidJSONIsWriteError(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -152,6 +160,7 @@ func TestHandlerInferredMem_InvalidJSONIsWriteError(t *testing.T) {
 }
 
 func TestHandlerInferredMem_SuccessiveBatches(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -170,6 +179,7 @@ func TestHandlerInferredMem_SuccessiveBatches(t *testing.T) {
 }
 
 func TestHandlerInferredMem_SingleRecord(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -189,6 +199,7 @@ func TestHandlerInferredMem_SingleRecord(t *testing.T) {
 // A handler SQL statement may be an INSERT that populates a managed table
 // rather than a SELECT that returns rows, as the tumbling window config does.
 func TestHandlerInferredMem_InsertIntoManagedTable(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -230,6 +241,7 @@ func TestHandlerInferredMem_InsertIntoManagedTable(t *testing.T) {
 // injects as kafka_topic / kafka_partition / kafka_offset columns. The
 // idempotent MotherDuck pattern reads them to skip already-ingested offsets.
 func TestHandlerInferredMem_InjectsKafkaMetadata(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -258,6 +270,7 @@ func TestHandlerInferredMem_InjectsKafkaMetadata(t *testing.T) {
 
 // Without metadata the columns must not appear, so a plain config is unchanged.
 func TestHandlerInferredMem_NoMetadataColumnsWithoutSource(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -276,6 +289,7 @@ func TestHandlerInferredMem_NoMetadataColumnsWithoutSource(t *testing.T) {
 // it is a batch with no rows -- and erroring turns an IGNORE policy into a
 // stream of spurious handler failures.
 func TestHandlerInferredMem_EmptyBatchIsNoOp(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -293,6 +307,7 @@ func TestHandlerInferredMem_EmptyBatchIsNoOp(t *testing.T) {
 // embed.images -- so a firehose config cannot run without these.
 
 func TestHandlerInferredMem_InfersListOfStrings(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -311,6 +326,7 @@ func TestHandlerInferredMem_InfersListOfStrings(t *testing.T) {
 }
 
 func TestHandlerInferredMem_InfersListOfStructs(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -330,6 +346,7 @@ func TestHandlerInferredMem_InfersListOfStructs(t *testing.T) {
 }
 
 func TestHandlerInferredMem_InfersListInsideStruct(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -347,6 +364,7 @@ func TestHandlerInferredMem_InfersListInsideStruct(t *testing.T) {
 }
 
 func TestHandlerInferredMem_PromotesListElementTypeAcrossBatch(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -363,6 +381,7 @@ func TestHandlerInferredMem_PromotesListElementTypeAcrossBatch(t *testing.T) {
 // list<item: null>; a later message that has elements must widen it rather
 // than fail the batch.
 func TestHandlerInferredMem_EmptyListTakesTypeFromLaterMessage(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -377,6 +396,7 @@ func TestHandlerInferredMem_EmptyListTakesTypeFromLaterMessage(t *testing.T) {
 }
 
 func TestHandlerInferredMem_EmptyListInEveryMessage(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -393,6 +413,7 @@ func TestHandlerInferredMem_EmptyListInEveryMessage(t *testing.T) {
 // A message missing the array leaves a null list, not an empty one, matching
 // the null a missing scalar produces.
 func TestHandlerInferredMem_MissingListIsNull(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -408,6 +429,7 @@ func TestHandlerInferredMem_MissingListIsNull(t *testing.T) {
 }
 
 func TestHandlerInferredMem_InfersNestedLists(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -423,6 +445,7 @@ func TestHandlerInferredMem_InfersNestedLists(t *testing.T) {
 // A list whose elements cannot be reconciled must fail the batch, the same way
 // a conflicting scalar column does, rather than silently nulling the value.
 func TestHandlerInferredMem_ConflictingListElementTypesError(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -444,6 +467,7 @@ func TestHandlerInferredMem_ConflictingListElementTypesError(t *testing.T) {
 // The Python engine decodes with json.loads, and a sink that stores the raw
 // bytes silently corrupts the value rather than failing.
 func TestHandlerInferredMem_DecodesJSONStringEscapes(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	cases := []struct {
 		name string
 		msg  string
@@ -480,6 +504,7 @@ func TestHandlerInferredMem_DecodesJSONStringEscapes(t *testing.T) {
 // The same decoding must apply wherever a string is built, not just at the top
 // level -- appendJSONValue is shared by struct fields and list elements.
 func TestHandlerInferredMem_DecodesEscapesInNestedValues(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -499,6 +524,7 @@ func TestHandlerInferredMem_DecodesEscapesInNestedValues(t *testing.T) {
 // on which message happens to arrive first in a batch.
 
 func TestHandlerInferredMem_UnionsNestedStructFieldsAcrossMessages(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -521,6 +547,7 @@ func TestHandlerInferredMem_UnionsNestedStructFieldsAcrossMessages(t *testing.T)
 // The Bluesky shape that made this non-deterministic on a live stream: whether
 // commit.record.langs exists depended on the first message in the batch.
 func TestHandlerInferredMem_UnionsDeeplyNestedStructFields(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -540,6 +567,7 @@ func TestHandlerInferredMem_UnionsDeeplyNestedStructFields(t *testing.T) {
 
 // A struct arriving later must not lose its own nested shape.
 func TestHandlerInferredMem_UnionsStructValuedFieldAddedLater(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -562,6 +590,7 @@ func TestHandlerInferredMem_UnionsStructValuedFieldAddedLater(t *testing.T) {
 // level down from a struct, where the first message defines the column but a
 // later one adds a sibling *column*, not a sibling field.
 func TestHandlerInferredMem_TopLevelColumnsStillComeFromFirstRow(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -580,6 +609,7 @@ func TestHandlerInferredMem_TopLevelColumnsStillComeFromFirstRow(t *testing.T) {
 
 // The batch that follows an empty one must still work.
 func TestHandlerInferredMem_BatchAfterEmptyBatch(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 

--- a/internal/handlers/json_null_test.go
+++ b/internal/handlers/json_null_test.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
 func TestHandlerInferredMem_ExplicitNullStringIsNull(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -37,6 +39,7 @@ func TestHandlerInferredMem_ExplicitNullStringIsNull(t *testing.T) {
 // untyped until a later message supplies the type, and the null row must still
 // be a null once it does.
 func TestHandlerInferredMem_ExplicitNullInFirstRowIsNull(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -57,6 +60,7 @@ func TestHandlerInferredMem_ExplicitNullInFirstRowIsNull(t *testing.T) {
 
 // List elements arrive through a different entry point than keyed fields.
 func TestHandlerInferredMem_ExplicitNullListElementIsNull(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -72,6 +76,7 @@ func TestHandlerInferredMem_ExplicitNullListElementIsNull(t *testing.T) {
 }
 
 func TestHandlerStructured_ExplicitNullStringIsNull(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -110,6 +115,7 @@ func TestHandlerStructured_ExplicitNullStringIsNull(t *testing.T) {
 // children's separately with no check between them. A row after the null is
 // what proves the child stayed aligned with its parent.
 func TestHandlerInferredMem_ExplicitNullStructIsANullStruct(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 

--- a/internal/handlers/registry_test.go
+++ b/internal/handlers/registry_test.go
@@ -12,6 +12,7 @@ import (
 // down, so nothing can be missing. This runs in the unit pass, in
 // milliseconds, so the gap closes before the matrix is ever regenerated.
 func TestToolingCoverageHandlerRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+	coverage.Covers(t, "tooling.coverage")
 	declared, err := coverage.Integrations("handler")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, declared, Kinds())
@@ -21,6 +22,7 @@ func TestToolingCoverageHandlerRegistry_MatchesTheConstructorSwitch(t *testing.T
 // config type with no builder panics on a nil function rather than reporting
 // an unsupported handler.
 func TestToolingCoverageHandlerRegistry_EveryConfigTypeHasABuilder(t *testing.T) {
+	coverage.Covers(t, "tooling.coverage")
 	for configType, kind := range configTypes {
 		if _, ok := builders[kind]; !ok {
 			t.Errorf("config type %q maps to %q, which has no builder", configType, kind)

--- a/internal/handlers/structured_test.go
+++ b/internal/handlers/structured_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-adbc/go/adbc/drivermgr"
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 	"os"
 	"testing"
@@ -55,6 +56,7 @@ func createTable(t *testing.T, conn adbc.Connection, ddl string) {
 }
 
 func TestHandlerStructured_SingleRecord(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -79,6 +81,7 @@ func TestHandlerStructured_SingleRecord(t *testing.T) {
 }
 
 func TestHandlerStructured_MultipleRecords(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -114,6 +117,7 @@ func TestHandlerStructured_MultipleRecords(t *testing.T) {
 }
 
 func TestHandlerStructured_NestedStruct(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -152,6 +156,7 @@ func TestHandlerStructured_NestedStruct(t *testing.T) {
 // field must still see the rows of the batch that arrives afterwards, not the
 // empty table the statement was planned against.
 func TestHandlerStructured_FilterSeesRowsIngestedAfterPrepare(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -189,6 +194,7 @@ func TestHandlerStructured_FilterSeesRowsIngestedAfterPrepare(t *testing.T) {
 // Same defect, different symptom: an expression over a list element inside a
 // struct folds to NULL when planned against the empty table.
 func TestHandlerStructured_ListElementSeesRowsIngestedAfterPrepare(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 
@@ -224,6 +230,7 @@ func TestHandlerStructured_ListElementSeesRowsIngestedAfterPrepare(t *testing.T)
 }
 
 func TestHandlerStructured_LargeBatch(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
 	conn, cleanup := newTestADBCConn(t)
 	defer cleanup()
 

--- a/internal/kafka/security_test.go
+++ b/internal/kafka/security_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
 func TestSourceKafka_SecurityOptionsPlaintextNeedsNoOptions(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	opts, err := SecurityOptions("", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(opts))
@@ -18,6 +20,7 @@ func TestSourceKafka_SecurityOptionsPlaintextNeedsNoOptions(t *testing.T) {
 }
 
 func TestSourceKafka_SecurityOptionsSASLMechanisms(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	for _, mech := range []string{"PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512", "scram-sha-512"} {
 		t.Run(mech, func(t *testing.T) {
 			opts, err := SecurityOptions("SASL_PLAINTEXT", nil, &config.KafkaSASL{
@@ -30,6 +33,7 @@ func TestSourceKafka_SecurityOptionsSASLMechanisms(t *testing.T) {
 }
 
 func TestSourceKafka_SecurityOptionsRejectsUnknownMechanism(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	_, err := SecurityOptions("SASL_PLAINTEXT", nil, &config.KafkaSASL{
 		Mechanism: "GSSAPI", Username: "u", Password: "p",
 	})
@@ -37,22 +41,26 @@ func TestSourceKafka_SecurityOptionsRejectsUnknownMechanism(t *testing.T) {
 }
 
 func TestSourceKafka_SecurityOptionsRejectsUnknownProtocol(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	_, err := SecurityOptions("SASL_MAGIC", nil, nil)
 	assert.Error(t, err)
 }
 
 func TestSourceKafka_SecurityOptionsSASLProtocolRequiresSASLBlock(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	_, err := SecurityOptions("SASL_SSL", nil, nil)
 	assert.Error(t, err)
 }
 
 func TestSourceKafka_SecurityOptionsSSLAddsDialer(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	opts, err := SecurityOptions("SSL", nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(opts))
 }
 
 func TestSourceKafka_SecurityOptionsSASLSSLAddsBoth(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	opts, err := SecurityOptions("SASL_SSL", nil, &config.KafkaSASL{
 		Mechanism: "PLAIN", Username: "u", Password: "p",
 	})
@@ -61,6 +69,7 @@ func TestSourceKafka_SecurityOptionsSASLSSLAddsBoth(t *testing.T) {
 }
 
 func TestSourceKafka_TLSConfigDisablesHostnameVerification(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	cfg, err := tlsConfig(&config.KafkaSSL{EndpointIdentificationAlgorithm: "none"})
 	assert.NoError(t, err)
 	assert.That(t, cfg.InsecureSkipVerify)
@@ -71,11 +80,13 @@ func TestSourceKafka_TLSConfigDisablesHostnameVerification(t *testing.T) {
 }
 
 func TestSourceKafka_TLSConfigReportsMissingCAFile(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	_, err := tlsConfig(&config.KafkaSSL{CALocation: "/nonexistent/ca.pem"})
 	assert.Error(t, err)
 }
 
 func TestSourceKafka_TLSConfigRequiresBothCertAndKey(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	_, err := tlsConfig(&config.KafkaSSL{CertificateLocation: "/tmp/cert.pem"})
 	assert.Error(t, err)
 }

--- a/internal/kafka/seek_test.go
+++ b/internal/kafka/seek_test.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/zeebo/assert"
 )
 
 func TestStateOffsets_SeekerNoMarksLeavesTheGroupOffsetsAlone(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	s := NewOffsetSeeker()
 	fetched := map[string]map[int32]kgo.Offset{
 		"events": {0: kgo.NewOffset().At(60)},
@@ -25,6 +27,7 @@ func TestStateOffsets_SeekerNoMarksLeavesTheGroupOffsetsAlone(t *testing.T) {
 // A stored mark names the last offset processed, so consumption resumes at the
 // next one.
 func TestStateOffsets_SeekerMarkOverridesTheGroupOffset(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	s := NewOffsetSeeker()
 	marks := core.NewMarks()
 	marks.Advance("events", 0, core.Mark{Offset: 9, LeaderEpoch: 4})
@@ -44,6 +47,7 @@ func TestStateOffsets_SeekerMarkOverridesTheGroupOffset(t *testing.T) {
 // here becomes a partition this member consumes without the group ever
 // assigning it -- two consumers reading the same partition.
 func TestStateOffsets_SeekerNeverAddsAnUnassignedPartition(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	s := NewOffsetSeeker()
 	marks := core.NewMarks()
 	marks.Advance("events", 0, core.Mark{Offset: 9})
@@ -64,6 +68,7 @@ func TestStateOffsets_SeekerNeverAddsAnUnassignedPartition(t *testing.T) {
 // A partition the pipeline holds no mark for keeps the group's own offset, so
 // a pipeline that gains a partition still follows auto_offset_reset for it.
 func TestStateOffsets_SeekerUnmarkedPartitionKeepsTheGroupOffset(t *testing.T) {
+	coverage.Covers(t, "state.offsets")
 	s := NewOffsetSeeker()
 	marks := core.NewMarks()
 	marks.Advance("events", 0, core.Mark{Offset: 9})
@@ -87,6 +92,7 @@ func TestStateOffsets_SeekerUnmarkedPartitionKeepsTheGroupOffset(t *testing.T) {
 //
 // SeekTo must therefore reach Kafka not at all.
 func TestIntegrationSourceKafka_SeekToIssuesNoCommit(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	broker := brokerOrFail(t)
 	topic := fmt.Sprintf("turbine-seek-nocommit-%d", time.Now().UnixNano())
 	client := newTestClient(t, broker, topic, topic)
@@ -109,6 +115,7 @@ func TestIntegrationSourceKafka_SeekToIssuesNoCommit(t *testing.T) {
 // End to end: the state database disagrees with the consumer group, and the
 // state database wins.
 func TestIntegrationSourceKafka_SeekToResumesFromDurableOffsets(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	broker := brokerOrFail(t)
 	topic := fmt.Sprintf("turbine-seek-resume-%d", time.Now().UnixNano())
 

--- a/internal/kafka/source_test.go
+++ b/internal/kafka/source_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/zeebo/assert"
 )
@@ -44,6 +45,7 @@ func produce(t *testing.T, client *kgo.Client, topic string, n int) {
 // offset 70,086 and how a batch that never reached ClickHouse had already been
 // committed.
 func TestIntegrationSourceKafka_CommitMarksCommitsOnlyTheProcessedPosition(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	broker := brokerOrFail(t)
 	topic := fmt.Sprintf("turbine-commit-marks-%d", time.Now().UnixNano())
 	client := newTestClient(t, broker, topic, topic)
@@ -89,6 +91,7 @@ func TestIntegrationSourceKafka_CommitMarksCommitsOnlyTheProcessedPosition(t *te
 // on the fetch itself. Without it, an operator cannot tell a healthy pipeline
 // from one falling behind.
 func TestIntegrationSourceKafka_MessagesCarryHighWatermark(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	broker := brokerOrFail(t)
 	topic := fmt.Sprintf("turbine-hwm-%d", time.Now().UnixNano())
 
@@ -124,6 +127,7 @@ func TestIntegrationSourceKafka_MessagesCarryHighWatermark(t *testing.T) {
 // from wherever the consumer group happens to sit. The state file is the
 // source of truth; Kafka's committed offsets are advisory.
 func TestIntegrationSourceKafka_SeekToResumesFromStoredOffsets(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	broker := brokerOrFail(t)
 	topic := fmt.Sprintf("turbine-seek-%d", time.Now().UnixNano())
 
@@ -166,6 +170,7 @@ func TestIntegrationSourceKafka_SeekToResumesFromStoredOffsets(t *testing.T) {
 // first run against a fresh state file. Seeking to zero here would be wrong:
 // "nothing recorded" and "recorded position zero" are different facts.
 func TestIntegrationSourceKafka_SeekToEmptyIsANoop(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
 	broker := brokerOrFail(t)
 	topic := fmt.Sprintf("turbine-seek-empty-%d", time.Now().UnixNano())
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 	"go.uber.org/zap/zapcore"
 )
@@ -10,6 +11,7 @@ import (
 // sqlflow.settings defaults SQLFLOW_LOG_LEVEL to INFO, which is quieter than
 // zap's development logger.
 func TestSinkRetry_NewDefaultsToInfo(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	t.Setenv("SQLFLOW_LOG_LEVEL", "")
 
 	l, err := New()
@@ -19,6 +21,7 @@ func TestSinkRetry_NewDefaultsToInfo(t *testing.T) {
 }
 
 func TestSinkRetry_NewHonorsEnvVar(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	tests := []struct {
 		level string
 		want  zapcore.Level
@@ -54,6 +57,7 @@ func TestSinkRetry_NewHonorsEnvVar(t *testing.T) {
 // Python's logging.basicConfig raises on an unknown level; the returned logger
 // still works so callers that only log the failure are not left without one.
 func TestSinkRetry_NewReportsUnknownLevel(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	t.Setenv("SQLFLOW_LOG_LEVEL", "chatty")
 
 	_, err := Level()

--- a/internal/managers/tumbling_test.go
+++ b/internal/managers/tumbling_test.go
@@ -3,6 +3,7 @@ package managers
 import (
 	"context"
 	"errors"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"os"
 	"path/filepath"
@@ -136,6 +137,7 @@ func newTestTumbling(conn adbc.Connection, sink *recordingSink) *Tumbling {
 }
 
 func TestManagerTumblingWindow__PublishesAndDeletesClosedWindows(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -154,6 +156,7 @@ func TestManagerTumblingWindow__PublishesAndDeletesClosedWindows(t *testing.T) {
 }
 
 func TestManagerTumblingWindow__NoClosedWindowsIsANoop(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 
@@ -172,6 +175,7 @@ func TestManagerTumblingWindow__NoClosedWindowsIsANoop(t *testing.T) {
 
 // Start must poll until its context is cancelled, and return cleanly.
 func TestManagerTumblingWindow__StartPollsUntilContextCancelled(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -235,6 +239,7 @@ func (s *failingSink) Flush(ctx context.Context) error {
 // A window that could not be written must stay in the table. Deleting it would
 // lose the aggregate with no record anywhere that it existed.
 func TestManagerTumblingWindow__SinkWriteFailureLeavesTheWindow(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -254,6 +259,7 @@ func TestManagerTumblingWindow__SinkWriteFailureLeavesTheWindow(t *testing.T) {
 // The same holds for a flush failure. Flush is where a Kafka sink blocks on
 // broker acks, so this is the likely half to fail in production.
 func TestManagerTumblingWindow__SinkFlushFailureLeavesTheWindow(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -276,6 +282,7 @@ func TestManagerTumblingWindow__SinkFlushFailureLeavesTheWindow(t *testing.T) {
 // buffered and a retry sends them again. That is the at-least-once guarantee,
 // and it is why a window sink wants a key it can deduplicate on.
 func TestManagerTumblingWindow__RetriesAfterAFailedPoll(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -304,6 +311,7 @@ func TestManagerTumblingWindow__RetriesAfterAFailedPoll(t *testing.T) {
 // A broken delete statement must surface as an error rather than silently
 // republishing the same window on every poll.
 func TestManagerTumblingWindow__DeleteFailureIsReported(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -328,6 +336,7 @@ func TestManagerTumblingWindow__DeleteFailureIsReported(t *testing.T) {
 // An open window must survive a poll untouched. Publishing it early would
 // emit a partial aggregate as if it were final.
 func TestManagerTumblingWindow__OpenWindowsAreNeitherPublishedNorDeleted(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 
@@ -349,6 +358,7 @@ func TestManagerTumblingWindow__OpenWindowsAreNeitherPublishedNorDeleted(t *test
 // A window that closes between two polls is published on the second, not
 // missed because the first poll saw it open.
 func TestManagerTumblingWindow__PublishesAWindowThatClosesBetweenPolls(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 
@@ -374,6 +384,7 @@ func TestManagerTumblingWindow__PublishesAWindowThatClosesBetweenPolls(t *testin
 // Polling a table whose closed windows have already been published must not
 // publish them a second time.
 func TestManagerTumblingWindow__RepeatedPollsDoNotRepublish(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -394,6 +405,7 @@ func TestManagerTumblingWindow__RepeatedPollsDoNotRepublish(t *testing.T) {
 // Start runs one final poll after its context is cancelled, so a window that
 // closes during shutdown is published rather than stranded in the table.
 func TestManagerTumblingWindow__FinalPollOnShutdownPublishesAClosedWindow(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -428,6 +440,7 @@ func TestManagerTumblingWindow__FinalPollOnShutdownPublishesAClosedWindow(t *tes
 // A failing poll must not kill the manager: the rows stay and the next tick
 // retries them.
 func TestManagerTumblingWindow__StartSurvivesAFailedPoll(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 	seedWindows(t, conn)
@@ -479,6 +492,7 @@ func TestManagerTumblingWindow__StartSurvivesAFailedPoll(t *testing.T) {
 // crash in between republishes the window on restart -- at-least-once, the
 // same guarantee the sink path gives.
 func TestManagerTumblingWindow__DeleteJoinsThePipelineTransaction(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	path := filepath.Join(t.TempDir(), "state.db")
 	db, err := duckdb.OpenPath(context.Background(), path)
 	assert.NoError(t, err)
@@ -526,6 +540,7 @@ func TestManagerTumblingWindow__DeleteJoinsThePipelineTransaction(t *testing.T) 
 // The window was already published, so the next poll publishes it again --
 // at-least-once rather than a lost window.
 func TestManagerTumblingWindow__DeleteRollsBackWithTheBatch(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	path := filepath.Join(t.TempDir(), "state.db")
 	db, err := duckdb.OpenPath(context.Background(), path)
 	assert.NoError(t, err)
@@ -568,6 +583,7 @@ func TestManagerTumblingWindow__DeleteRollsBackWithTheBatch(t *testing.T) {
 // Committing is what advances the clock, which is why the consume loop now
 // commits on its flush tick even with nothing buffered.
 func TestManagerTumblingWindow__ClockAdvancesOnlyAcrossACommit(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
 	conn, cleanup := newTestConn(t)
 	defer cleanup()
 

--- a/internal/sinks/classify_test.go
+++ b/internal/sinks/classify_test.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/zeebo/assert"
 )
@@ -24,6 +25,7 @@ func (fakeTimeout) Timeout() bool   { return true }
 func (fakeTimeout) Temporary() bool { return true }
 
 func TestSinkRetry_ClassifyNetworkFailuresAreUnreachable(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	for name, err := range map[string]error{
 		"connection refused":  syscall.ECONNREFUSED,
 		"connection reset":    syscall.ECONNRESET,
@@ -48,6 +50,7 @@ func TestSinkRetry_ClassifyNetworkFailuresAreUnreachable(t *testing.T) {
 // A server that answered and rejected the write is not unreachable. Retrying
 // a schema mismatch burns the deadline and reports it late.
 func TestSinkRetry_ClassifyServerRejectionsAreNotUnreachable(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	for name, err := range map[string]error{
 		"missing column": errors.New("code: 16, message: No such column city in table events"),
 		"type mismatch":  errors.New("code: 53, message: Type mismatch"),
@@ -60,12 +63,14 @@ func TestSinkRetry_ClassifyServerRejectionsAreNotUnreachable(t *testing.T) {
 }
 
 func TestSinkRetry_ClassifyNilIsNotUnreachable(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	assert.That(t, !isUnreachable(nil))
 }
 
 // sinkError applies the classification, so a call site can wrap once and get
 // the right code either way.
 func TestSinkRetry_SinkErrorCodesByCause(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	network := sinkError(syscall.ECONNREFUSED, "clickhouse sink: prepare batch")
 	assert.Equal(t, errs.CodeSinkUnreachable, errs.CodeOf(network))
 	assert.That(t, errors.Is(network, syscall.ECONNREFUSED))
@@ -77,6 +82,7 @@ func TestSinkRetry_SinkErrorCodesByCause(t *testing.T) {
 // The classification has to reach the ladder: an unreachable cause is
 // retried, a rejection is not.
 func TestSinkRetry_SinkErrorDrivesTheRetryDecision(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	assert.That(t, retryable(sinkError(syscall.ECONNREFUSED, "prepare")))
 	assert.That(t, !retryable(sinkError(errors.New("no such column"), "append")))
 }

--- a/internal/sinks/clickhouse_test.go
+++ b/internal/sinks/clickhouse_test.go
@@ -12,10 +12,12 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
 func TestSinkClickhouse_OptionsPythonDSN(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	// The dsn the Python configs carry. clickhouse_connect speaks only the
 	// HTTP interface, so 8123 is an HTTP port and must not be dialed with
 	// the native protocol.
@@ -31,6 +33,7 @@ func TestSinkClickhouse_OptionsPythonDSN(t *testing.T) {
 }
 
 func TestSinkClickhouse_OptionsCredentials(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	opts, err := clickhouseOptions("clickhouse://alice:s3cret@ch.example.com/analytics")
 	assert.NoError(t, err)
 
@@ -42,6 +45,7 @@ func TestSinkClickhouse_OptionsCredentials(t *testing.T) {
 }
 
 func TestSinkClickhouse_OptionsSecure(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	opts, err := clickhouseOptions("clickhouses://ch.example.com/analytics")
 	assert.NoError(t, err)
 
@@ -51,6 +55,7 @@ func TestSinkClickhouse_OptionsSecure(t *testing.T) {
 }
 
 func TestSinkClickhouse_OptionsNative(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	opts, err := clickhouseOptions("tcp://localhost:9000/test")
 	assert.NoError(t, err)
 
@@ -59,6 +64,7 @@ func TestSinkClickhouse_OptionsNative(t *testing.T) {
 }
 
 func TestSinkClickhouse_OptionsInvalid(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	_, err := clickhouseOptions("postgres://localhost:5432/test")
 	assert.Error(t, err)
 
@@ -67,6 +73,7 @@ func TestSinkClickhouse_OptionsInvalid(t *testing.T) {
 }
 
 func TestSinkClickhouse_NewRequiresTable(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	_, err := NewClickhouseSink(config.ClickhouseSink{DSN: "clickhouse://localhost:8123/test"})
 	assert.Error(t, err)
 }
@@ -75,6 +82,7 @@ func TestSinkClickhouse_NewRequiresTable(t *testing.T) {
 // returns nothing: the rows go straight to ClickHouse and are not held for a
 // downstream reader.
 func TestSinkClickhouse_BatchIsNil(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, "")
 
 	batch, err := s.Batch()
@@ -133,6 +141,7 @@ func clickhouseRowCount(t *testing.T, s *ClickhouseSink) uint64 {
 }
 
 func TestSinkClickhouse_InsertsRows(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
 		timestamp DateTime,
 		user_id UInt64,
@@ -160,6 +169,7 @@ func TestSinkClickhouse_InsertsRows(t *testing.T) {
 // Flushing it must be a no-op: the column list would otherwise be empty and
 // the INSERT malformed.
 func TestSinkClickhouse_EmptyTableIsNoop(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, "")
 
 	table := array.NewTable(arrow.NewSchema(nil, nil), nil, 0)
@@ -170,6 +180,7 @@ func TestSinkClickhouse_EmptyTableIsNoop(t *testing.T) {
 }
 
 func TestSinkClickhouse_NullsBecomeDefaults(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
 		user_id UInt64,
 		action Nullable(String)
@@ -243,6 +254,7 @@ func clickhouseFixtureTable(t *testing.T) arrow.Table {
 // ordinary config -- a Bluesky pipeline selecting commit.record.langs
 // produces exactly this shape.
 func TestSinkClickhouse_InsertsArrays(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
 		id UInt64,
 		langs Array(String),
@@ -314,6 +326,7 @@ func TestSinkClickhouse_InsertsArrays(t *testing.T) {
 // A list of lists must reach Array(Array(T)), since the handler infers
 // nested lists from nested JSON arrays.
 func TestSinkClickhouse_InsertsNestedArrays(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
 		id UInt64,
 		matrix Array(Array(Int64))
@@ -360,6 +373,7 @@ func TestSinkClickhouse_InsertsNestedArrays(t *testing.T) {
 // pinned to one far from UTC so the test means the same thing on a UTC CI
 // runner as on a laptop.
 func TestSinkClickhouse_StringTemporalsAreNotShiftedByHostZone(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	tokyo, err := time.LoadLocation("Asia/Tokyo") // UTC+9, no DST
 	assert.NoError(t, err)
 	prev := time.Local

--- a/internal/sinks/conformance_kafka_test.go
+++ b/internal/sinks/conformance_kafka_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/conformance"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/zeebo/assert"
 )
@@ -33,6 +34,10 @@ import (
 const sinkBrokerImage = "confluentinc/confluent-local:7.5.0"
 
 func TestIntegrationSinkKafka_Conformance(t *testing.T) {
+	// Before the skip: the unit pass never reaches the harness, and a test
+	// that emits nothing there reads as covering no feature at all.
+	coverage.Covers(t, "sink.kafka")
+
 	if testing.Short() {
 		t.Skip("integration test: -short runs the unit pass only")
 	}

--- a/internal/sinks/conformance_test.go
+++ b/internal/sinks/conformance_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/conformance"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -50,6 +51,10 @@ func clickhouseDSN(addr string) string {
 }
 
 func TestIntegrationSinkClickhouse_Conformance(t *testing.T) {
+	// Before the skip: the unit pass never reaches the harness, and a test
+	// that emits nothing there reads as covering no feature at all.
+	coverage.Covers(t, "sink.clickhouse")
+
 	if testing.Short() {
 		t.Skip("integration test: -short runs the unit pass only")
 	}

--- a/internal/sinks/iceberg_test.go
+++ b/internal/sinks/iceberg_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/apache/iceberg-go"
 	"github.com/apache/iceberg-go/catalog"
 	sqlcat "github.com/apache/iceberg-go/catalog/sql"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -44,6 +45,7 @@ func writePyicebergConfig(t *testing.T, body string) {
 }
 
 func TestSinkIceberg_NewRequiresCatalogAndTable(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	ctx := context.Background()
 
 	_, err := NewIcebergSink(ctx, "", "default.events")
@@ -57,6 +59,7 @@ func TestSinkIceberg_NewRequiresCatalogAndTable(t *testing.T) {
 // Resolving that name the way pyiceberg does is what lets the same config run
 // on either engine, so the translation is asserted key by key.
 func TestSinkIceberg_CatalogPropertiesFromPyicebergFile(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	writePyicebergConfig(t, `catalog:
   local:
     uri: sqlite:////tmp/wh/catalog.db
@@ -86,6 +89,7 @@ func TestSinkIceberg_CatalogPropertiesFromPyicebergFile(t *testing.T) {
 // file. Both forms must work, and the environment must win: it is how one
 // image runs against a different catalog per deployment.
 func TestSinkIceberg_CatalogPropertiesEnvOverridesFile(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	writePyicebergConfig(t, `catalog:
   local:
     uri: sqlite:////tmp/from-file/catalog.db
@@ -104,6 +108,7 @@ func TestSinkIceberg_CatalogPropertiesEnvOverridesFile(t *testing.T) {
 // empty property set instead would have iceberg-go fail later with a message
 // about a missing driver, which names the wrong problem.
 func TestSinkIceberg_CatalogPropertiesRequireAURI(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	isolateCatalogLookup(t)
 
 	_, err := icebergCatalogProperties("nowhere")
@@ -113,6 +118,7 @@ func TestSinkIceberg_CatalogPropertiesRequireAURI(t *testing.T) {
 // Only SQL-backed catalogs are supported so far. A REST catalog must be
 // rejected by name rather than half-configured as a SQL one.
 func TestSinkIceberg_CatalogPropertiesRejectAnUnsupportedScheme(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	isolateCatalogLookup(t)
 	t.Setenv("PYICEBERG_CATALOG__REMOTE__URI", "https://catalog.example.com")
 
@@ -125,6 +131,7 @@ func TestSinkIceberg_CatalogPropertiesRejectAnUnsupportedScheme(t *testing.T) {
 // unreadable from Go until the column is added, and every table in it reads as
 // missing -- the exact failure a user migrating between engines hits first.
 func TestSinkIceberg_AddsPyicebergsMissingTypeColumn(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	path := filepath.Join(t.TempDir(), "catalog.db")
 
 	db, err := sql.Open("sqlite", path)
@@ -167,6 +174,7 @@ func TestSinkIceberg_AddsPyicebergsMissingTypeColumn(t *testing.T) {
 // A catalog with no iceberg_tables table at all is one turbine is about to
 // create itself, and creating it is iceberg-go's job, not this function's.
 func TestSinkIceberg_TypeColumnSkipsAnEmptyCatalog(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	path := filepath.Join(t.TempDir(), "catalog.db")
 
 	props := iceberg.Properties{sqlcat.DriverKey: "sqlite", "uri": path}
@@ -236,6 +244,7 @@ func icebergRowCount(t *testing.T, catalogName, tableName string) int64 {
 // The sink's whole job, proven against a committed snapshot rather than
 // against its own buffer.
 func TestSinkIceberg_AppendsEveryRow(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	catalogName, tableName := newLocalIcebergTable(t)
 
 	s, err := NewIcebergSink(context.Background(), catalogName, tableName)
@@ -262,6 +271,7 @@ func TestSinkIceberg_AppendsEveryRow(t *testing.T) {
 // flushes on an interval whether or not a batch arrived, so a sink that
 // re-appended its last batch would duplicate the table once per interval.
 func TestSinkIceberg_FlushWithNothingPendingAppendsNothing(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	catalogName, tableName := newLocalIcebergTable(t)
 
 	s, err := NewIcebergSink(context.Background(), catalogName, tableName)
@@ -283,6 +293,7 @@ func TestSinkIceberg_FlushWithNothingPendingAppendsNothing(t *testing.T) {
 // would commit a snapshot with no data files, so a table's history would fill
 // with empty commits on a quiet topic.
 func TestSinkIceberg_EmptyBatchAppendsNothing(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	catalogName, tableName := newLocalIcebergTable(t)
 
 	s, err := NewIcebergSink(context.Background(), catalogName, tableName)
@@ -300,6 +311,7 @@ func TestSinkIceberg_EmptyBatchAppendsNothing(t *testing.T) {
 
 // Batch is what the tumbling-window manager reads back after a write.
 func TestSinkIceberg_BatchIsTheLastWrite(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	catalogName, tableName := newLocalIcebergTable(t)
 
 	s, err := NewIcebergSink(context.Background(), catalogName, tableName)
@@ -321,6 +333,7 @@ func TestSinkIceberg_BatchIsTheLastWrite(t *testing.T) {
 // A table the catalog does not have must fail the start. Discovering it on the
 // first flush instead loses the batch and every offset behind it.
 func TestSinkIceberg_MissingTableFailsTheStart(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
 	catalogName, _ := newLocalIcebergTable(t)
 
 	_, err := NewIcebergSink(context.Background(), catalogName, "default.no_such_table")

--- a/internal/sinks/kafka_test.go
+++ b/internal/sinks/kafka_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -54,6 +55,7 @@ func flushWithin(t *testing.T, s *KafkaSink, ctx context.Context, limit time.Dur
 }
 
 func TestSinkKafka_NewRequiresATopic(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
 	_, err := NewKafkaSink(config.KafkaSink{Brokers: []string{unreachableBroker}})
 	assert.Error(t, err)
 }
@@ -62,6 +64,7 @@ func TestSinkKafka_NewRequiresATopic(t *testing.T) {
 // client anyway produces a sink that connects in the clear, which is worse
 // than not starting.
 func TestSinkKafka_NewRejectsAnUnknownSecurityProtocol(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
 	_, err := NewKafkaSink(config.KafkaSink{
 		Brokers:          []string{unreachableBroker},
 		Topic:            "sink-test",
@@ -80,6 +83,7 @@ func TestSinkKafka_NewRejectsAnUnknownSecurityProtocol(t *testing.T) {
 // franz-go retries a produce indefinitely by default. The process hangs on
 // shutdown and a supervisor eventually kills it.
 func TestSinkKafka_FlushHonoursItsContext(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
 	s := newUnreachableKafkaSink(t)
 
 	table := newTestTable(t, []string{"nyc"}, []int64{1})
@@ -109,6 +113,7 @@ func TestSinkKafka_FlushHonoursItsContext(t *testing.T) {
 // 127.0.0.1:1. The sink now buffers on the way in, so no context can fail a
 // write, and the guarantee that matters moved to Flush.
 func TestSinkKafka_WriteTableBuffersWhateverItsContextSays(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
 	s := newUnreachableKafkaSink(t)
 
 	table := newTestTable(t, []string{"nyc"}, []int64{1})
@@ -129,6 +134,7 @@ func TestSinkKafka_WriteTableBuffersWhateverItsContextSays(t *testing.T) {
 // after a flush returns clean, so a flush that hides a failed produce loses
 // the batch and every offset behind it.
 func TestSinkKafka_FlushReportsProduceErrors(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
 	s := newUnreachableKafkaSink(t)
 
 	table := newTestTable(t, []string{"nyc", "sfo"}, []int64{1, 2})
@@ -143,6 +149,7 @@ func TestSinkKafka_FlushReportsProduceErrors(t *testing.T) {
 
 // Batch is what the tumbling-window manager reads back after a write.
 func TestSinkKafka_BatchIsTheLastWrite(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
 	s := newUnreachableKafkaSink(t)
 
 	batch, err := s.Batch()

--- a/internal/sinks/metrics_test.go
+++ b/internal/sinks/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/zeebo/assert"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -49,6 +50,7 @@ func newMeteredRetry(inner *flakySink, p RetryPolicy) (*retrying, sdkmetric.Read
 
 // Two failures then a success is two retries, counted before the batch lands.
 func TestSinkRetry_MetricsCountsEveryRetry(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 2, err: errs.New(errs.CodeSinkUnreachable, "refused")}
 	r, reader := newMeteredRetry(inner, testPolicy())
 
@@ -60,6 +62,7 @@ func TestSinkRetry_MetricsCountsEveryRetry(t *testing.T) {
 // A sink that works records nothing, so a nonzero counter always means the
 // destination is struggling.
 func TestSinkRetry_MetricsSuccessCountsNoRetries(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{}
 	r, reader := newMeteredRetry(inner, testPolicy())
 
@@ -70,6 +73,7 @@ func TestSinkRetry_MetricsSuccessCountsNoRetries(t *testing.T) {
 
 // A rejected write is not retried, so it must not inflate the retry counter.
 func TestSinkRetry_MetricsNonRetryableCountsNoRetries(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkWriteFailed, "no such column")}
 	r, reader := newMeteredRetry(inner, testPolicy())
 
@@ -81,6 +85,7 @@ func TestSinkRetry_MetricsNonRetryableCountsNoRetries(t *testing.T) {
 // An exhausted ladder counts every retry it made, which is one fewer than the
 // attempts: the last attempt is not followed by another.
 func TestSinkRetry_MetricsExhaustedLadderCountsItsRetries(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	p := testPolicy()
 	p.MaxAttempts = 4
 	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "refused")}
@@ -94,6 +99,7 @@ func TestSinkRetry_MetricsExhaustedLadderCountsItsRetries(t *testing.T) {
 // A nil provider must not panic. A pipeline started without --metrics still
 // retries.
 func TestSinkRetry_MetricsNilProviderIsSafe(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 1, err: errs.New(errs.CodeSinkUnreachable, "refused")}
 	r, _ := newTestRetry(inner, testPolicy())
 	r.onRetry = retryCounter(nil, "clickhouse")

--- a/internal/sinks/probe_test.go
+++ b/internal/sinks/probe_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/zeebo/assert"
 )
@@ -31,6 +32,7 @@ func (s *probeSink) Probe(ctx context.Context) error {
 }
 
 func TestSinkRetry_ProbeReachableSinkStarts(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s := &probeSink{}
 
 	assert.NoError(t, probe(context.Background(), s))
@@ -40,6 +42,7 @@ func TestSinkRetry_ProbeReachableSinkStarts(t *testing.T) {
 // A destination that is not there fails the start with the code whose exit
 // status tells a supervisor the dependency may come back.
 func TestSinkRetry_ProbeUnreachableSinkFailsTheStart(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s := &probeSink{err: syscall.ECONNREFUSED}
 
 	err := probe(context.Background(), s)
@@ -54,6 +57,7 @@ func TestSinkRetry_ProbeUnreachableSinkFailsTheStart(t *testing.T) {
 // A server that answers and refuses is the user's to fix. Reporting it as
 // unreachable would have a supervisor retry a pipeline that cannot start.
 func TestSinkRetry_ProbeAuthFailureIsAUserError(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s := &probeSink{err: errors.New("code: 516, message: Authentication failed")}
 
 	err := probe(context.Background(), s)
@@ -65,6 +69,7 @@ func TestSinkRetry_ProbeAuthFailureIsAUserError(t *testing.T) {
 
 // A sink with nothing to dial is not probed and must not fail the start.
 func TestSinkRetry_ProbeSinksWithNothingToDialAreSkipped(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	for _, s := range []config.Sink{
 		{Type: "noop"},
 		{Type: "console"},
@@ -83,6 +88,7 @@ func TestSinkRetry_ProbeSinksWithNothingToDialAreSkipped(t *testing.T) {
 // destination that is genuinely down, and it would run before the pipeline has
 // consumed anything, where there is nothing to lose by failing fast.
 func TestSinkRetry_ProbeDialsOnceAndDoesNotRetry(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s := &probeSink{err: syscall.ECONNREFUSED}
 
 	assert.Error(t, probe(context.Background(), s))
@@ -91,6 +97,7 @@ func TestSinkRetry_ProbeDialsOnceAndDoesNotRetry(t *testing.T) {
 
 // A cancelled context stops the start rather than dialing anyway.
 func TestSinkRetry_ProbeRespectsACancelledContext(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s := &probeSink{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/sinks/registry_test.go
+++ b/internal/sinks/registry_test.go
@@ -12,6 +12,7 @@ import (
 // down, so nothing can be missing. This runs in the unit pass, in
 // milliseconds, so the gap closes before the matrix is ever regenerated.
 func TestToolingCoverageSinkRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+	coverage.Covers(t, "tooling.coverage")
 	declared, err := coverage.Integrations("sink")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, declared, Kinds())

--- a/internal/sinks/retry_bounds_test.go
+++ b/internal/sinks/retry_bounds_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/zeebo/assert"
 )
@@ -24,6 +25,7 @@ func alwaysFails() *flakySink {
 // The batch must reach the sink even under a nonsense policy. Skipping the
 // flush loses the batch, and the caller is told it succeeded.
 func TestSinkRetry_BoundsMaxAttemptsZeroStillFlushesOnce(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{}
 	p := testPolicy()
 	p.MaxAttempts = 0
@@ -36,6 +38,7 @@ func TestSinkRetry_BoundsMaxAttemptsZeroStillFlushesOnce(t *testing.T) {
 }
 
 func TestSinkRetry_BoundsMaxAttemptsNegativeStillFlushesOnce(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{}
 	p := testPolicy()
 	p.MaxAttempts = -3
@@ -47,6 +50,7 @@ func TestSinkRetry_BoundsMaxAttemptsNegativeStillFlushesOnce(t *testing.T) {
 
 // A failure under a zero policy still has to be reported, not swallowed.
 func TestSinkRetry_BoundsMaxAttemptsZeroReportsTheFailure(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 0
@@ -59,6 +63,7 @@ func TestSinkRetry_BoundsMaxAttemptsZeroReportsTheFailure(t *testing.T) {
 }
 
 func TestSinkRetry_BoundsMaxAttemptsOneMakesExactlyOneAttempt(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 1
@@ -70,6 +75,7 @@ func TestSinkRetry_BoundsMaxAttemptsOneMakesExactlyOneAttempt(t *testing.T) {
 }
 
 func TestSinkRetry_BoundsMaxAttemptsTwoSleepsExactlyOnce(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 2
@@ -82,6 +88,7 @@ func TestSinkRetry_BoundsMaxAttemptsTwoSleepsExactlyOnce(t *testing.T) {
 
 // The ladder sleeps between attempts, never after the last one.
 func TestSinkRetry_BoundsNeverSleepsAfterTheFinalAttempt(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	for attempts := 1; attempts <= 6; attempts++ {
 		inner := alwaysFails()
 		p := testPolicy()
@@ -104,6 +111,7 @@ func TestSinkRetry_BoundsNeverSleepsAfterTheFinalAttempt(t *testing.T) {
 // A cap below the initial backoff must bind on the first sleep. Applying it
 // only after the first sleep lets one wait exceed the cap the operator set.
 func TestSinkRetry_BoundsInitialBackoffAboveTheCapIsCapped(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 3
@@ -124,6 +132,7 @@ func TestSinkRetry_BoundsInitialBackoffAboveTheCapIsCapped(t *testing.T) {
 // Zero backoff means retry immediately, which is a legitimate ask. It must
 // stay bounded by MaxAttempts rather than spinning.
 func TestSinkRetry_BoundsZeroBackoffRetriesImmediately(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 4
@@ -141,6 +150,7 @@ func TestSinkRetry_BoundsZeroBackoffRetriesImmediately(t *testing.T) {
 
 // A negative backoff must not become a negative sleep or an endless one.
 func TestSinkRetry_BoundsNegativeBackoffIsTreatedAsZero(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 3
@@ -161,6 +171,7 @@ func TestSinkRetry_BoundsNegativeBackoffIsTreatedAsZero(t *testing.T) {
 // Doubling must not overflow into a negative duration, which would turn a
 // long backoff into a tight loop.
 func TestSinkRetry_BoundsHugeBackoffDoesNotOverflow(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 8
@@ -182,6 +193,7 @@ func TestSinkRetry_BoundsHugeBackoffDoesNotOverflow(t *testing.T) {
 // A zero deadline leaves no room to wait, so the ladder makes its one attempt
 // and reports. It must not skip the flush.
 func TestSinkRetry_BoundsZeroDeadlineMakesOneAttempt(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 10
@@ -194,6 +206,7 @@ func TestSinkRetry_BoundsZeroDeadlineMakesOneAttempt(t *testing.T) {
 }
 
 func TestSinkRetry_BoundsNegativeDeadlineMakesOneAttempt(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 10
@@ -208,6 +221,7 @@ func TestSinkRetry_BoundsNegativeDeadlineMakesOneAttempt(t *testing.T) {
 // rather than overrunning, because it runs inside the state transaction whose
 // clock the window depends on.
 func TestSinkRetry_BoundsTotalSleepNeverExceedsTheDeadline(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 50
@@ -233,6 +247,7 @@ func TestSinkRetry_BoundsTotalSleepNeverExceedsTheDeadline(t *testing.T) {
 // the deadline. Reporting "after N attempts" when the deadline stopped it
 // early sends them to the wrong knob.
 func TestSinkRetry_BoundsErrorSaysTheDeadlineStoppedIt(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 100
@@ -251,6 +266,7 @@ func TestSinkRetry_BoundsErrorSaysTheDeadlineStoppedIt(t *testing.T) {
 }
 
 func TestSinkRetry_BoundsErrorSaysAttemptsWereExhausted(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 3
@@ -265,6 +281,7 @@ func TestSinkRetry_BoundsErrorSaysAttemptsWereExhausted(t *testing.T) {
 
 // The cause has to survive so an operator sees what the destination said.
 func TestSinkRetry_BoundsExhaustedErrorWrapsTheCause(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	cause := errors.New("dial tcp 10.0.0.1:9000: connect: connection refused")
 	inner := &flakySink{failures: 1 << 30, err: cause}
 	p := testPolicy()
@@ -282,6 +299,7 @@ func TestSinkRetry_BoundsExhaustedErrorWrapsTheCause(t *testing.T) {
 
 // Succeeding on the final attempt is a success, not an exhausted ladder.
 func TestSinkRetry_BoundsSuccessOnTheFinalAttempt(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 3, err: errs.New(errs.CodeSinkUnreachable, "refused")}
 	p := testPolicy()
 	p.MaxAttempts = 4
@@ -295,6 +313,7 @@ func TestSinkRetry_BoundsSuccessOnTheFinalAttempt(t *testing.T) {
 
 // A context cancelled partway through stops the ladder there.
 func TestSinkRetry_BoundsCancellationMidLadderStops(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := alwaysFails()
 	p := testPolicy()
 	p.MaxAttempts = 10
@@ -318,6 +337,7 @@ func TestSinkRetry_BoundsCancellationMidLadderStops(t *testing.T) {
 // A rejected write must stop after one attempt regardless of how generous the
 // policy is.
 func TestSinkRetry_BoundsNonRetryableStopsUnderAnyPolicy(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	for _, p := range []RetryPolicy{
 		{MaxAttempts: 0},
 		{MaxAttempts: 1},

--- a/internal/sinks/retry_drain_test.go
+++ b/internal/sinks/retry_drain_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -40,6 +41,7 @@ func mismatchedTable(t *testing.T) arrow.Table {
 }
 
 func TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, `CREATE TABLE %s (id UInt64) ENGINE = MergeTree() ORDER BY id`)
 
 	ctx := context.Background()
@@ -60,6 +62,7 @@ func TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered(t *testing.T) {
 }
 
 func TestSinkClickhouse_SuccessfulFlushClearsTheBuffer(t *testing.T) {
+	coverage.Covers(t, "sink.clickhouse")
 	s := newLiveClickhouseSink(t, `CREATE TABLE %s (
 		timestamp DateTime,
 		user_id   Int64,
@@ -81,6 +84,7 @@ func TestSinkClickhouse_SuccessfulFlushClearsTheBuffer(t *testing.T) {
 // The ladder's half of the contract: given a sink that keeps what it could not
 // deliver, a retried flush delivers it rather than reporting a hollow success.
 func TestSinkRetry_RetriedFlushDeliversTheBatch(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	sink := &flakySink{failures: 1, err: errors.New("connection reset by peer")}
 	r := newRetrying(sink, testPolicy())
 
@@ -94,6 +98,7 @@ func TestSinkRetry_RetriedFlushDeliversTheBatch(t *testing.T) {
 
 // A flush that gives up must not claim the rows were delivered.
 func TestSinkRetry_ExhaustedLadderReportsTheFailure(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	sink := &flakySink{failures: 99, err: errors.New("connection reset by peer")}
 	r := newRetrying(sink, testPolicy())
 

--- a/internal/sinks/retry_test.go
+++ b/internal/sinks/retry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/zeebo/assert"
 )
@@ -84,6 +85,7 @@ func newTestRetry(inner *flakySink, p RetryPolicy) (*retrying, *[]time.Duration)
 // back, and a restart to recover from a 50ms hiccup costs a cold start and a
 // group rejoin.
 func TestSinkRetry_RetriesAnUnreachableSink(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 2, err: errs.New(errs.CodeSinkUnreachable, "connection refused")}
 	r, slept := newTestRetry(inner, testPolicy())
 
@@ -96,6 +98,7 @@ func TestSinkRetry_RetriesAnUnreachableSink(t *testing.T) {
 // A rejected write fails the same way every attempt. Retrying a schema
 // mismatch burns the deadline and reports the failure minutes late.
 func TestSinkRetry_DoesNotRetryARejectedWrite(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkWriteFailed, "no such column")}
 	r, slept := newTestRetry(inner, testPolicy())
 
@@ -109,6 +112,7 @@ func TestSinkRetry_DoesNotRetryARejectedWrite(t *testing.T) {
 
 // A misconfigured sink is the user's to fix. No number of attempts helps.
 func TestSinkRetry_DoesNotRetryAConfigError(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkInvalid, "table is required")}
 	r, _ := newTestRetry(inner, testPolicy())
 
@@ -122,6 +126,7 @@ func TestSinkRetry_DoesNotRetryAConfigError(t *testing.T) {
 // Exhausting the ladder reports the destination as unreachable, which maps to
 // a retryable exit code so a supervisor restarts rather than giving up.
 func TestSinkRetry_ExhaustedAttemptsReportUnreachable(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "connection refused")}
 	r, _ := newTestRetry(inner, testPolicy())
 
@@ -136,6 +141,7 @@ func TestSinkRetry_ExhaustedAttemptsReportUnreachable(t *testing.T) {
 // Backoff grows and then stops growing. An unbounded ladder sleeps past the
 // flush interval and freezes the window clock.
 func TestSinkRetry_BackoffGrowsAndIsCapped(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	p := testPolicy()
 	p.MaxAttempts = 6
 	p.InitialBackoff = 10 * time.Millisecond
@@ -157,6 +163,7 @@ func TestSinkRetry_BackoffGrowsAndIsCapped(t *testing.T) {
 // The reason the interface carries a context. A SIGTERM mid-ladder must stop
 // the retries, or the graceful drain waits out the whole deadline.
 func TestSinkRetry_CancellationStopsTheLadder(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 99, err: errs.New(errs.CodeSinkUnreachable, "refused")}
 	r := newRetrying(inner, testPolicy())
 
@@ -173,6 +180,7 @@ func TestSinkRetry_CancellationStopsTheLadder(t *testing.T) {
 
 // A sink that works costs nothing.
 func TestSinkRetry_SuccessDoesNotSleep(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 0}
 	r, slept := newTestRetry(inner, testPolicy())
 
@@ -185,6 +193,7 @@ func TestSinkRetry_SuccessDoesNotSleep(t *testing.T) {
 // The deadline bounds the whole ladder, not each attempt. It is what keeps a
 // retry from outliving the flush interval.
 func TestSinkRetry_DeadlineStopsTheLadder(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	p := testPolicy()
 	p.MaxAttempts = 100
 	p.Deadline = 25 * time.Millisecond
@@ -204,6 +213,7 @@ func TestSinkRetry_DeadlineStopsTheLadder(t *testing.T) {
 // Retrying it is the safer default: the alternative fails a pipeline on a
 // driver error nobody classified yet.
 func TestSinkRetry_RetriesAnUncodedError(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	inner := &flakySink{failures: 1, err: errors.New("i/o timeout")}
 	r, _ := newTestRetry(inner, testPolicy())
 
@@ -220,6 +230,7 @@ func isRetrying(s core.Sink) bool {
 // backoff, and a second ladder on top of that one delays the report without
 // improving delivery. The sinks reaching nothing remote gain nothing either.
 func TestSinkRetry_HelpsOnlyForSinksThatCrossANetwork(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	for sinkType, want := range map[string]bool{
 		"clickhouse": true,
 		"iceberg":    true,
@@ -238,6 +249,7 @@ func TestSinkRetry_HelpsOnlyForSinksThatCrossANetwork(t *testing.T) {
 // The sinks that reach nothing remote are built without a ladder. These build
 // for real, so they also prove construction does not dial.
 func TestSinkRetry_NewLocalSinksAreNotWrapped(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	for _, s := range []config.Sink{
 		{Type: "noop"},
 		{Type: "console"},
@@ -251,6 +263,7 @@ func TestSinkRetry_NewLocalSinksAreNotWrapped(t *testing.T) {
 
 // max_attempts: 1 is how an operator turns retrying off.
 func TestSinkRetry_NewMaxAttemptsOneDisablesRetrying(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	assert.That(t, !RetryPolicyFrom(&config.SinkRetry{MaxAttempts: 1}).Enabled())
 	assert.That(t, RetryPolicyFrom(&config.SinkRetry{MaxAttempts: 2}).Enabled())
 }
@@ -258,6 +271,7 @@ func TestSinkRetry_NewMaxAttemptsOneDisablesRetrying(t *testing.T) {
 // An omitted block takes the defaults rather than turning retrying off. One
 // refused connection killing the process was the defect, not the baseline.
 func TestSinkRetry_PolicyFromDefaultsAreOn(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	p := RetryPolicyFrom(nil)
 
 	assert.That(t, p.Enabled())
@@ -266,6 +280,7 @@ func TestSinkRetry_PolicyFromDefaultsAreOn(t *testing.T) {
 }
 
 func TestSinkRetry_PolicyFromOverridesOnlyWhatIsSet(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	p := RetryPolicyFrom(&config.SinkRetry{MaxAttempts: 9, DeadlineSeconds: 3})
 
 	assert.Equal(t, 9, p.MaxAttempts)

--- a/internal/sinks/rows_test.go
+++ b/internal/sinks/rows_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -33,6 +34,7 @@ func newTestTable(t *testing.T, cities []string, counts []int64) arrow.Table {
 }
 
 func TestSinkConsole_RowsAsJSONOneObjectPerRow(t *testing.T) {
+	coverage.Covers(t, "sink.console")
 	table := newTestTable(t, []string{"NYC", "SF"}, []int64{3, 1})
 	defer table.Release()
 
@@ -52,6 +54,7 @@ func TestSinkConsole_RowsAsJSONOneObjectPerRow(t *testing.T) {
 }
 
 func TestSinkConsole_RowsAsJSONEmptyTable(t *testing.T) {
+	coverage.Covers(t, "sink.console")
 	table := newTestTable(t, []string{}, []int64{})
 	defer table.Release()
 

--- a/internal/sinks/sqlcommand_test.go
+++ b/internal/sinks/sqlcommand_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"github.com/zeebo/assert"
 )
@@ -97,6 +98,7 @@ func queryStrings(t *testing.T, conn adbc.Connection, sql string) []string {
 }
 
 func TestSinkSqlcommand_NewRequiresSQL(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 
 	_, err := NewSQLCommandSink(conn, "", nil)
@@ -110,6 +112,7 @@ func TestSinkSqlcommand_NewRequiresSQL(t *testing.T) {
 // The batch reaches the user's SQL under the name the Python sink registered
 // it as. A different name and every shipped sqlcommand config stops working.
 func TestSinkSqlcommand_RunsSQLAgainstTheBatch(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 	exec(t, conn, "CREATE TABLE out (city VARCHAR, count BIGINT)")
 
@@ -129,6 +132,7 @@ func TestSinkSqlcommand_RunsSQLAgainstTheBatch(t *testing.T) {
 // Writes accumulate until a flush, so a batch split across several WriteTable
 // calls reaches the SQL as one table rather than as the last write.
 func TestSinkSqlcommand_AccumulatesUntilFlush(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 	exec(t, conn, "CREATE TABLE out (city VARCHAR, count BIGINT)")
 
@@ -156,6 +160,7 @@ func TestSinkSqlcommand_AccumulatesUntilFlush(t *testing.T) {
 // rewrites them on every flush -- a pipeline that duplicates its whole history
 // once per interval.
 func TestSinkSqlcommand_EachFlushReplacesTheBatchTable(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 	exec(t, conn, "CREATE TABLE out (city VARCHAR, count BIGINT)")
 
@@ -181,6 +186,7 @@ func TestSinkSqlcommand_EachFlushReplacesTheBatchTable(t *testing.T) {
 // an interval whether or not a batch arrived, so an INSERT that fired on an
 // empty flush would write the previous batch again every interval.
 func TestSinkSqlcommand_FlushWithNothingPendingIsANoop(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 	exec(t, conn, "CREATE TABLE out (city VARCHAR, count BIGINT)")
 
@@ -204,6 +210,7 @@ func TestSinkSqlcommand_FlushWithNothingPendingIsANoop(t *testing.T) {
 // the COPY that writes a parquet file, an ATTACHed table's DELETE -- still
 // happens.
 func TestSinkSqlcommand_EmptyBatchStillRunsTheSQL(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 	exec(t, conn, "CREATE TABLE runs (n BIGINT)")
 
@@ -222,6 +229,7 @@ func TestSinkSqlcommand_EmptyBatchStillRunsTheSQL(t *testing.T) {
 // Substitutions are how a config writes one file per flush instead of
 // overwriting a single path. Each flush must produce a different value.
 func TestSinkSqlcommand_SubstitutesUUID4(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 	exec(t, conn, "CREATE TABLE out (name VARCHAR)")
 
@@ -251,6 +259,7 @@ func TestSinkSqlcommand_SubstitutesUUID4(t *testing.T) {
 // placeholder in the SQL, where it would be a syntax error whose message names
 // the wrong problem.
 func TestSinkSqlcommand_RejectsAnUnknownSubstitution(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 
 	s, err := NewSQLCommandSink(conn, "INSERT INTO out VALUES ('<x>')",
@@ -270,6 +279,7 @@ func TestSinkSqlcommand_RejectsAnUnknownSubstitution(t *testing.T) {
 // pipeline's error policy is what decides the consequence, and it can only
 // decide on an error it is handed.
 func TestSinkSqlcommand_ReportsASQLError(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 
 	s, err := NewSQLCommandSink(conn, "INSERT INTO no_such_table SELECT * FROM sqlflow_sink_batch", nil)
@@ -284,6 +294,7 @@ func TestSinkSqlcommand_ReportsASQLError(t *testing.T) {
 
 // Batch is what the tumbling-window manager reads back after a write.
 func TestSinkSqlcommand_BatchIsTheLastWrite(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 
 	s, err := NewSQLCommandSink(conn, "SELECT 1", nil)

--- a/internal/sinks/structural_test.go
+++ b/internal/sinks/structural_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -21,12 +22,14 @@ import (
 // now names one of these tests, and the generator rejects one that does not.
 
 func TestSinkConsole_ImplementsNoProber(t *testing.T) {
+	coverage.Covers(t, "sink.console")
 	var s core.Sink = NewConsoleSink()
 	_, ok := s.(Prober)
 	assert.That(t, !ok)
 }
 
 func TestSinkSqlcommand_ImplementsNoProber(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
 	conn := newSinkTestConn(t)
 	built, err := NewSQLCommandSink(conn, "SELECT 1", nil)
 	assert.NoError(t, err)
@@ -37,6 +40,7 @@ func TestSinkSqlcommand_ImplementsNoProber(t *testing.T) {
 }
 
 func TestSinkNoop_ImplementsNoProber(t *testing.T) {
+	coverage.Covers(t, "sink.noop")
 	var s core.Sink = &NoopSink{}
 	_, ok := s.(Prober)
 	assert.That(t, !ok)
@@ -49,6 +53,7 @@ func TestSinkNoop_ImplementsNoProber(t *testing.T) {
 // legitimate exemption if discarding is deliberate and total, which is what
 // this asserts.
 func TestSinkNoop_DeliversNothingAndSaysSo(t *testing.T) {
+	coverage.Covers(t, "sink.noop")
 	s := &NoopSink{}
 	ctx := context.Background()
 

--- a/internal/sources/init_test.go
+++ b/internal/sources/init_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/webhook"
 	"github.com/turbolytics/sql-flow/internal/websocket"
 	"github.com/zeebo/assert"
@@ -17,6 +18,7 @@ import (
 )
 
 func TestSinkRetry_NewWebsocket(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s, err := New(config.Source{
 		Type:      "websocket",
 		Websocket: &config.WebsocketSource{URI: "ws://localhost:1234/subscribe"},
@@ -28,11 +30,13 @@ func TestSinkRetry_NewWebsocket(t *testing.T) {
 }
 
 func TestSinkRetry_NewWebsocketRequiresURI(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	_, err := New(config.Source{Type: "websocket"}, zap.NewNop(), nil)
 	assert.Error(t, err)
 }
 
 func TestSinkRetry_NewWebhook(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s, err := New(config.Source{
 		Type: "webhook",
 		Webhook: &config.WebhookSource{
@@ -54,6 +58,7 @@ func TestSinkRetry_NewWebhook(t *testing.T) {
 // signature_type is what turns HMAC verification on, matching
 // sqlflow/sources/__init__.py.
 func TestSinkRetry_NewWebhookWithoutSignatureType(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s, err := New(config.Source{
 		Type:    "webhook",
 		Webhook: &config.WebhookSource{},
@@ -68,6 +73,7 @@ func TestSinkRetry_NewWebhookWithoutSignatureType(t *testing.T) {
 // The webhook source is the only one that records its own metrics, so the
 // provider has to survive the trip through New.
 func TestSinkRetry_NewWebhookRecordsRequestMetrics(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	reader := sdkmetric.NewManualReader()
 	s, err := New(
 		config.Source{Type: "webhook", Webhook: &config.WebhookSource{}},
@@ -102,6 +108,7 @@ func TestSinkRetry_NewWebhookRecordsRequestMetrics(t *testing.T) {
 }
 
 func TestSinkRetry_NewUnsupportedSource(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	_, err := New(config.Source{Type: "carrier-pigeon"}, zap.NewNop(), nil)
 	assert.Error(t, err)
 }

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -12,6 +12,7 @@ import (
 // down, so nothing can be missing. This runs in the unit pass, in
 // milliseconds, so the gap closes before the matrix is ever regenerated.
 func TestToolingCoverageSourceRegistry_MatchesTheConstructorSwitch(t *testing.T) {
+	coverage.Covers(t, "tooling.coverage")
 	declared, err := coverage.Integrations("source")
 	assert.NoError(t, err)
 	assert.DeepEqual(t, declared, Kinds())

--- a/internal/webhook/metrics_test.go
+++ b/internal/webhook/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -43,6 +44,7 @@ func drain(s *Source) {
 // Names, units and descriptions come from sqlflow/sources/webhook.py, where
 // the meter is created as 'sqlflow.sources.http'.
 func TestSinkRetry_MetricsMatchPythonInstruments(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	reader := sdkmetric.NewManualReader()
 	s, err := NewSource(WithMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))))
 	assert.NoError(t, err)
@@ -67,6 +69,7 @@ func TestSinkRetry_MetricsMatchPythonInstruments(t *testing.T) {
 // The Python middleware wraps the whole app and attributes every response by
 // its status code, so rejected and unrouted requests are counted too.
 func TestSinkRetry_MetricsCountRequestsByStatusCode(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	reader := sdkmetric.NewManualReader()
 	s, err := NewSource(
 		WithMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))),
@@ -106,6 +109,7 @@ func TestSinkRetry_MetricsCountRequestsByStatusCode(t *testing.T) {
 }
 
 func TestSinkRetry_MetricsRecordRequestDuration(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	reader := sdkmetric.NewManualReader()
 	s, err := NewSource(WithMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))))
 	assert.NoError(t, err)
@@ -134,6 +138,7 @@ func TestSinkRetry_MetricsRecordRequestDuration(t *testing.T) {
 // A source built without a provider must still serve, so the request path
 // needs no nil checks.
 func TestSinkRetry_MetricsNoProviderRecordsNothing(t *testing.T) {
+	coverage.Covers(t, "sink.retry")
 	s, err := NewSource()
 	assert.NoError(t, err)
 	defer s.Close()

--- a/internal/webhook/source_test.go
+++ b/internal/webhook/source_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/zeebo/assert"
 )
 
@@ -47,6 +48,7 @@ func readBody(t *testing.T, resp *http.Response) string {
 // Status codes and response bodies are the Python engine's, see
 // tests/sources/test_webhook.py.
 func TestSourceWebhook_EventsHMACValidation(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	body := []byte(`{"key": "value"}`)
 	conf := &HMAC{Header: "X-HMAC-Signature", SigKey: "sha256", Secret: "test_secret"}
 
@@ -128,6 +130,7 @@ func TestSourceWebhook_EventsHMACValidation(t *testing.T) {
 }
 
 func TestSourceWebhook_DeliversBodyToStream(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	s, err := NewSource()
 	assert.NoError(t, err)
 	defer s.Close()
@@ -152,6 +155,7 @@ func TestSourceWebhook_DeliversBodyToStream(t *testing.T) {
 // The Python source queues at most one message, so a second delivery waits
 // for the pipeline to consume the first.
 func TestSourceWebhook_BackpressureHoldsSecondRequest(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	s, err := NewSource()
 	assert.NoError(t, err)
 	defer s.Close()
@@ -191,6 +195,7 @@ func TestSourceWebhook_BackpressureHoldsSecondRequest(t *testing.T) {
 }
 
 func TestSourceWebhook_CloseReleasesBlockedRequest(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	s, err := NewSource()
 	assert.NoError(t, err)
 
@@ -220,6 +225,7 @@ func TestSourceWebhook_CloseReleasesBlockedRequest(t *testing.T) {
 }
 
 func TestSourceWebhook_RoutesOnlyPostEvents(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	s, err := NewSource()
 	assert.NoError(t, err)
 	defer s.Close()
@@ -238,6 +244,7 @@ func TestSourceWebhook_RoutesOnlyPostEvents(t *testing.T) {
 }
 
 func TestSourceWebhook_StartServesOnItsOwnListener(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	s, err := NewSource(WithAddr("127.0.0.1:0"))
 	assert.NoError(t, err)
 	assert.NoError(t, s.Start())
@@ -257,6 +264,7 @@ func TestSourceWebhook_StartServesOnItsOwnListener(t *testing.T) {
 }
 
 func TestSourceWebhook_StartReportsBindFailure(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	first, err := NewSource(WithAddr("127.0.0.1:0"))
 	assert.NoError(t, err)
 	assert.NoError(t, first.Start())
@@ -268,12 +276,14 @@ func TestSourceWebhook_StartReportsBindFailure(t *testing.T) {
 }
 
 func TestSourceWebhook_DefaultsToPythonHostAndPort(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	s, err := NewSource()
 	assert.NoError(t, err)
 	assert.Equal(t, "0.0.0.0:8001", s.addr)
 }
 
 func TestSourceWebhook_CloseIsIdempotent(t *testing.T) {
+	coverage.Covers(t, "source.webhook")
 	s, err := NewSource(WithAddr("127.0.0.1:0"))
 	assert.NoError(t, err)
 	assert.NoError(t, s.Start())

--- a/internal/websocket/source_test.go
+++ b/internal/websocket/source_test.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -70,6 +71,7 @@ func recv(t *testing.T, stream <-chan []core.Message) []byte {
 }
 
 func TestSourceWebsocket_StreamsMessages(t *testing.T) {
+	coverage.Covers(t, "source.websocket")
 	srv, _ := newServer(t, []string{"one", "two", "three"}, true)
 
 	s, err := NewSource(wsURL(srv))
@@ -84,6 +86,7 @@ func TestSourceWebsocket_StreamsMessages(t *testing.T) {
 }
 
 func TestSourceWebsocket_StartReportsDialFailure(t *testing.T) {
+	coverage.Covers(t, "source.websocket")
 	// A port that nothing listens on: bind one, then release it.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
@@ -98,6 +101,7 @@ func TestSourceWebsocket_StartReportsDialFailure(t *testing.T) {
 // The server drops every connection after one message, so a second message
 // can only arrive over a reconnect.
 func TestSourceWebsocket_ReconnectsAfterDrop(t *testing.T) {
+	coverage.Covers(t, "source.websocket")
 	srv, conns := newServer(t, []string{"msg"}, false)
 
 	s, err := NewSource(wsURL(srv), WithReconnectDelay(10*time.Millisecond))
@@ -112,6 +116,7 @@ func TestSourceWebsocket_ReconnectsAfterDrop(t *testing.T) {
 }
 
 func TestSourceWebsocket_CloseEndsStream(t *testing.T) {
+	coverage.Covers(t, "source.websocket")
 	srv, _ := newServer(t, []string{"one"}, true)
 
 	s, err := NewSource(wsURL(srv))
@@ -136,6 +141,7 @@ func TestSourceWebsocket_CloseEndsStream(t *testing.T) {
 // A message larger than the library's 32KiB default read limit must not kill
 // the connection.
 func TestSourceWebsocket_ReadsLargeMessages(t *testing.T) {
+	coverage.Covers(t, "source.websocket")
 	large := strings.Repeat("a", 128*1024)
 	srv, _ := newServer(t, []string{large}, true)
 

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -164,40 +164,6 @@ def validate_registries(invariants, integrations, features):
     return problems
 
 
-def go_prefix(feature_id):
-    """sink.clickhouse -> TestSinkClickhouse"""
-    parts = re.split(r"[._]", feature_id)
-    return "Test" + "".join(p.capitalize() for p in parts)
-
-
-def py_prefix(feature_id):
-    """sink.clickhouse -> test_sink_clickhouse"""
-    return "test_" + feature_id.replace(".", "_")
-
-
-def strip_level_prefix(name):
-    """TestIntegrationSourceKafka_Commits -> TestSourceKafka_Commits
-
-    The prefix says which pass runs the test. It must not also say which
-    feature the test covers, or every integration test would attribute to
-    nothing and land in the unattributed list.
-    """
-    if name.startswith(INTEGRATION_PREFIX):
-        return "Test" + name[len(INTEGRATION_PREFIX):]
-    return name
-
-
-def match(name, prefixes):
-    """Longest matching prefix wins, so sink.iceberg does not swallow
-    sink.iceberg_merge."""
-    best = None
-    for feature_id, prefix in prefixes.items():
-        if name.startswith(prefix):
-            if best is None or len(prefix) > len(prefixes[best]):
-                best = feature_id
-    return best
-
-
 # A plain marker names an extra feature. A structured one names an invariant
 # and the integration it was proven on; the harness emits those, and a test
 # name cannot carry two ids.
@@ -267,49 +233,66 @@ def parse_pytest(path):
     return results, covers, {}
 
 
+def parent(name):
+    """TestParent/case -> TestParent. A subtest is part of its parent."""
+    return name.split("/", 1)[0]
+
+
 def build(features, go_results, py_results, go_covers=None, py_covers=None,
           it_results=None, it_covers=None):
-    """Attribute tests to features.
+    """Attribute tests to features, by marker and only by marker.
 
-    The name is the primary attribution and stays the cheap default: rename a
-    test and it is attributed, with no import and no marker. Markers add the
-    extra features an end-to-end test genuinely proves, which a single name
-    cannot express. A feature covered only by markers has no test of its own,
-    and the secondary-attribution section below says so.
+    A test used to attribute to the feature whose id its name happened to
+    prefix. That silently miscredited a test whose name merely started the same
+    way, and silently credited nothing when a name drifted: #221 landed four
+    tests that covered no feature and nothing said so until the matrix moved.
+
+    A test now says what it covers. A subtest inherits its parent, because a
+    subtest is part of that test rather than one of its own -- requiring a
+    marker inside every t.Run would put one in 149 closures to repeat what the
+    enclosing test already said.
     """
     known = {f["id"] for f in features}
-    go_prefixes = {f["id"]: go_prefix(f["id"]) for f in features}
-    py_prefixes = {f["id"]: py_prefix(f["id"]) for f in features}
 
     coverage = {f["id"]: {lvl: [] for lvl in LEVELS} for f in features}
     secondary = {f["id"]: {lvl: [] for lvl in LEVELS} for f in features}
     unmatched = {lvl: [] for lvl in LEVELS}
     unknown_markers = []
 
-    for level, results, prefixes, extras in (
-        ("unit", go_results, go_prefixes, go_covers or {}),
-        ("integration", it_results or {}, go_prefixes, it_covers or {}),
-        ("release", py_results, py_prefixes, py_covers or {}),
+    for level, results, extras in (
+        ("unit", go_results, go_covers or {}),
+        ("integration", it_results or {}, it_covers or {}),
+        ("release", py_results, py_covers or {}),
     ):
         for name, outcome in sorted(results.items()):
-            feature_id = match(strip_level_prefix(name), prefixes)
-            if feature_id:
-                coverage[feature_id][level].append((name, outcome))
-            elif not extras.get(name):
-                # A test carrying a marker is attributed by it. Listing it here
-                # would tell the reader to rename a test that already says what
-                # it covers, and the conformance harness attributes only by
-                # marker: its runner's name matches no feature at all.
-                unmatched[level].append(name)
+            # Deduped, order kept. A test can reach the same marker twice --
+            # the conformance entry points emit one before the -short skip and
+            # one when the harness finishes -- and counting both would put the
+            # same name in a cell twice.
+            claimed = extras.get(name) or extras.get(parent(name)) or []
+            marks, seen = [], set()
+            for feature_id in claimed:
+                if feature_id not in seen:
+                    seen.add(feature_id)
+                    marks.append(feature_id)
 
-            for extra in extras.get(name, []):
-                if extra not in known:
-                    unknown_markers.append((name, extra))
+            if not marks:
+                # Report the parent once rather than every subtest under it:
+                # naming the test is what a reader has to act on, and listing
+                # its cases buries that line.
+                if parent(name) not in unmatched[level]:
+                    unmatched[level].append(parent(name))
+                continue
+
+            for feature_id in marks:
+                if feature_id not in known:
+                    unknown_markers.append((name, feature_id))
                     continue
-                if extra == feature_id:
-                    continue
-                coverage[extra][level].append((name, outcome))
-                secondary[extra][level].append(name)
+                coverage[feature_id][level].append((name, outcome))
+                # Every attribution is a marker now, so "secondary" means the
+                # second and later features one test claims.
+                if feature_id != marks[0]:
+                    secondary[feature_id][level].append(name)
 
     return coverage, secondary, unmatched, unknown_markers
 
@@ -558,9 +541,10 @@ def render(snap):
         "Do not edit by hand.",
         "",
         "Features are declared in `docs/coverage/features.yml`. A test attaches",
-        "to one by name -- `sink.clickhouse` is covered by `TestSinkClickhouse*`",
-        "or `test_sink_clickhouse*` -- and that is the cheap default: rename a",
-        "test and it is attributed, with no import and no marker.",
+        "to one by saying so: `coverage.Covers(t, \"sink.clickhouse\")` in Go, or",
+        "the `covers` marker in pytest. A test used to attach by the shape of",
+        "its name, which credited a test whose name merely started the same way",
+        "and credited nothing when a name drifted.",
         "",
         "Levels are derived from where a test ran, never declared, so they",
         "cannot drift. `unit` is `go test -short`, `integration` is the Go",
@@ -659,8 +643,8 @@ def render(snap):
         lines.append("")
 
     # Secondary attribution is visible on purpose. One test per feature is the
-    # goal; a feature reached only through another test's marker has no test of
-    # its own, and this is where that shows.
+    # goal; a feature every test claims second is one no test is about, and
+    # this is where that shows.
     by_marker = []
     for feature in snap["features"]:
         for level in LEVELS:
@@ -672,9 +656,9 @@ def render(snap):
         lines += [
             "## Covered only by another test's marker",
             "",
-            "These features have no test named for them. That is legitimate for a",
-            "capability an end-to-end run proves in passing, and a smell for one",
-            "that deserves its own test.",
+            "Every test that covers these claims something else first. That is",
+            "legitimate for a capability an end-to-end run proves in passing, and",
+            "a smell for one that deserves a test of its own.",
             "",
         ]
         for fid, level, names in by_marker:
@@ -687,8 +671,8 @@ def render(snap):
             lines += [
                 f"## Unattributed {level} tests ({len(names)})",
                 "",
-                "These match no declared feature. Either rename them to the",
-                "convention, or add the feature to `features.yml`.",
+                "These carry no `coverage.Covers` marker, so they cover nothing.",
+                "Add the marker, or add the feature to `features.yml` first.",
                 "",
             ]
             lines += [f"- `{n}`" for n in names]

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -62,14 +62,12 @@ KINDS = ("sink", "source", "handler", "pipeline")
 # attribute the same claim.
 VERIFIERS = ("harness", "typetable")
 
-# A pipeline invariant is a property of the engine, not of anything a config
-# names, so its marker carries this in place of an integration id and it gets
-# one cell rather than a column per integration.
 PIPELINE = "pipeline"
 
-# pipeline is not among them: no constructor switch builds a pipeline, so no
-# entry in integrations.yml carries that kind.
-INTEGRATION_KINDS = ("sink", "source", "handler")
+# A pipeline configuration is an integration of the harness, though no
+# constructor switch builds one. `constructed: false` says so, and the Kinds()
+# agreement tests skip those entries.
+INTEGRATION_KINDS = ("sink", "source", "handler", "pipeline")
 
 
 def load_features():
@@ -333,9 +331,6 @@ def build_invariants(invariants, integrations, results, evidence):
     kinds = {i["id"]: i["kind"] for i in integrations}
     allowed = {}
     for inv in invariants:
-        if inv["applies_to"] == PIPELINE:
-            allowed[inv["id"]] = {PIPELINE}
-            continue
         allowed[inv["id"]] = {
             iid for iid, kind in kinds.items() if kind == inv["applies_to"]
         }
@@ -402,14 +397,7 @@ def snapshot_invariants(invariants, integrations, built):
         if inv.get("violated_once"):
             entry["violated_once"] = list(inv["violated_once"])
 
-        # A pipeline invariant is a property of the engine rather than of
-        # anything a config names, so it gets one cell instead of a column per
-        # integration.
-        subjects = by_kind.get(inv["applies_to"], [])
-        if inv["applies_to"] == PIPELINE:
-            subjects = [{"id": PIPELINE}]
-
-        for integ in subjects:
+        for integ in by_kind.get(inv["applies_to"], []):
             exemption = exemptions.get((inv["id"], integ["id"]))
             reason = exemption  # None when the integration must prove it
             levels = {}
@@ -924,17 +912,30 @@ def render_invariants(snap):
 
         if per_pipeline:
             lines += [
-                f"These {family} invariants are properties of the engine rather",
-                "than of anything a config names, so they carry one cell instead",
-                "of a column per integration. A test proves one by calling",
-                "`coverage.PipelineInvariant`.",
+                f"These {family} invariants are properties of the consume loop",
+                "rather than of anything a config file names. The columns are",
+                "its configurations, and `internal/conformance` runs each one",
+                "through every path that reaches a batch: the batch filling, the",
+                "flush interval elapsing, the source closing, and a cancel that",
+                "drains. An invariant holds only if it holds on all four.",
                 "",
-                "| Invariant | Claim | Proven |",
-                "| --- | --- | --- |",
             ]
+            pipeline_columns = []
             for inv in per_pipeline:
-                cell = invariant_cell(inv["integrations"][PIPELINE], inv["requires"])
-                lines.append(f"| `{inv['id']}` | {describe_claim(inv)} | {cell} |")
+                for integ in inv["integrations"]:
+                    if integ not in pipeline_columns:
+                        pipeline_columns.append(integ)
+
+            lines.append("| Invariant | Claim | "
+                         + " | ".join(f"`{c}`" for c in pipeline_columns) + " |")
+            lines.append("| --- | --- | "
+                         + " | ".join("---" for _ in pipeline_columns) + " |")
+            for inv in per_pipeline:
+                cells = " | ".join(
+                    invariant_cell(inv["integrations"][c], inv["requires"])
+                    if c in inv["integrations"] else "·"
+                    for c in pipeline_columns)
+                lines.append(f"| `{inv['id']}` | {describe_claim(inv)} | {cells} |")
             lines.append("")
 
     if snap["invariant_gaps"]:

--- a/tests/release/test_image.py
+++ b/tests/release/test_image.py
@@ -262,6 +262,7 @@ def run_image(image, command, volumes=None, env=None):
 
 
 @pytest.mark.covers("cli.dev_invoke", "sink.console")
+@pytest.mark.covers("handler.inferred_mem")
 def test_handler_inferred_mem_invoke_renders_rows(image):
     """The README quickstart, run against the image.
 
@@ -280,6 +281,7 @@ def test_handler_inferred_mem_invoke_renders_rows(image):
     ], f"unexpected output: {stdout!r} stderr={stderr!r}"
 
 
+@pytest.mark.covers("cli.version")
 def test_cli_version_is_stamped_into_the_image(image):
     """The entrypoint resolves and the binary is stamped.
 
@@ -294,6 +296,7 @@ def test_cli_version_is_stamped_into_the_image(image):
 
 
 @pytest.mark.covers("config.templating")
+@pytest.mark.covers("config.validation")
 def test_config_validation_accepts_a_shipped_example(image):
     """config validate works with no libduckdb setup beyond the image."""
     stdout, stderr = run_docker_container(
@@ -314,6 +317,7 @@ def test_config_validation_accepts_a_shipped_example(image):
     '''
 
 @pytest.mark.covers("source.kafka", "sink.kafka")
+@pytest.mark.covers("handler.inferred_mem")
 def test_handler_inferred_mem_aggregates_every_message(image, stack):
     num_messages = 1000
     in_topic = unique('input-simple-agg-mem')
@@ -342,6 +346,7 @@ def test_handler_inferred_mem_aggregates_every_message(image, stack):
 
 
 @pytest.mark.covers("source.websocket", "handler.structured")
+@pytest.mark.covers("handler.inferred_mem")
 def test_handler_inferred_mem_preserves_arrays_and_unioned_fields(image):
     """Arrays, unioned struct fields and decoded JSON escapes, via the image.
 
@@ -404,6 +409,7 @@ def _wait_for_clickhouse(url, timeout=90):
         f"clickhouse did not answer within {timeout}s; last attempt: {last}")
 
 
+@pytest.mark.covers("sink.clickhouse")
 def test_sink_clickhouse_inserts_rows(image, stack, request):
     """A sink other than console/kafka, exercised through the image.
 
@@ -493,6 +499,7 @@ def test_sink_clickhouse_inserts_rows(image, stack, request):
 
 
 @pytest.mark.covers("state.offsets", "manager.tumbling_window", "source.kafka")
+@pytest.mark.covers("state.durability")
 def test_state_durability_survives_a_restart(image, stack):
     """A crash mid-window must not lose the aggregate.
 
@@ -574,6 +581,7 @@ def test_state_durability_survives_a_restart(image, stack):
         f"stored offset should be the last processed message: {offset}")
 
 
+@pytest.mark.covers("lifecycle.drain")
 def test_lifecycle_drain_writes_the_buffered_batch_on_sigterm(image, stack):
     """A supervisor stops a pipeline with SIGTERM, so SIGTERM must drain it.
 
@@ -646,6 +654,7 @@ def test_lifecycle_drain_writes_the_buffered_batch_on_sigterm(image, stack):
 
 
 @pytest.mark.covers("state.corruption")
+@pytest.mark.covers("lifecycle.exit_codes")
 def test_lifecycle_exit_codes_carry_the_error_code(image):
     """A supervisor reads the process's exit status, so the image must set it.
 
@@ -702,6 +711,7 @@ def test_lifecycle_exit_codes_carry_the_error_code(image):
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.covers("sink.iceberg")
 def test_sink_iceberg_writes_every_row(image, stack):
     """Kafka to an Iceberg table, read back through pyiceberg.
 
@@ -750,6 +760,7 @@ def test_sink_iceberg_writes_every_row(image, stack):
         assert len(iceberg_table.scan().to_arrow()) == num_messages
 
 
+@pytest.mark.covers("sink.parquet")
 def test_sink_parquet_writes_every_row(image, stack):
     """Kafka to parquet files on disk, read back with pyarrow."""
     num_messages = 2000
@@ -780,6 +791,7 @@ def test_sink_parquet_writes_every_row(image, stack):
         assert total == num_messages, f"parquet holds {total} of {num_messages}"
 
 
+@pytest.mark.covers("error.ignore")
 def test_error_ignore_drops_bad_records_and_keeps_going(image, stack):
     """A malformed record must not stop the pipeline under policy IGNORE.
 
@@ -811,6 +823,7 @@ def test_error_ignore_drops_bad_records_and_keeps_going(image, stack):
     assert len(read_all_kafka_messages(stack.bootstrap, out_topic)) == 5
 
 
+@pytest.mark.covers("handler.inferred_mem")
 def test_handler_inferred_mem_joins_against_a_csv(image, stack):
     """A join against a CSV read from disk.
 
@@ -839,6 +852,7 @@ def test_handler_inferred_mem_joins_against_a_csv(image, stack):
     assert len(messages) == num_messages, f"joined {len(messages)} of {num_messages}"
 
 
+@pytest.mark.covers("handler.inferred_mem")
 def test_handler_inferred_mem_enriches_every_row(image, stack):
     """Per-record enrichment through the handler SQL."""
     num_messages = 1000
@@ -859,6 +873,7 @@ def test_handler_inferred_mem_enriches_every_row(image, stack):
     assert len(messages) == num_messages, f"enriched {len(messages)} of {num_messages}"
 
 
+@pytest.mark.covers("error.dlq")
 def test_error_dlq_diverts_a_record_the_handler_cannot_parse(image, stack):
     """A malformed record must reach the DLQ, not vanish.
 
@@ -896,6 +911,7 @@ def test_error_dlq_diverts_a_record_the_handler_cannot_parse(image, stack):
     assert record["timestamp"]
 
 
+@pytest.mark.covers("error.dlq")
 def test_error_dlq_diverts_a_batch_the_handler_cannot_query(image, stack):
     """A valid record the handler SQL cannot bind against still reaches the DLQ.
 

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -46,31 +46,10 @@ def level(s, feature_id, lvl):
     raise AssertionError(f"{feature_id} not in the snapshot")
 
 
-# --- Name-based attribution ------------------------------------------------
-
-def test_go_prefix_derives_from_the_feature_id():
-    assert cm.go_prefix("sink.clickhouse") == "TestSinkClickhouse"
-    assert cm.go_prefix("observability.debug_api") == "TestObservabilityDebugApi"
-
-
-def test_py_prefix_derives_from_the_feature_id():
-    assert cm.py_prefix("sink.clickhouse") == "test_sink_clickhouse"
-    assert cm.py_prefix("error.dlq") == "test_error_dlq"
-
-
 def test_a_test_attaches_to_the_feature_its_name_names():
-    s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.PASS})
+    s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.PASS},
+             go_covers={"TestSinkClickhouse_InsertsRows": ["sink.clickhouse"]})
     assert level(s, "sink.clickhouse", "unit")["status"] == "covered"
-
-
-def test_longest_prefix_wins():
-    """sink.console must not swallow a hypothetical sink.console_extra."""
-    features = FEATURES + [
-        {"id": "sink.console_extra", "description": "x", "requires": ["unit"]}]
-    s = snap(go_results={"TestSinkConsoleExtra_Thing": cm.PASS}, features=features)
-
-    assert level(s, "sink.console_extra", "unit")["status"] == "covered"
-    assert level(s, "sink.console", "unit")["status"] == "missing"
 
 
 def test_an_unmatched_test_is_reported_not_invented():
@@ -83,7 +62,8 @@ def test_an_unmatched_test_is_reported_not_invented():
 def test_a_skipped_test_does_not_cover_its_feature():
     """The whole reason this tool exists. sink.iceberg shipped for months
     behind a unit test that skipped and printed ok."""
-    s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.SKIP})
+    s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.SKIP},
+             go_covers={"TestSinkClickhouse_InsertsRows": ["sink.clickhouse"]})
 
     assert level(s, "sink.clickhouse", "unit")["status"] == "skipped"
     assert {"feature": "sink.clickhouse", "level": "unit",
@@ -94,6 +74,9 @@ def test_one_passing_test_covers_a_feature_others_skipped():
     s = snap(go_results={
         "TestSinkClickhouse_InsertsRows": cm.PASS,
         "TestSinkClickhouse_InsertsArrays": cm.SKIP,
+    }, go_covers={
+        "TestSinkClickhouse_InsertsRows": ["sink.clickhouse"],
+        "TestSinkClickhouse_InsertsArrays": ["sink.clickhouse"],
     })
     assert level(s, "sink.clickhouse", "unit")["status"] == "covered"
 
@@ -102,6 +85,9 @@ def test_a_failing_test_does_not_cover_its_feature():
     s = snap(go_results={
         "TestSinkClickhouse_InsertsRows": cm.PASS,
         "TestSinkClickhouse_InsertsArrays": cm.FAIL,
+    }, go_covers={
+        "TestSinkClickhouse_InsertsRows": ["sink.clickhouse"],
+        "TestSinkClickhouse_InsertsArrays": ["sink.clickhouse"],
     })
     assert level(s, "sink.clickhouse", "unit")["status"] == "failing"
 
@@ -124,7 +110,8 @@ def test_a_required_level_with_no_test_is_a_gap():
 def test_coverage_beyond_what_is_required_still_shows():
     """A test at a level the registry does not demand is reported, not hidden:
     dropping it later should be visible."""
-    s = snap(py_results={"test_sink_console_writes_rows": cm.PASS})
+    s = snap(py_results={"test_sink_console_writes_rows": cm.PASS},
+             py_covers={"test_sink_console_writes_rows": ["sink.console"]})
     assert level(s, "sink.console", "release")["status"] == "covered"
 
 
@@ -137,19 +124,11 @@ def test_levels_run_from_cheapest_to_most_real():
 def test_an_integration_result_lands_at_the_integration_level():
     s = snap(
         integration_results={"TestIntegrationSourceKafka_Commits": cm.PASS},
+        integration_covers={"TestIntegrationSourceKafka_Commits": ["source.kafka"]},
         features=[{"id": "source.kafka", "description": "kafka",
                    "requires": ["integration"]}],
     )
     assert level(s, "source.kafka", "integration")["status"] == "covered"
-
-
-def test_the_integration_prefix_does_not_decide_the_feature():
-    """Level and feature stay separate axes. The prefix selects which pass runs
-    a test; the rest of the name still says which feature it covers."""
-    assert (cm.strip_level_prefix("TestIntegrationSourceKafka_Commits")
-            == "TestSourceKafka_Commits")
-    assert (cm.strip_level_prefix("TestSourceKafka_Commits")
-            == "TestSourceKafka_Commits")
 
 
 def test_an_integration_test_does_not_manufacture_unit_coverage():
@@ -157,7 +136,9 @@ def test_an_integration_test_does_not_manufacture_unit_coverage():
     coverage there just because the integration pass ran it for real."""
     s = snap(
         go_results={"TestIntegrationSourceKafka_Commits": cm.SKIP},
+        go_covers={"TestIntegrationSourceKafka_Commits": ["source.kafka"]},
         integration_results={"TestIntegrationSourceKafka_Commits": cm.PASS},
+        integration_covers={"TestIntegrationSourceKafka_Commits": ["source.kafka"]},
         features=[{"id": "source.kafka", "description": "kafka",
                    "requires": ["unit", "integration"]}],
     )
@@ -170,6 +151,7 @@ def test_a_skipped_integration_test_is_a_gap():
     sink.iceberg failure one level up. It must not read as coverage."""
     s = snap(
         integration_results={"TestIntegrationSourceKafka_Commits": cm.SKIP},
+        integration_covers={"TestIntegrationSourceKafka_Commits": ["source.kafka"]},
         features=[{"id": "source.kafka", "description": "kafka",
                    "requires": ["integration"]}],
     )
@@ -196,9 +178,12 @@ def test_a_marker_attributes_a_second_feature():
 
 
 def test_a_marker_is_recorded_as_secondary_attribution():
+    """A test may claim more than one feature. The first is what it is for;
+    the rest are what it proves in passing, and the page names those."""
     s = snap(
         py_results={"test_handler_inferred_mem_aggregates": cm.PASS},
-        py_covers={"test_handler_inferred_mem_aggregates": ["source.kafka"]},
+        py_covers={"test_handler_inferred_mem_aggregates":
+                   ["handler.inferred_mem", "source.kafka"]},
         features=FEATURES + [{"id": "handler.inferred_mem", "description": "h",
                               "requires": ["release"]}],
     )
@@ -342,7 +327,8 @@ def test_the_snapshot_orders_tests_stably():
 # rather than repeated on all 489 entries as the default they usually carry.
 
 def test_a_test_is_recorded_as_a_bare_name():
-    s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.PASS})
+    s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.PASS},
+             go_covers={"TestSinkClickhouse_InsertsRows": ["sink.clickhouse"]})
     assert level(s, "sink.clickhouse", "unit")["tests"] == [
         "TestSinkClickhouse_InsertsRows"]
 
@@ -361,7 +347,9 @@ def test_an_empty_list_is_omitted_entirely():
 def test_a_skipped_test_is_named_in_the_skipped_list():
     """Status alone cannot say which of several tests skipped."""
     s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.PASS,
-                         "TestSinkClickhouse_InsertsArrays": cm.SKIP})
+                         "TestSinkClickhouse_InsertsArrays": cm.SKIP},
+             go_covers={"TestSinkClickhouse_InsertsRows": ["sink.clickhouse"],
+                        "TestSinkClickhouse_InsertsArrays": ["sink.clickhouse"]})
     lvl = level(s, "sink.clickhouse", "unit")
 
     assert lvl["status"] == "covered"
@@ -371,7 +359,9 @@ def test_a_skipped_test_is_named_in_the_skipped_list():
 
 def test_a_failing_test_is_named_in_the_failing_list():
     s = snap(go_results={"TestSinkClickhouse_InsertsRows": cm.PASS,
-                         "TestSinkClickhouse_InsertsArrays": cm.FAIL})
+                         "TestSinkClickhouse_InsertsArrays": cm.FAIL},
+             go_covers={"TestSinkClickhouse_InsertsRows": ["sink.clickhouse"],
+                        "TestSinkClickhouse_InsertsArrays": ["sink.clickhouse"]})
     lvl = level(s, "sink.clickhouse", "unit")
 
     assert lvl["failing"] == ["TestSinkClickhouse_InsertsArrays"]
@@ -409,7 +399,9 @@ def test_render_counts_the_tests_rather_than_sampling_them():
     """The table is the cheap view. Three arbitrary names out of seventy-three
     answer nobody's question and cost every reader the width; the count answers
     "is this feature thinly covered" and matrix.json names them all."""
-    s = snap(go_results={f"TestSinkClickhouse_{i}": cm.PASS for i in range(4)})
+    s = snap(go_results={f"TestSinkClickhouse_{i}": cm.PASS for i in range(4)},
+             go_covers={f"TestSinkClickhouse_{i}": ["sink.clickhouse"]
+                        for i in range(4)})
     row = next(line for line in cm.render(s).splitlines()
                if line.startswith("| `sink.clickhouse`"))
 
@@ -431,9 +423,12 @@ def test_render_points_at_the_json_for_the_test_names():
 
 
 def test_render_reports_a_feature_covered_only_by_a_marker():
+    """source.kafka is claimed second by a test that is about something else,
+    and by nothing that names it first."""
     s = snap(
         py_results={"test_handler_inferred_mem_aggregates": cm.PASS},
-        py_covers={"test_handler_inferred_mem_aggregates": ["source.kafka"]},
+        py_covers={"test_handler_inferred_mem_aggregates":
+                   ["handler.inferred_mem", "source.kafka"]},
         features=FEATURES + [{"id": "handler.inferred_mem", "description": "h",
                               "requires": ["release"]}],
     )
@@ -1205,6 +1200,10 @@ def test_the_page_pairs_the_most_tested_feature_with_the_least_proven_invariant(
         "TestSinkClickhouse_A": cm.PASS,
         "TestSinkClickhouse_B": cm.PASS,
         "TestSinkConsole_C": cm.PASS,
+    }, go_covers={
+        "TestSinkClickhouse_A": ["sink.clickhouse"],
+        "TestSinkClickhouse_B": ["sink.clickhouse"],
+        "TestSinkConsole_C": ["sink.console"],
     })
     s.update(inv_snap())
     md = cm.render(s)
@@ -1224,6 +1223,9 @@ def test_the_argument_pairs_a_feature_and_an_invariant_of_the_same_layer():
     s = snap(features=features, go_results={
         **{f"TestConfigValidation_{i}": cm.PASS for i in range(20)},
         **{f"TestSinkRetry_{i}": cm.PASS for i in range(5)},
+    }, go_covers={
+        **{f"TestConfigValidation_{i}": ["config.validation"] for i in range(20)},
+        **{f"TestSinkRetry_{i}": ["sink.retry"] for i in range(5)},
     })
     s.update(inv_snap())
 
@@ -1239,7 +1241,8 @@ def test_the_argument_needs_an_invariant_in_the_same_layer():
     """A layer with tests and no invariants declared is not an argument."""
     features = [{"id": "config.validation", "description": "c", "requires": ["unit"]}]
     s = snap(features=features,
-             go_results={"TestConfigValidation_A": cm.PASS})
+             go_results={"TestConfigValidation_A": cm.PASS},
+             go_covers={"TestConfigValidation_A": ["config.validation"]})
     s.update(inv_snap())
     assert cm.strongest_argument(s) is None
 
@@ -1259,8 +1262,11 @@ def test_the_argument_is_omitted_when_no_feature_has_a_test():
 def test_the_most_tested_feature_counts_across_every_level():
     s = snap(
         go_results={"TestSinkClickhouse_A": cm.PASS},
+        go_covers={"TestSinkClickhouse_A": ["sink.clickhouse"]},
         py_results={"test_sink_clickhouse_b": cm.PASS},
+        py_covers={"test_sink_clickhouse_b": ["sink.clickhouse"]},
         integration_results={"TestSinkConsole_C": cm.PASS},
+        integration_covers={"TestSinkConsole_C": ["sink.console"]},
     )
     assert cm.most_tested_feature(s) == ("sink.clickhouse", 2)
 
@@ -1567,3 +1573,32 @@ def test_a_test_with_neither_marker_nor_matching_name_is_still_unattributed():
         FEATURES, {}, {}, {}, {}, {"TestNobodyDeclaredThis": cm.PASS}, {})
     s = cm.snapshot(FEATURES, coverage, secondary, unmatched, unknown)
     assert s["unattributed"]["integration"] == ["TestNobodyDeclaredThis"]
+
+
+def test_a_skipped_test_still_reports_its_feature():
+    """A marker must fire before any early return. Under name attribution a
+    test kept its feature even when it skipped; a marker placed after a
+    `-short` guard fires never, and the test covers nothing.
+
+    The integration tests skip in the unit pass, so this is every one of
+    them."""
+    s = snap(
+        go_results={"TestIntegrationSinkClickhouse_Conformance": cm.SKIP},
+        go_covers={"TestIntegrationSinkClickhouse_Conformance": ["sink.clickhouse"]},
+    )
+    cell = level(s, "sink.clickhouse", "unit")
+
+    assert cell["status"] == "skipped"
+    assert cell["skipped"] == ["TestIntegrationSinkClickhouse_Conformance"]
+    assert s["unattributed"]["unit"] == []
+
+
+def test_a_feature_claimed_twice_by_one_test_counts_once():
+    """A test can reach the same marker twice: the conformance entry points
+    emit one before the -short skip and one when the harness finishes. Counting
+    both inflates the Tests column and puts the same name in a cell twice."""
+    s = snap(
+        go_results={"TestX": cm.PASS},
+        go_covers={"TestX": ["sink.clickhouse", "sink.clickhouse"]},
+    )
+    assert level(s, "sink.clickhouse", "unit")["tests"] == ["TestX"]

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -21,6 +21,7 @@ import coverage_matrix as cm  # noqa: E402
 
 
 FEATURES = [
+    {"id": "state.durability", "description": "state", "requires": ["unit"]},
     {"id": "sink.clickhouse", "description": "ch", "requires": ["unit", "release"]},
     {"id": "sink.console", "description": "console", "requires": ["unit"]},
     {"id": "source.kafka", "description": "kafka", "requires": ["release"]},
@@ -499,6 +500,8 @@ INTEGRATIONS = [
                  "proven_by": "TestSinkConsole_ImplementsNoProber"}]},
     {"id": "source.kafka", "kind": "source", "implements": ["Source"],
      "feature": "source.kafka", "exempt": []},
+    {"id": "pipeline.stateful", "kind": "pipeline", "constructed": False,
+     "implements": ["Sink"], "feature": "state.durability", "exempt": []},
 ]
 
 
@@ -511,7 +514,8 @@ def test_the_committed_registries_load_and_validate():
 
     assert cm.validate_registries(invariants, integrations, features) == []
     assert len(invariants) >= 20
-    assert {i["kind"] for i in integrations} == {"sink", "source", "handler"}
+    assert {i["kind"] for i in integrations} == {
+        "sink", "source", "handler", "pipeline"}
 
 
 def test_every_committed_invariant_is_unenforced_in_this_revision():
@@ -919,11 +923,11 @@ def test_snapshot_an_exempt_cell_carries_no_tests_even_with_evidence():
     assert "tests" not in c
 
 
-def test_snapshot_a_pipeline_invariant_carries_exactly_one_cell():
-    """It is a property of the engine, not of anything a config names, so it
-    gets one cell rather than a column per integration."""
+def test_snapshot_a_pipeline_invariant_gets_a_cell_per_configuration():
+    """The consume loop has configurations, and durable state changes what a
+    commit means. One cell each is what shows which configuration proved it."""
     s = inv_snap(invariants=PIPELINE)
-    assert list(s["invariants"][0]["integrations"]) == ["pipeline"]
+    assert list(s["invariants"][0]["integrations"]) == ["pipeline.stateful"]
 
 
 def test_snapshot_orders_tests_stably_whatever_order_they_arrived_in():
@@ -1094,19 +1098,20 @@ def test_render_omits_the_gap_section_when_there_are_none():
     assert "## Invariant gaps" not in cm.render_invariants(inv_snap())
 
 
-def test_render_shows_a_pipeline_invariant_as_missing_when_nothing_proves_it():
+def test_render_gives_the_pipeline_table_a_column_per_configuration():
     """A pipeline row among sink columns used to render as a line of dots,
     which reads as "not applicable" when the truth is "unproven"."""
     md = cm.render_invariants(inv_snap(invariants=PIPELINE))
 
-    assert "| Invariant | Claim | Proven |" in md
+    assert "| Invariant | Claim | `pipeline.stateful` |" in md
     assert "| `pipeline.commit.after_flush` | c | ❌ missing |" in md
 
 
 def test_render_shows_a_pipeline_invariant_as_covered_once_proven():
     s = inv_snap(
         invariants=PIPELINE,
-        evidence={"unit": {"TestA": [("pipeline.commit.after_flush", "pipeline")]}},
+        evidence={"unit": {"TestA": [("pipeline.commit.after_flush",
+                                      "pipeline.stateful")]}},
         results={"unit": {"TestA": cm.PASS}},
     )
     assert "| `pipeline.commit.after_flush` | c | ✅ u |" in cm.render_invariants(s)
@@ -1122,10 +1127,10 @@ def test_render_separates_pipeline_rows_from_integration_rows_in_one_family():
 
     assert md.count("## Invariants: checkpoint") == 1
     assert "| Invariant | Claim | `source.kafka` |" in md
-    assert "| Invariant | Claim | Proven |" in md
-    # The pipeline row never appears in the integration table.
-    integration_table = md.split("| Invariant | Claim | Proven |")[0]
-    assert "pipeline.commit.after_flush" not in integration_table
+    assert "| Invariant | Claim | `pipeline.stateful` |" in md
+    # The pipeline row never appears in the source table.
+    source_table = md.split("| Invariant | Claim | `pipeline.stateful` |")[0]
+    assert "pipeline.commit.after_flush" not in source_table
 
 
 # --- The summary a skimmer reads -------------------------------------------
@@ -1172,9 +1177,8 @@ def test_the_tally_counts_every_cell_by_state():
     assert unwired == 0
 
 
-def test_the_tally_counts_a_pipeline_invariant_once():
-    """One cell, counted like any other. It used to carry none and be tallied
-    separately as unwired."""
+def test_the_tally_counts_a_pipeline_cell_like_any_other():
+    """It used to carry no cell and be tallied separately as unwired."""
     tally, unwired = cm.invariant_tally(inv_snap(invariants=PIPELINE))
 
     assert unwired == 0
@@ -1498,18 +1502,19 @@ PIPELINE = [
 def test_a_pipeline_invariant_is_proven_by_a_marker():
     s = inv_snap(
         invariants=PIPELINE,
-        evidence={"unit": {"TestA": [("pipeline.commit.after_flush", "pipeline")]}},
+        evidence={"unit": {"TestA": [("pipeline.commit.after_flush",
+                                      "pipeline.stateful")]}},
         results={"unit": {"TestA": cm.PASS}},
     )
     inv = s["invariants"][0]
-    assert inv["integrations"]["pipeline"]["unit"]["status"] == "covered"
+    assert inv["integrations"]["pipeline.stateful"]["unit"]["status"] == "covered"
 
 
 def test_a_pipeline_invariant_with_no_marker_is_missing_not_absent():
     """It used to render "none collected", which reads as "not applicable"."""
     s = inv_snap(invariants=PIPELINE)
     inv = s["invariants"][0]
-    assert inv["integrations"]["pipeline"]["unit"]["status"] == "missing"
+    assert inv["integrations"]["pipeline.stateful"]["unit"]["status"] == "missing"
 
 
 def test_a_pipeline_marker_naming_a_sink_is_unknown():
@@ -1550,3 +1555,15 @@ def test_named_is_no_longer_a_verifier():
 def test_no_committed_invariant_uses_named():
     for inv in cm.load_invariants():
         assert inv["verified_by"] != "named", inv["id"]
+
+
+# The conformance harness emits a feature marker inside every subtest, so
+# nothing it runs relies on its name. An earlier attempt excused any
+# marker-carrying test from this report instead, which let a test contribute to
+# no feature while nothing said so.
+
+def test_a_test_with_neither_marker_nor_matching_name_is_still_unattributed():
+    coverage, secondary, unmatched, unknown = cm.build(
+        FEATURES, {}, {}, {}, {}, {"TestNobodyDeclaredThis": cm.PASS}, {})
+    s = cm.snapshot(FEATURES, coverage, secondary, unmatched, unknown)
+    assert s["unattributed"]["integration"] == ["TestNobodyDeclaredThis"]


### PR DESCRIPTION
Two changes to how the matrix knows things. The consume loop becomes a conformance subject, and attribution stops being inferred from test names.

## The pipeline is not one implementation

Four pipeline and lifecycle invariants were proven by markers on hand-written tests, on the grounds that the pipeline has one subject. It has eight.

Durable state changes what a commit means, and four paths reach `processBatch`:

| Line | Trigger |
|---|---|
| 513 | the batch reached its size |
| 422 | the flush interval elapsed |
| 523 | the source stream closed |
| 451 | a cancel that drains, through `context.WithoutCancel` |

Two configurations times four paths. Two combinations were tested. The other six held these guarantees by inspection.

`conformance.Pipelines` takes a configuration as its subject and runs every path against it. An invariant holds only if it holds on all four. A loop that commits after flushing when the batch fills, and before flushing when the interval elapses, loses rows on the second path alone.

The harness owns the instrumented parts. A recorder collects the event order, and the subject supplies only its options. What proving "commit after flush" means now lives in one place rather than in each test's assertions.

## Configurations are integrations

`pipeline.stateful` and `pipeline.stateless` get a column each:

```
| Invariant                          | pipeline.stateful | pipeline.stateless |
| pipeline.commit.after_flush        | ✅ u              | ✅ u               |
| pipeline.commit.nothing_on_failure | ✅ u              | ✅ u               |
| pipeline.state.with_offsets        | ✅ u              | — exempt           |
| lifecycle.drain.on_cancel          | ✅ u              | ✅ u               |
```

A single cell could not show that. Neither is a constructor case, so `constructed: false` keeps them out of the `Kinds()` agreement.

## One trigger was a lie, and its own mutation found it

`TriggerInterval` closed the source immediately, so the loop processed through the source-closed branch. Two triggers tested one path while the harness claimed four.

The stream now stays open and closes when the interval's flush lands: deterministic, no sleep. A panic planted in each branch confirms every one is reached.

```
batch-full (513):     MUTATION batch-full reached
drain (451):          MUTATION drain reached
source-closed (523):  MUTATION source-closed-or-tail reached
flush-interval:       panic: the flush-interval branch was reached
```

## A test says what it covers

A test used to attribute to the feature whose id its name happened to prefix. That mechanism had three edges, and two had already cut.

It credited a test whose name merely started the same way, and nothing could tell that apart from a test that meant it. It credited nothing when a name drifted, which is how #221 landed four tests covering no feature. And `go_prefix` lowercases after the first letter, so `sink.sqlcommand` reads as `TestSinkSqlcommand`: a test named `TestSinkSQLCommand` matched nothing, silently.

371 Go tests and 22 pytest markers now name their feature. `go_prefix`, `py_prefix`, `match` and `strip_level_prefix` are gone.

A subtest inherits its parent, because a subtest is part of that test rather than one of its own. Requiring a marker in every `t.Run` would put one in 149 closures to repeat what the enclosing test already said.

## Two rules the old mechanism hid

**A marker must fire before any early return.** Attribution used to survive a skip, because the name was still there. A marker placed after a `-short` guard fires never, and the test covers nothing. That is every integration test in the unit pass, and it cost a real regression before the diff caught it.

**A feature claimed twice counts once.** The conformance entry points reach the same marker twice, once before the skip and once when the harness finishes.

Both now have tests.

## Invariants are untouched

A test still cannot claim an invariant. The harness emits those, because a marker asserting that something was *proved* has to come from the thing that did the proving. A feature marker is a claim about scope, which the author is the right person to make.

## Evidence

Regenerated from all three suites, every one of the 34 features attributes to exactly the same tests at exactly the same levels as before. **Zero levels changed.** The mechanism moved; the result did not.

148 tooling tests and 16 Go packages pass. The gate exits 0 with no feature gaps, no invariant gaps, no unattributed tests and no unknown markers.

## Out of scope

A test can still name the wrong feature and nothing objects. That is a smaller lie than claiming an unproven invariant, and catching it needs something this design does not have.
