### PR TITLE
Invariants are safety or liveness, and the page says which

### DIFF
--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -27,6 +27,7 @@ invariants:
   # --- Resilience: the sink contract ---------------------------------------
   - id: sink.write.buffers_only
     family: resilience
+    class: safety
     applies_to: sink
     claim: WriteTable does not reach the destination. Only Flush does.
     verified_by: harness
@@ -38,6 +39,7 @@ invariants:
 
   - id: sink.flush.keeps_batch
     family: resilience
+    class: safety
     applies_to: sink
     claim: >
       A failed Flush leaves every undelivered row buffered. The next Flush
@@ -49,6 +51,7 @@ invariants:
 
   - id: sink.flush.no_hollow_success
     family: resilience
+    class: safety
     applies_to: sink
     claim: >
       Flush returns nil only when every row since the last success was
@@ -59,6 +62,7 @@ invariants:
 
   - id: sink.flush.preserves_order
     family: resilience
+    class: safety
     applies_to: sink
     claim: Rows reach the destination in WriteTable order, across a retry.
     verified_by: harness
@@ -66,6 +70,7 @@ invariants:
 
   - id: sink.flush.honours_context
     family: resilience
+    class: safety
     applies_to: sink
     claim: Flush returns ctx.Err() when the context ends. Rows stay buffered.
     verified_by: harness
@@ -74,6 +79,7 @@ invariants:
 
   - id: sink.flush.empty_is_noop
     family: resilience
+    class: safety
     applies_to: sink
     claim: Flush with nothing buffered returns nil and touches nothing.
     verified_by: harness
@@ -81,6 +87,7 @@ invariants:
 
   - id: sink.buffer.reports_depth
     family: resilience
+    class: safety
     applies_to: sink
     claim: >
       A sink reports how many rows it is holding, and the count rises when a
@@ -91,6 +98,7 @@ invariants:
 
   - id: sink.batch.reports_buffer
     family: resilience
+    class: safety
     applies_to: sink
     claim: Batch returns what is buffered, and nil when nothing is.
     verified_by: harness
@@ -98,6 +106,7 @@ invariants:
 
   - id: sink.error.classifies
     family: resilience
+    class: safety
     applies_to: sink
     claim: >
       The sink's errors classify as unreachable or rejected, so the retry
@@ -107,6 +116,7 @@ invariants:
 
   - id: sink.probe.fails_start
     family: resilience
+    class: safety
     applies_to: sink
     claim: >
       A Prober whose destination is unreachable fails the start once, without
@@ -117,6 +127,7 @@ invariants:
   # --- Checkpoint: the pipeline and source contract ------------------------
   - id: pipeline.commit.after_flush
     family: checkpoint
+    class: safety
     applies_to: pipeline
     claim: Offsets and state commit only after Flush returned nil.
     verified_by: harness
@@ -125,6 +136,7 @@ invariants:
 
   - id: pipeline.commit.nothing_on_failure
     family: checkpoint
+    class: safety
     applies_to: pipeline
     claim: A failed flush commits nothing. Not offsets, not state.
     verified_by: harness
@@ -133,6 +145,7 @@ invariants:
 
   - id: pipeline.state.with_offsets
     family: checkpoint
+    class: safety
     applies_to: pipeline
     claim: Window state and the offsets that produced it commit atomically.
     verified_by: harness
@@ -141,6 +154,7 @@ invariants:
 
   - id: source.commit.only_processed
     family: checkpoint
+    class: safety
     applies_to: source
     claim: >
       A source commits the marks the pipeline processed, never what it
@@ -151,6 +165,7 @@ invariants:
 
   - id: source.resume.from_committed
     family: checkpoint
+    class: safety
     applies_to: source
     claim: >
       Restart resumes at the committed position. No gap, and no replay before
@@ -160,6 +175,7 @@ invariants:
 
   - id: source.marks.never_regress
     family: checkpoint
+    class: safety
     applies_to: source
     claim: A committed position never moves backwards.
     verified_by: harness
@@ -167,6 +183,7 @@ invariants:
 
   - id: source.commit.on_revoke
     family: checkpoint
+    class: safety
     applies_to: source
     claim: >
       Marks commit when a partition is revoked, before the rebalance
@@ -178,6 +195,7 @@ invariants:
   # --- Types: per integration, from its declared table ---------------------
   - id: type.roundtrip
     family: types
+    class: safety
     applies_to: sink
     claim: >
       Every declared Arrow type reads back with the declared outcome: exact,
@@ -188,6 +206,7 @@ invariants:
 
   - id: type.null
     family: types
+    class: safety
     applies_to: sink
     claim: A null in every declared type reads back as declared.
     verified_by: typetable
@@ -195,6 +214,7 @@ invariants:
 
   - id: type.timestamp.instant
     family: types
+    class: safety
     applies_to: sink
     claim: >
       A timestamp reads back as the same instant. Zone-less is UTC, and the
@@ -205,6 +225,7 @@ invariants:
 
   - id: type.nested
     family: types
+    class: safety
     applies_to: sink
     claim: >
       list, struct, list-of-struct and list-of-list read back, or are declared
@@ -214,6 +235,7 @@ invariants:
 
   - id: type.string.fidelity
     family: types
+    class: safety
     applies_to: sink
     claim: Unicode, escapes and the empty string round-trip byte for byte.
     verified_by: typetable
@@ -222,6 +244,7 @@ invariants:
 
   - id: type.undeclared.fails_loud
     family: types
+    class: safety
     applies_to: sink
     claim: >
       An Arrow type absent from the table fails the batch with a coded error.
@@ -232,14 +255,43 @@ invariants:
   # --- Lifecycle -----------------------------------------------------------
   - id: lifecycle.drain.on_cancel
     family: lifecycle
+    class: safety
     applies_to: pipeline
     claim: Cancel or SIGTERM flushes the buffered batch, then commits.
     verified_by: harness
     requires: []
     enforced: true
 
+  # --- Liveness: the pipeline makes progress -------------------------------
+  # Every claim above is safety: nothing bad happens. None of them says the
+  # pipeline does anything, and a sink that never flushes satisfies all of
+  # them. These are the claims that it does.
+  - id: pipeline.flush.eventually
+    family: lifecycle
+    class: liveness
+    applies_to: pipeline
+    claim: >
+      A batch that never reaches batchSize still reaches the sink, within the
+      flush interval.
+    verified_by: harness
+    requires: []
+    enforced: true
+
+  - id: pipeline.progress.no_silent_stall
+    family: lifecycle
+    class: liveness
+    applies_to: pipeline
+    claim: >
+      A configuration that cannot make progress fails at startup rather than
+      running quietly. flush_interval_seconds of 0 removes the ticker
+      entirely, so a batch a low-traffic topic never fills waits forever.
+      Unenforced and untracked: the engine permits the configuration today.
+    verified_by: harness
+    requires: []
+
   - id: lifecycle.drain.bounded
     family: lifecycle
+    class: liveness
     applies_to: pipeline
     claim: The drain finishes or fails inside its deadline.
     verified_by: harness
@@ -248,6 +300,7 @@ invariants:
 
   - id: lifecycle.close.idempotent
     family: lifecycle
+    class: safety
     applies_to: sink
     claim: Close twice is safe.
     verified_by: harness
@@ -255,6 +308,7 @@ invariants:
 
   - id: pipeline.batch.timeout
     family: lifecycle
+    class: liveness
     applies_to: pipeline
     claim: >
       A batch whose query exceeds the timeout fails the batch, not the
@@ -266,6 +320,7 @@ invariants:
   # --- Error policy --------------------------------------------------------
   - id: error.dlq.carries_provenance
     family: errors
+    class: safety
     applies_to: pipeline
     claim: A DLQ record carries the payload, offset, partition and reason.
     verified_by: harness
@@ -274,6 +329,7 @@ invariants:
 
   - id: error.bad_record.threshold
     family: errors
+    class: safety
     applies_to: pipeline
     claim: >
       N bad records in a window fail the pipeline rather than discarding

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -628,6 +628,7 @@
             "TestPipelineStateful_Conformance/lifecycle.drain.on_cancel",
             "TestPipelineStateful_Conformance/pipeline.commit.after_flush",
             "TestPipelineStateful_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateful_Conformance/pipeline.flush.eventually",
             "TestPipelineStateful_Conformance/pipeline.state.with_offsets",
             "TestStateDurability_DBSecondConnectionSeesOnlyCommittedState",
             "TestStateDurability_OpenPathEmptyPathIsInMemory",
@@ -819,6 +820,7 @@
             "TestPipelineStateless_Conformance/lifecycle.drain.on_cancel",
             "TestPipelineStateless_Conformance/pipeline.commit.after_flush",
             "TestPipelineStateless_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateless_Conformance/pipeline.flush.eventually",
             "TestPipelineStateless_Conformance/pipeline.state.with_offsets",
             "TestPipelineStateless_KeepsNoDurableState"
           ],
@@ -1312,6 +1314,7 @@
             "TestToolingConformanceDescribe_NamesTheRowsItFound",
             "TestToolingConformancePipelines_AStatelessSubjectSkipsStateInvariants",
             "TestToolingConformancePipelines_CatchesACommitBeforeTheFlush",
+            "TestToolingConformancePipelines_JudgeOneLivenessClaim",
             "TestToolingConformancePipelines_JudgeOnlyDeclaredInvariants",
             "TestToolingConformancePipelines_RunsEveryTrigger",
             "TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink",
@@ -1392,6 +1395,7 @@
       "applies_to": "sink",
       "claim": "WriteTable does not reach the destination. Only Flush does.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": true,
       "integrations": {
@@ -1500,6 +1504,7 @@
       "applies_to": "sink",
       "claim": "A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": true,
       "integrations": {
@@ -1611,6 +1616,7 @@
       "applies_to": "sink",
       "claim": "Flush returns nil only when every row since the last success was acknowledged by the destination.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -1712,6 +1718,7 @@
       "applies_to": "sink",
       "claim": "Rows reach the destination in WriteTable order, across a retry.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -1810,6 +1817,7 @@
       "applies_to": "sink",
       "claim": "Flush returns ctx.Err() when the context ends. Rows stay buffered.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -1911,6 +1919,7 @@
       "applies_to": "sink",
       "claim": "Flush with nothing buffered returns nil and touches nothing.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2006,6 +2015,7 @@
       "applies_to": "sink",
       "claim": "A sink reports how many rows it is holding, and the count rises when a flush fails and falls to zero when one succeeds.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": true,
       "integrations": {
@@ -2114,6 +2124,7 @@
       "applies_to": "sink",
       "claim": "Batch returns what is buffered, and nil when nothing is.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2212,6 +2223,7 @@
       "applies_to": "sink",
       "claim": "The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2310,6 +2322,7 @@
       "applies_to": "sink",
       "claim": "A Prober whose destination is unreachable fails the start once, without retrying.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2414,6 +2427,7 @@
       "applies_to": "pipeline",
       "claim": "Offsets and state commit only after Flush returned nil.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": true,
       "integrations": {
@@ -2457,6 +2471,7 @@
       "applies_to": "pipeline",
       "claim": "A failed flush commits nothing. Not offsets, not state.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": true,
       "integrations": {
@@ -2500,6 +2515,7 @@
       "applies_to": "pipeline",
       "claim": "Window state and the offsets that produced it commit atomically.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": true,
       "integrations": {
@@ -2544,6 +2560,7 @@
       "applies_to": "source",
       "claim": "A source commits the marks the pipeline processed, never what it fetched.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2606,6 +2623,7 @@
       "applies_to": "source",
       "claim": "Restart resumes at the committed position. No gap, and no replay before it.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2665,6 +2683,7 @@
       "applies_to": "source",
       "claim": "A committed position never moves backwards.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2724,6 +2743,7 @@
       "applies_to": "source",
       "claim": "Marks commit when a partition is revoked, before the rebalance completes.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2784,6 +2804,7 @@
       "applies_to": "sink",
       "claim": "Every declared Arrow type reads back with the declared outcome: exact, coerced by the stated rule, or unsupported with a coded error.",
       "verified_by": "typetable",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2884,6 +2905,7 @@
       "applies_to": "sink",
       "claim": "A null in every declared type reads back as declared.",
       "verified_by": "typetable",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -2979,6 +3001,7 @@
       "applies_to": "sink",
       "claim": "A timestamp reads back as the same instant. Zone-less is UTC, and the host zone never leaks into the type.",
       "verified_by": "typetable",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3077,6 +3100,7 @@
       "applies_to": "sink",
       "claim": "list, struct, list-of-struct and list-of-list read back, or are declared unsupported. Never silently flattened.",
       "verified_by": "typetable",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3172,6 +3196,7 @@
       "applies_to": "sink",
       "claim": "Unicode, escapes and the empty string round-trip byte for byte.",
       "verified_by": "typetable",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3270,6 +3295,7 @@
       "applies_to": "sink",
       "claim": "An Arrow type absent from the table fails the batch with a coded error. Never coerced silently.",
       "verified_by": "typetable",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3365,6 +3391,7 @@
       "applies_to": "pipeline",
       "claim": "Cancel or SIGTERM flushes the buffered batch, then commits.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": true,
       "integrations": {
@@ -3403,11 +3430,96 @@
       }
     },
     {
+      "id": "pipeline.flush.eventually",
+      "family": "lifecycle",
+      "applies_to": "pipeline",
+      "claim": "A batch that never reaches batchSize still reaches the sink, within the flush interval.",
+      "verified_by": "harness",
+      "class": "liveness",
+      "requires": [],
+      "enforced": true,
+      "integrations": {
+        "pipeline.stateful": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestPipelineStateful_Conformance/pipeline.flush.eventually"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestPipelineStateless_Conformance/pipeline.flush.eventually"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
+      "id": "pipeline.progress.no_silent_stall",
+      "family": "lifecycle",
+      "applies_to": "pipeline",
+      "claim": "A configuration that cannot make progress fails at startup rather than running quietly. flush_interval_seconds of 0 removes the ticker entirely, so a batch a low-traffic topic never fills waits forever. Unenforced and untracked: the engine permits the configuration today.",
+      "verified_by": "harness",
+      "class": "liveness",
+      "requires": [],
+      "enforced": false,
+      "integrations": {
+        "pipeline.stateful": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
+          "unit": {
+            "status": "missing",
+            "tests": []
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      }
+    },
+    {
       "id": "lifecycle.drain.bounded",
       "family": "lifecycle",
       "applies_to": "pipeline",
       "claim": "The drain finishes or fails inside its deadline.",
       "verified_by": "harness",
+      "class": "liveness",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3448,6 +3560,7 @@
       "applies_to": "sink",
       "claim": "Close twice is safe.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3543,6 +3656,7 @@
       "applies_to": "pipeline",
       "claim": "A batch whose query exceeds the timeout fails the batch, not the process.",
       "verified_by": "harness",
+      "class": "liveness",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3583,6 +3697,7 @@
       "applies_to": "pipeline",
       "claim": "A DLQ record carries the payload, offset, partition and reason.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {
@@ -3623,6 +3738,7 @@
       "applies_to": "pipeline",
       "claim": "N bad records in a window fail the pipeline rather than discarding forever.",
       "verified_by": "harness",
+      "class": "safety",
       "requires": [],
       "enforced": false,
       "integrations": {

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -36,12 +36,12 @@ names every one of them.
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
 | `handler.structured` | Binds a declared schema, ingesting through Arrow. | ✅ | — | ✅ | 8 |
-| `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 16 |
+| `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 17 |
 | `state.offsets` | Kafka positions are stored in DuckDB and resumed on restart. | ✅ | — | ✅ | 22 |
 | `state.corruption` | A damaged state file fails the start rather than silently resetting. | ✅ | — | ✅ | 6 |
 | `lifecycle.drain` | SIGTERM writes the buffered batch before exiting. | ✅ | — | ✅ | 2 |
 | `lifecycle.exit_codes` | The process exit status carries the error code a supervisor reads. | ✅ | — | ✅ | 8 |
-| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 20 |
+| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 21 |
 | `error.taxonomy` | Every failure carries a class.domain.reason code. | ✅ | — | — | 16 |
 | `error.raise` | Policy RAISE stops the pipeline on a bad record. | ✅ | — | — | 1 |
 | `error.ignore` | Policy IGNORE drops a bad record and keeps the pipeline running. | ✅ | — | ✅ | 5 |
@@ -54,7 +54,7 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
-| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 26 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 27 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
 **34 features declared. 34 have at least one passing test attributed at every level they require, so 0 gap(s).**
@@ -65,7 +65,14 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**29 invariants declared. Of 130 (invariant, integration) cells: 22 proven, 88 missing, 0 skipped, 0 failing, 20 exempt. 0 gap(s), because no invariant requires a level yet.**
+**31 invariants declared: 27 safety and 4 liveness. Of 134 (invariant, integration) cells: 24 proven, 90 missing, 0 skipped, 0 failing, 20 exempt. 0 gap(s).**
+
+Safety says nothing bad happens. Liveness says something good
+eventually does, and the two are not interchangeable: a sink that
+never flushes satisfies every safety invariant on this page.
+`keeps_batch` holds if you never flush, and `commit.after_flush`
+holds if you never commit. Only a liveness claim says the pipeline
+does anything at all.
 
 ## Why invariants, and not the test count
 
@@ -117,7 +124,7 @@ shipped image. **exempt** carries its reason in the JSON, and
 **missing** means no evidence. Nothing here fails the build until an
 invariant's `requires` is filled in, and none is yet.
 
-## Invariants: resilience
+## Safety invariants: resilience
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -132,7 +139,7 @@ invariant's `requires` is filled in, and none is yet.
 | `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
 
-## Invariants: checkpoint
+## Safety invariants: checkpoint
 
 | Invariant | Claim | `source.kafka` | `source.websocket` | `source.webhook` |
 | --- | --- | --- | --- | --- |
@@ -154,7 +161,7 @@ drains. An invariant holds only if it holds on all four.
 | `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | ✅ u | ✅ u |
 | `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | ✅ u | — exempt |
 
-## Invariants: types
+## Safety invariants: types
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -165,7 +172,7 @@ drains. An invariant holds only if it holds on all four.
 | `type.string.fidelity` | Unicode, escapes and the empty string round-trip byte for byte. *(violated once: #149)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 | `type.undeclared.fails_loud` | An Arrow type absent from the table fails the batch with a coded error. Never coerced silently. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
 
-## Invariants: lifecycle
+## Safety invariants: lifecycle
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -181,10 +188,8 @@ drains. An invariant holds only if it holds on all four.
 | Invariant | Claim | `pipeline.stateful` | `pipeline.stateless` |
 | --- | --- | --- | --- |
 | `lifecycle.drain.on_cancel` | Cancel or SIGTERM flushes the buffered batch, then commits. | ✅ u | ✅ u |
-| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ missing | ❌ missing |
-| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ missing | ❌ missing |
 
-## Invariants: errors
+## Safety invariants: errors
 
 These errors invariants are properties of the consume loop
 rather than of anything a config file names. The columns are
@@ -197,4 +202,20 @@ drains. An invariant holds only if it holds on all four.
 | --- | --- | --- | --- |
 | `error.dlq.carries_provenance` | A DLQ record carries the payload, offset, partition and reason. *(declared, tracked by #166)* | ❌ missing | ❌ missing |
 | `error.bad_record.threshold` | N bad records in a window fail the pipeline rather than discarding forever. *(declared, tracked by #166)* | ❌ missing | ❌ missing |
+
+## Liveness invariants: lifecycle
+
+These lifecycle invariants are properties of the consume loop
+rather than of anything a config file names. The columns are
+its configurations, and `internal/conformance` runs each one
+through every path that reaches a batch: the batch filling, the
+flush interval elapsing, the source closing, and a cancel that
+drains. An invariant holds only if it holds on all four.
+
+| Invariant | Claim | `pipeline.stateful` | `pipeline.stateless` |
+| --- | --- | --- | --- |
+| `pipeline.flush.eventually` | A batch that never reaches batchSize still reaches the sink, within the flush interval. | ✅ u | ✅ u |
+| `pipeline.progress.no_silent_stall` | A configuration that cannot make progress fails at startup rather than running quietly. flush_interval_seconds of 0 removes the ticker entirely, so a batch a low-traffic topic never fills waits forever. Unenforced and untracked: the engine permits the configuration today. | ❌ missing | ❌ missing |
+| `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ missing | ❌ missing |
+| `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ missing | ❌ missing |
 

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -548,6 +548,23 @@ func pipelineVerdictsFor(t *testing.T, s PipelineSubject) map[string]verdict {
 	for _, v := range pipelineVerdicts(t, s) {
 		out[v.invariant] = v
 	}
-	assert.Equal(t, 4, len(out))
+	assert.Equal(t, 5, len(out))
 	return out
+}
+
+// The liveness claim is the only one that says the pipeline does anything.
+// Every safety verdict above holds for a pipeline that never flushes, so a
+// harness that judged safety alone would call a permanently stalled loop
+// conformant.
+func TestToolingConformancePipelines_JudgeOneLivenessClaim(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+
+	vs := pipelineVerdictsFor(t, PipelineSubject{
+		Integration: "pipeline.stateless",
+		KeepsState:  false,
+		Options:     func(*Recorder) []core.TurbineOption { return nil },
+	})
+
+	assert.Equal(t, "", vs[flushEventually].failure)
+	assert.Equal(t, "", vs[flushEventually].skipped)
 }

--- a/internal/conformance/pipeline.go
+++ b/internal/conformance/pipeline.go
@@ -120,6 +120,7 @@ const (
 	commitNothingOnFail = "pipeline.commit.nothing_on_failure"
 	stateWithOffsets    = "pipeline.state.with_offsets"
 	drainOnCancel       = "lifecycle.drain.on_cancel"
+	flushEventually     = "pipeline.flush.eventually"
 )
 
 // pipelineVerdicts runs every trigger against the subject and judges each
@@ -136,6 +137,7 @@ func pipelineVerdicts(t *testing.T, s PipelineSubject) []verdict {
 	onFailure := verdict{invariant: commitNothingOnFail}
 	withOffsets := verdict{invariant: stateWithOffsets}
 	drain := verdict{invariant: drainOnCancel}
+	eventually := verdict{invariant: flushEventually}
 
 	if !s.KeepsState {
 		withOffsets.skipped = s.Integration + " keeps no durable state, so " +
@@ -173,7 +175,14 @@ func pipelineVerdicts(t *testing.T, s PipelineSubject) []verdict {
 		drain.failure = err.Error()
 	}
 
-	return []verdict{afterFlush, onFailure, withOffsets, drain}
+	// The only liveness claim here. Everything above says the pipeline does
+	// nothing wrong; this says it does something. A sink that never flushed
+	// would satisfy every one of them and fail this one alone.
+	if err := checkFlushEventually(t, s); err != nil {
+		eventually.failure = err.Error()
+	}
+
+	return []verdict{afterFlush, onFailure, withOffsets, drain, eventually}
 }
 
 // checkCommitAfterFlush runs one trigger and holds the event order.
@@ -268,6 +277,39 @@ func checkDrain(t *testing.T, s PipelineSubject) error {
 	return nil
 }
 
+// checkFlushEventually holds that a batch too small to fill still lands.
+//
+// The interval scenario writes fewer messages than batchSize and lets the
+// ticker fire. Without that path a low-traffic topic -- and any push source
+// between deliveries -- buffers until the process dies.
+func checkFlushEventually(t *testing.T, s PipelineSubject) error {
+	t.Helper()
+
+	run := runPipeline(t, s, TriggerInterval, faults{})
+	if run.stalled {
+		return fmt.Errorf(
+			"a batch of %d, below batchSize, did not reach the sink within %s "+
+				"of a %s flush interval; the run had to be cancelled to end it",
+			intervalRows, stallTimeout, 100*time.Millisecond)
+	}
+	if run.err != nil {
+		return fmt.Errorf("interval: the pipeline failed with no fault "+
+			"injected: %v", run.err)
+	}
+	if run.flushes == 0 {
+		return errors.New(
+			"a batch smaller than batchSize never reached the sink; only the " +
+				"flush interval can move it, and a pipeline that waits for a " +
+				"batch that never fills stalls for as long as it runs")
+	}
+	if run.rows != intervalRows {
+		return fmt.Errorf(
+			"the flush interval delivered %d of %d buffered rows",
+			run.rows, intervalRows)
+	}
+	return nil
+}
+
 func sameOrder(got, want []string) bool {
 	if len(got) != len(want) {
 		return false
@@ -300,11 +342,25 @@ type outcome struct {
 	flushes       int
 	sourceCommits int
 	err           error
+
+	// stalled is set when the run had to be cancelled to end it. A liveness
+	// check must never wait on the thing it is testing: a pipeline that never
+	// flushes would otherwise hang the suite rather than fail one invariant.
+	stalled bool
 }
 
 // drainRows is the number of messages the drain scenario buffers. Small, and
 // larger than one, so a drain that writes a partial batch is visible.
 const drainRows = 10
+
+// intervalRows is the partial batch the flush interval has to move. Fewer than
+// any batchSize the harness sets, so the batch can never fill.
+const intervalRows = 2
+
+// stallTimeout bounds the interval scenario at many times its 100ms tick. A
+// pipeline that never flushes is what this check exists to catch, so it must
+// report rather than wait.
+const stallTimeout = 5 * time.Second
 
 // runPipeline builds the subject's pipeline over the harness's instrumented
 // parts and runs it until the trigger fires.
@@ -314,6 +370,7 @@ func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) out
 	rec := &Recorder{failOffsets: f.offsets}
 	src := &recordingSource{rec: rec}
 	sink := &recordingSink{rec: rec, fail: f.flush}
+	var flushed chan struct{}
 
 	// Sized so only the intended trigger can fire. A batch size above the
 	// message count keeps the batch from filling; an hour-long interval keeps
@@ -323,20 +380,26 @@ func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) out
 	case TriggerBatchFull:
 		src.batch = messages(4)
 	case TriggerInterval:
+		// intervalRows is below every batchSize the harness uses, so only the
+		// ticker can move them.
 		// The stream stays open so the select blocks on it and the ticker
 		// wins. Closing it here instead would end the run through the
 		// source-closed path, which is a different branch: an earlier version
 		// did exactly that and tested one path twice.
-		src.batch = messages(2)
+		src.batch = messages(intervalRows)
 		src.block = true
 		batchSize, interval = 1000, 100*time.Millisecond
 
 		// Close as soon as the interval's flush lands, so the run ends
 		// deterministically and no second tick can fire.
+		flushed = make(chan struct{})
 		var once sync.Once
 		rec.onEvent = func(event string) {
 			if event == "flush" || event == "flush-failed" {
-				once.Do(func() { go src.Close() })
+				once.Do(func() {
+					close(flushed)
+					go src.Close()
+				})
 			}
 		}
 	case TriggerSourceClosed:
@@ -358,6 +421,24 @@ func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) out
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	stalled := false
+	if flushed != nil {
+		// The run ends when the flush lands. If it never does, end it here
+		// instead of waiting: that is the failure, not a reason to hang.
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-flushed:
+			case <-time.After(stallTimeout):
+				stalled = true
+				cancel()
+				go src.Close()
+			case <-done:
+			}
+		}()
+		defer close(done)
+	}
+
 	if trigger == TriggerDrain {
 		go func() {
 			src.wrote.Wait()
@@ -373,6 +454,7 @@ func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) out
 		flushes:       sink.Flushes(),
 		sourceCommits: src.Commits(),
 		err:           err,
+		stalled:       stalled,
 	}
 }
 

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -55,6 +55,19 @@ INTEGRATION_PREFIX = "TestIntegration"
 # The closed vocabularies invariants.yml may use. A value outside one of them
 # is a typo, and a typo must not reach the matrix as a missing cell.
 FAMILIES = ("resilience", "checkpoint", "types", "lifecycle", "errors")
+
+# What kind of claim an invariant makes, which is orthogonal to its family.
+#
+#   safety    nothing bad happens: never commit a position for rows the sink
+#             did not take, never lose a batch a flush could not deliver.
+#   liveness  something good eventually happens: buffered rows reach the sink,
+#             a drain finishes, a stalled configuration fails at startup.
+#
+# The distinction is not academic. A sink that never flushes satisfies every
+# safety invariant here -- keeps_batch holds vacuously if you never flush, and
+# commit.after_flush holds if you never commit. Only a liveness claim says the
+# pipeline does anything at all.
+CLASSES = ("safety", "liveness")
 KINDS = ("sink", "source", "handler", "pipeline")
 # How an invariant collects evidence. Both are explicit markers: a test says
 # what it proves. `named` used to mean "a test whose name matches the id",
@@ -101,12 +114,16 @@ def validate_registries(invariants, integrations, features):
             problems.append(f"invariants.yml: duplicate id {fid}")
         by_id[fid] = inv
 
-        for key in ("family", "applies_to", "claim", "verified_by", "requires"):
+        for key in ("family", "class", "applies_to", "claim", "verified_by",
+                    "requires"):
             if key not in inv:
                 problems.append(f"invariants.yml: {fid} has no {key}")
         if inv.get("family") not in FAMILIES:
             problems.append(
                 f"invariants.yml: {fid} family {inv.get('family')!r} is not one of {FAMILIES}")
+        if inv.get("class") not in CLASSES:
+            problems.append(
+                f"invariants.yml: {fid} class {inv.get('class')!r} is not one of {CLASSES}")
         if inv.get("applies_to") not in KINDS:
             problems.append(
                 f"invariants.yml: {fid} applies_to {inv.get('applies_to')!r} is not one of {KINDS}")
@@ -371,6 +388,7 @@ def snapshot_invariants(invariants, integrations, built):
             # words keeps the JSON diff stable when the wrapping changes.
             "claim": " ".join(inv["claim"].split()),
             "verified_by": inv["verified_by"],
+            "class": inv["class"],
             "requires": sorted(required),
             "enforced": bool(inv.get("enforced")),
             "integrations": {},
@@ -593,13 +611,22 @@ def render(snap):
     if snap.get("invariants"):
         tally, unwired = invariant_tally(snap)
         total = sum(tally.values())
+        safety = sum(1 for i in snap["invariants"] if i["class"] == "safety")
+        liveness = sum(1 for i in snap["invariants"] if i["class"] == "liveness")
+
         lines += [
-            f"**{len(snap['invariants'])} invariants declared. Of {total} "
-            f"(invariant, integration) cells: {tally['covered']} proven, "
-            f"{tally['missing']} missing, {tally['skipped']} skipped, "
-            f"{tally['failing']} failing, {tally['exempt']} exempt. "
-            f"{len(snap['invariant_gaps'])} gap(s), because no invariant "
-            "requires a level yet.**",
+            f"**{len(snap['invariants'])} invariants declared: {safety} safety "
+            f"and {liveness} liveness. Of {total} (invariant, integration) "
+            f"cells: {tally['covered']} proven, {tally['missing']} missing, "
+            f"{tally['skipped']} skipped, {tally['failing']} failing, "
+            f"{tally['exempt']} exempt. {len(snap['invariant_gaps'])} gap(s).**",
+            "",
+            "Safety says nothing bad happens. Liveness says something good",
+            "eventually does, and the two are not interchangeable: a sink that",
+            "never flushes satisfies every safety invariant on this page.",
+            "`keeps_batch` holds if you never flush, and `commit.after_flush`",
+            "holds if you never commit. Only a liveness claim says the pipeline",
+            "does anything at all.",
             "",
         ]
         if unwired:
@@ -859,13 +886,19 @@ def render_invariants(snap):
         "",
     ]
 
-    families = []
+    # Grouped by class first. A liveness section that is entirely red sitting
+    # beside a green safety one is the imbalance a reader has to see, and a
+    # column would let it pass unnoticed.
+    groups = []
     for inv in snap["invariants"]:
-        if inv["family"] not in families:
-            families.append(inv["family"])
+        key = (inv["class"], inv["family"])
+        if key not in groups:
+            groups.append(key)
+    groups.sort(key=lambda k: (CLASSES.index(k[0]), FAMILIES.index(k[1])))
 
-    for family in families:
-        rows = [i for i in snap["invariants"] if i["family"] == family]
+    for cls, family in groups:
+        rows = [i for i in snap["invariants"]
+                if i["class"] == cls and i["family"] == family]
 
         # Split on what the invariant applies to. A pipeline row in a table of
         # sink columns renders as a line of dots, which reads as "not
@@ -879,7 +912,7 @@ def render_invariants(snap):
                 if integ not in columns:
                     columns.append(integ)
 
-        lines += [f"## Invariants: {family}", ""]
+        lines += [f"## {cls.capitalize()} invariants: {family}", ""]
 
         if per_integration:
             lines.append("| Invariant | Claim | "

--- a/tests/tooling/test_coverage_matrix.py
+++ b/tests/tooling/test_coverage_matrix.py
@@ -480,10 +480,12 @@ def test_the_check_exits_non_zero_on_a_gap(tmp_path):
 # --- Registries ------------------------------------------------------------
 
 INVARIANTS = [
-    {"id": "sink.flush.keeps_batch", "family": "resilience", "applies_to": "sink",
-     "claim": "kept", "verified_by": "harness", "requires": []},
+    {"id": "sink.flush.keeps_batch", "family": "resilience", "class": "safety",
+     "applies_to": "sink", "claim": "kept", "verified_by": "harness",
+     "requires": []},
     {"id": "source.commit.only_processed", "family": "checkpoint",
-     "applies_to": "source", "claim": "c", "verified_by": "harness", "requires": []},
+     "class": "safety", "applies_to": "source", "claim": "c",
+     "verified_by": "harness", "requires": []},
 ]
 
 INTEGRATIONS = [
@@ -683,8 +685,8 @@ def test_a_tracked_invariant_renders_as_declared_unenforced():
 def test_render_carries_one_table_per_family():
     s = inv_snap()
     md = cm.render_invariants(s)
-    assert "## Invariants: resilience" in md
-    assert "## Invariants: checkpoint" in md
+    assert "## Safety invariants: resilience" in md
+    assert "## Safety invariants: checkpoint" in md
     assert "| `sink.flush.keeps_batch` |" in md
 
 
@@ -1120,7 +1122,7 @@ def test_render_separates_pipeline_rows_from_integration_rows_in_one_family():
     ]
     md = cm.render_invariants(inv_snap(invariants=mixed))
 
-    assert md.count("## Invariants: checkpoint") == 1
+    assert md.count("## Safety invariants: checkpoint") == 1
     assert "| Invariant | Claim | `source.kafka` |" in md
     assert "| Invariant | Claim | `pipeline.stateful` |" in md
     # The pipeline row never appears in the source table.
@@ -1500,8 +1502,8 @@ def test_the_committed_registry_marks_the_double_test_only():
 
 PIPELINE = [
     {"id": "pipeline.commit.after_flush", "family": "checkpoint",
-     "applies_to": "pipeline", "claim": "c", "verified_by": "harness",
-     "requires": []},
+     "class": "safety", "applies_to": "pipeline", "claim": "c",
+     "verified_by": "harness", "requires": []},
 ]
 
 
@@ -1602,3 +1604,71 @@ def test_a_feature_claimed_twice_by_one_test_counts_once():
         go_covers={"TestX": ["sink.clickhouse", "sink.clickhouse"]},
     )
     assert level(s, "sink.clickhouse", "unit")["tests"] == ["TestX"]
+
+
+# --- Safety and liveness ----------------------------------------------------
+#
+# Every invariant declared before this was a safety property: nothing bad
+# happens. None was a liveness property: something good eventually happens.
+#
+# That gap is not cosmetic. A sink that never flushes satisfies every safety
+# invariant in the file. keeps_batch holds vacuously if you never flush;
+# commit.after_flush holds if you never commit. A pipeline that buffers forever
+# reads as fully conformant, which is the one outcome the matrix must never
+# report as fine.
+
+SAFETY = dict(INVARIANTS[0], **{"class": "safety"})
+LIVENESS = {"id": "pipeline.flush.eventually", "family": "lifecycle",
+            "class": "liveness", "applies_to": "pipeline",
+            "claim": "buffered rows reach the sink within the flush interval",
+            "verified_by": "harness", "requires": []}
+
+
+def test_every_committed_invariant_declares_its_class():
+    for inv in cm.load_invariants():
+        assert inv.get("class") in ("safety", "liveness"), inv["id"]
+
+
+def test_validate_rejects_an_invariant_with_no_class():
+    bad = [{k: v for k, v in SAFETY.items() if k != "class"}]
+    problems = cm.validate_registries(bad, INTEGRATIONS, FEATURES)
+    assert any("class" in p for p in problems)
+
+
+def test_validate_rejects_an_unknown_class():
+    bad = [dict(SAFETY, **{"class": "eventual"})]
+    problems = cm.validate_registries(bad, INTEGRATIONS, FEATURES)
+    assert any("eventual" in p for p in problems)
+
+
+def test_the_registry_declares_at_least_one_liveness_invariant():
+    """A file of safety claims alone cannot say the pipeline does anything."""
+    classes = {i["class"] for i in cm.load_invariants()}
+    assert "liveness" in classes
+
+
+def test_render_groups_tables_by_class_then_family():
+    """Grouping rather than a column, so a liveness section that is entirely
+    red is visible beside a green safety one."""
+    s = inv_snap(invariants=[SAFETY, LIVENESS])
+    md = cm.render_invariants(s)
+
+    assert "## Safety invariants: resilience" in md
+    assert "## Liveness invariants: lifecycle" in md
+
+
+def test_render_counts_each_class_separately():
+    """Beside the feature count, because a reader who stops at the first bold
+    line should see both numbers."""
+    s = snap()
+    s.update(inv_snap(invariants=[SAFETY, LIVENESS]))
+    md = cm.render(s)
+    assert "1 safety" in md and "1 liveness" in md
+
+
+def test_render_says_what_safety_alone_cannot_prove():
+    """The vacuity is the reason the distinction exists, and a reader cannot
+    infer it from a page of green cells."""
+    s = snap()
+    s.update(inv_snap(invariants=[SAFETY, LIVENESS]))
+    assert "never flushes" in cm.render(s)


### PR DESCRIPTION
Every invariant declared before this was a safety property: *nothing bad happens*. Never commit a position for rows the sink did not take. Never lose a batch a flush could not deliver.

None was a liveness property, and the gap is not cosmetic.

## A sink that never flushes satisfies all 27 safety invariants

`keeps_batch` holds vacuously if you never flush. `commit.after_flush` holds if you never commit. `no_hollow_success` holds if you never return. A pipeline that buffers until the process dies read as fully conformant, which is the one outcome this matrix must never report as fine.

## The classification

`class: safety | liveness` is required on every invariant and validated against a closed set. It is orthogonal to `family`: family says what area a claim is about, class says what kind of claim it is.

Tables group by class before family, so the liveness section sits beside the safety one rather than hiding inside it as a column. The summary counts each and states the vacuity outright, because a reader cannot infer it from a page of green cells.

## Two liveness invariants, both from guarantees the code already states

**`pipeline.flush.eventually`** is enforced and proven on both configurations. The claim is `turbine.go:400`'s own: *"A batch that never reaches batchSize still has to reach the sink, or a low-traffic topic -- and any push source between deliveries -- stalls indefinitely."* The interval scenario was already doing the work and never claimed it.

**`pipeline.progress.no_silent_stall`** is declared and unproven. `flush_interval_seconds: 0` removes the ticker entirely, so a batch a low-traffic topic never fills waits forever, and nothing rejects the configuration. The CLI defaults to 30s, so no shipped config hits it.

## A liveness check must never wait on the thing it tests

The interval scenario ends when the flush lands, so a pipeline that never flushes would have hung the suite rather than failed one invariant. It is bounded now and reports the stall.

## Evidence

Disabling the flush-interval branch fails `pipeline.flush.eventually` alone:

```
--- FAIL: TestPipelineStateful_Conformance/pipeline.flush.eventually
    a batch of 2, below batchSize, did not reach the sink within 5s of a
    100ms flush interval; the run had to be cancelled to end it
```

All four safety invariants still pass against that same stalled loop. That is the whole argument for the distinction.

155 tooling tests and 16 Go packages pass. Eight invariants enforced. The gate exits 0 with no gaps, no unattributed tests and no unknown markers.

## The state of liveness

| Invariant | Proven | Note |
|---|---|---|
| `pipeline.flush.eventually` | yes, both configurations | enforced |
| `pipeline.progress.no_silent_stall` | no | the engine permits the configuration |
| `lifecycle.drain.bounded` | no | #161 |
| `pipeline.batch.timeout` | no | #163 |

One of four. That is the honest picture, and it should stay uncomfortable until it moves.

## Out of scope

`pipeline.progress.no_silent_stall` has no tracking issue. It needs one, and rejecting a stalled configuration at startup is a behaviour change worth its own review.
