### PR TITLE
The pipeline is judged on rows a real table holds

### DIFF
--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -134,6 +134,23 @@ invariants:
     requires: []
     enforced: true
 
+  # The property pipeline.commit.after_flush approximates. after_flush asserts
+  # the order the loop does things, which is a mechanism: a correct rewrite
+  # that committed optimistically and rolled back would fail it. This asserts
+  # the outcome, against rows a destination actually holds, so it survives any
+  # implementation that keeps the guarantee.
+  - id: pipeline.commit.only_delivered_rows
+    family: checkpoint
+    class: safety
+    applies_to: pipeline
+    claim: >
+      The pipeline never commits a position covering a row the destination did
+      not take, and never leaves a delivered row uncommitted after a clean run.
+    verified_by: harness
+    requires: []
+    enforced: true
+    violated_once: ["#154"]
+
   - id: pipeline.commit.nothing_on_failure
     family: checkpoint
     class: safety

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -624,10 +624,18 @@
         "unit": {
           "status": "covered",
           "tests": [
+            "TestPipelineStatefulRealSink_Conformance",
+            "TestPipelineStatefulRealSink_Conformance/lifecycle.drain.on_cancel",
+            "TestPipelineStatefulRealSink_Conformance/pipeline.commit.after_flush",
+            "TestPipelineStatefulRealSink_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStatefulRealSink_Conformance/pipeline.commit.only_delivered_rows",
+            "TestPipelineStatefulRealSink_Conformance/pipeline.flush.eventually",
+            "TestPipelineStatefulRealSink_Conformance/pipeline.state.with_offsets",
             "TestPipelineStateful_Conformance",
             "TestPipelineStateful_Conformance/lifecycle.drain.on_cancel",
             "TestPipelineStateful_Conformance/pipeline.commit.after_flush",
             "TestPipelineStateful_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateful_Conformance/pipeline.commit.only_delivered_rows",
             "TestPipelineStateful_Conformance/pipeline.flush.eventually",
             "TestPipelineStateful_Conformance/pipeline.state.with_offsets",
             "TestStateDurability_DBSecondConnectionSeesOnlyCommittedState",
@@ -640,6 +648,9 @@
             "TestStateDurability_Stats_ExcludesTheBatchTable",
             "TestStateDurability_Stats_IsDeterministicallyOrdered",
             "TestStateDurability_Stats_TableNamesSurviveReaderRelease"
+          ],
+          "skipped": [
+            "TestPipelineStateful_Conformance/pipeline.commit.only_delivered_rows"
           ]
         },
         "integration": {
@@ -816,15 +827,25 @@
             "TestCoreConsumeLoop_ProcessBatchRollsBackWhenSinkFails",
             "TestCoreConsumeLoop_ProcessBatchSavesTheProcessedOffsets",
             "TestCoreConsumeLoop_WritesEveryMessageAcrossManyBatches",
+            "TestPipelineStatelessRealSink_Conformance",
+            "TestPipelineStatelessRealSink_Conformance/lifecycle.drain.on_cancel",
+            "TestPipelineStatelessRealSink_Conformance/pipeline.commit.after_flush",
+            "TestPipelineStatelessRealSink_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStatelessRealSink_Conformance/pipeline.commit.only_delivered_rows",
+            "TestPipelineStatelessRealSink_Conformance/pipeline.flush.eventually",
+            "TestPipelineStatelessRealSink_Conformance/pipeline.state.with_offsets",
             "TestPipelineStateless_Conformance",
             "TestPipelineStateless_Conformance/lifecycle.drain.on_cancel",
             "TestPipelineStateless_Conformance/pipeline.commit.after_flush",
             "TestPipelineStateless_Conformance/pipeline.commit.nothing_on_failure",
+            "TestPipelineStateless_Conformance/pipeline.commit.only_delivered_rows",
             "TestPipelineStateless_Conformance/pipeline.flush.eventually",
             "TestPipelineStateless_Conformance/pipeline.state.with_offsets",
             "TestPipelineStateless_KeepsNoDurableState"
           ],
           "skipped": [
+            "TestPipelineStatelessRealSink_Conformance/pipeline.state.with_offsets",
+            "TestPipelineStateless_Conformance/pipeline.commit.only_delivered_rows",
             "TestPipelineStateless_Conformance/pipeline.state.with_offsets"
           ]
         },
@@ -2435,6 +2456,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatefulRealSink_Conformance/pipeline.commit.after_flush",
               "TestPipelineStateful_Conformance/pipeline.commit.after_flush"
             ]
           },
@@ -2451,6 +2473,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatelessRealSink_Conformance/pipeline.commit.after_flush",
               "TestPipelineStateless_Conformance/pipeline.commit.after_flush"
             ]
           },
@@ -2466,6 +2489,53 @@
       }
     },
     {
+      "id": "pipeline.commit.only_delivered_rows",
+      "family": "checkpoint",
+      "applies_to": "pipeline",
+      "claim": "The pipeline never commits a position covering a row the destination did not take, and never leaves a delivered row uncommitted after a clean run.",
+      "verified_by": "harness",
+      "class": "safety",
+      "requires": [],
+      "enforced": true,
+      "integrations": {
+        "pipeline.stateful": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestPipelineStatefulRealSink_Conformance/pipeline.commit.only_delivered_rows"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        },
+        "pipeline.stateless": {
+          "unit": {
+            "status": "covered",
+            "tests": [
+              "TestPipelineStatelessRealSink_Conformance/pipeline.commit.only_delivered_rows"
+            ]
+          },
+          "integration": {
+            "status": "missing",
+            "tests": []
+          },
+          "release": {
+            "status": "missing",
+            "tests": []
+          }
+        }
+      },
+      "violated_once": [
+        "#154"
+      ]
+    },
+    {
       "id": "pipeline.commit.nothing_on_failure",
       "family": "checkpoint",
       "applies_to": "pipeline",
@@ -2479,6 +2549,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatefulRealSink_Conformance/pipeline.commit.nothing_on_failure",
               "TestPipelineStateful_Conformance/pipeline.commit.nothing_on_failure"
             ]
           },
@@ -2495,6 +2566,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatelessRealSink_Conformance/pipeline.commit.nothing_on_failure",
               "TestPipelineStateless_Conformance/pipeline.commit.nothing_on_failure"
             ]
           },
@@ -2523,6 +2595,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatefulRealSink_Conformance/pipeline.state.with_offsets",
               "TestPipelineStateful_Conformance/pipeline.state.with_offsets"
             ]
           },
@@ -3399,6 +3472,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatefulRealSink_Conformance/lifecycle.drain.on_cancel",
               "TestPipelineStateful_Conformance/lifecycle.drain.on_cancel"
             ]
           },
@@ -3415,6 +3489,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatelessRealSink_Conformance/lifecycle.drain.on_cancel",
               "TestPipelineStateless_Conformance/lifecycle.drain.on_cancel"
             ]
           },
@@ -3443,6 +3518,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatefulRealSink_Conformance/pipeline.flush.eventually",
               "TestPipelineStateful_Conformance/pipeline.flush.eventually"
             ]
           },
@@ -3459,6 +3535,7 @@
           "unit": {
             "status": "covered",
             "tests": [
+              "TestPipelineStatelessRealSink_Conformance/pipeline.flush.eventually",
               "TestPipelineStateless_Conformance/pipeline.flush.eventually"
             ]
           },

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -36,12 +36,12 @@ names every one of them.
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
 | `handler.structured` | Binds a declared schema, ingesting through Arrow. | ✅ | — | ✅ | 8 |
-| `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 17 |
+| `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 25 |
 | `state.offsets` | Kafka positions are stored in DuckDB and resumed on restart. | ✅ | — | ✅ | 22 |
 | `state.corruption` | A damaged state file fails the start rather than silently resetting. | ✅ | — | ✅ | 6 |
 | `lifecycle.drain` | SIGTERM writes the buffered batch before exiting. | ✅ | — | ✅ | 2 |
 | `lifecycle.exit_codes` | The process exit status carries the error code a supervisor reads. | ✅ | — | ✅ | 8 |
-| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 21 |
+| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 29 |
 | `error.taxonomy` | Every failure carries a class.domain.reason code. | ✅ | — | — | 16 |
 | `error.raise` | Policy RAISE stops the pipeline on a bad record. | ✅ | — | — | 1 |
 | `error.ignore` | Policy IGNORE drops a bad record and keeps the pipeline running. | ✅ | — | ✅ | 5 |
@@ -65,7 +65,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**31 invariants declared: 27 safety and 4 liveness. Of 134 (invariant, integration) cells: 24 proven, 90 missing, 0 skipped, 0 failing, 20 exempt. 0 gap(s).**
+**32 invariants declared: 28 safety and 4 liveness. Of 136 (invariant, integration) cells: 26 proven, 90 missing, 0 skipped, 0 failing, 20 exempt. 0 gap(s).**
 
 Safety says nothing bad happens. Liveness says something good
 eventually does, and the two are not interchangeable: a sink that
@@ -158,6 +158,7 @@ drains. An invariant holds only if it holds on all four.
 | Invariant | Claim | `pipeline.stateful` | `pipeline.stateless` |
 | --- | --- | --- | --- |
 | `pipeline.commit.after_flush` | Offsets and state commit only after Flush returned nil. | ✅ u | ✅ u |
+| `pipeline.commit.only_delivered_rows` | The pipeline never commits a position covering a row the destination did not take, and never leaves a delivered row uncommitted after a clean run. *(violated once: #154)* | ✅ u | ✅ u |
 | `pipeline.commit.nothing_on_failure` | A failed flush commits nothing. Not offsets, not state. | ✅ u | ✅ u |
 | `pipeline.state.with_offsets` | Window state and the offsets that produced it commit atomically. | ✅ u | — exempt |
 

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -506,6 +506,8 @@ func TestToolingConformancePipelines_AStatelessSubjectSkipsStateInvariants(t *te
 	})
 
 	assert.True(t, strings.Contains(vs[stateWithOffsets].skipped, "no durable state"))
+	// It reads nothing back either, so the outcome check cannot run.
+	assert.True(t, strings.Contains(vs[onlyDeliveredRows].skipped, "read back"))
 	assert.Equal(t, "", vs[stateWithOffsets].failure)
 
 	// The other three still apply to a stateless pipeline.
@@ -548,7 +550,7 @@ func pipelineVerdictsFor(t *testing.T, s PipelineSubject) map[string]verdict {
 	for _, v := range pipelineVerdicts(t, s) {
 		out[v.invariant] = v
 	}
-	assert.Equal(t, 5, len(out))
+	assert.Equal(t, 6, len(out))
 	return out
 }
 

--- a/internal/conformance/pipeline.go
+++ b/internal/conformance/pipeline.go
@@ -72,6 +72,29 @@ type PipelineSubject struct {
 	// Options builds the pipeline's options from the harness's recorder. A
 	// stateful configuration returns core.WithStateStore(r.Offsets(), r.Tx()).
 	Options func(r *Recorder) []core.TurbineOption
+
+	// NewSink supplies the destination the pipeline writes to. Nil means the
+	// harness discards the rows and judges the event order alone.
+	//
+	// A subject that supplies one, with ReadBack and Break, is judged on what
+	// the destination actually holds. That is the difference between asserting
+	// the loop emitted three events in an order and asserting it never
+	// committed offsets for a row the sink never wrote.
+	NewSink func(t *testing.T) core.Sink
+
+	// ReadBack returns every row the destination holds. Required with NewSink.
+	ReadBack func(t *testing.T) []Row
+
+	// Break makes the destination stop accepting writes, and Heal reverses it.
+	// With a real sink these replace the harness's synthetic flush failure, so
+	// the flush fails the way it would in production.
+	Break func(t *testing.T)
+	Heal  func(t *testing.T)
+}
+
+// readsBack reports whether the subject can be judged on delivered rows.
+func (s PipelineSubject) readsBack() bool {
+	return s.NewSink != nil && s.ReadBack != nil && s.Break != nil && s.Heal != nil
 }
 
 // Pipelines proves every pipeline invariant the subject can exercise.
@@ -121,6 +144,7 @@ const (
 	stateWithOffsets    = "pipeline.state.with_offsets"
 	drainOnCancel       = "lifecycle.drain.on_cancel"
 	flushEventually     = "pipeline.flush.eventually"
+	onlyDeliveredRows   = "pipeline.commit.only_delivered_rows"
 )
 
 // pipelineVerdicts runs every trigger against the subject and judges each
@@ -138,6 +162,13 @@ func pipelineVerdicts(t *testing.T, s PipelineSubject) []verdict {
 	withOffsets := verdict{invariant: stateWithOffsets}
 	drain := verdict{invariant: drainOnCancel}
 	eventually := verdict{invariant: flushEventually}
+	delivered := verdict{invariant: onlyDeliveredRows}
+
+	if !s.readsBack() {
+		delivered.skipped = s.Integration + " has no destination to read back " +
+			"from, so what it committed cannot be compared with what landed; " +
+			"supply NewSink, ReadBack, Break and Heal"
+	}
 
 	if !s.KeepsState {
 		withOffsets.skipped = s.Integration + " keeps no durable state, so " +
@@ -175,6 +206,20 @@ func pipelineVerdicts(t *testing.T, s PipelineSubject) []verdict {
 		drain.failure = err.Error()
 	}
 
+	// The outcome, not the order. after_flush asserts the sequence the loop
+	// happens to use; this asserts the guarantee that sequence exists for, and
+	// it needs a destination to count.
+	if s.readsBack() {
+		for _, trigger := range Triggers {
+			if delivered.failure != "" {
+				break
+			}
+			if err := checkOnlyDeliveredRows(t, s, trigger); err != nil {
+				delivered.failure = err.Error()
+			}
+		}
+	}
+
 	// The only liveness claim here. Everything above says the pipeline does
 	// nothing wrong; this says it does something. A sink that never flushed
 	// would satisfy every one of them and fail this one alone.
@@ -182,7 +227,8 @@ func pipelineVerdicts(t *testing.T, s PipelineSubject) []verdict {
 		eventually.failure = err.Error()
 	}
 
-	return []verdict{afterFlush, onFailure, withOffsets, drain, eventually}
+	return []verdict{afterFlush, onFailure, withOffsets, drain, eventually,
+		delivered}
 }
 
 // checkCommitAfterFlush runs one trigger and holds the event order.
@@ -201,8 +247,8 @@ func checkCommitAfterFlush(t *testing.T, s PipelineSubject, trigger Trigger) err
 	if !sameOrder(run.events, want) {
 		return fmt.Errorf(
 			"%s: the pipeline did %s; want %s. Committing before the flush "+
-				"moves the position past rows the sink never took, and the "+
-				"consumer group reports no lag while they are gone",
+				"records progress past rows the sink never wrote, so a restart "+
+				"skips them and nothing looks wrong",
 			trigger, list(run.events), list(want))
 	}
 	return nil
@@ -226,8 +272,9 @@ func checkNothingOnFailure(t *testing.T, s PipelineSubject, trigger Trigger) err
 	}
 	if run.sourceCommits != 0 {
 		return fmt.Errorf(
-			"%s: the flush failed and the source was still told to commit %d "+
-				"time(s); the rows never landed, so the position must not move",
+			"%s: the flush failed and the pipeline still committed its offsets "+
+				"%d time(s). Nothing was written, so a restart has to re-read "+
+				"those messages rather than skip them",
 			trigger, run.sourceCommits)
 	}
 	return nil
@@ -245,14 +292,16 @@ func checkStateWithOffsets(t *testing.T, s PipelineSubject, trigger Trigger) err
 	if !sameOrder(run.events, []string{"flush", "save-offsets-failed", "rollback"}) {
 		return fmt.Errorf(
 			"%s: after a failed offset save the pipeline did %s; want a "+
-				"rollback, so the state this batch wrote goes back with the "+
-				"offsets that describe it",
+				"rollback. The window state this batch wrote has to go back "+
+				"with the offsets that say where it came from, or a restart "+
+				"replays the batch into state that already holds it",
 			trigger, list(run.events))
 	}
 	if run.sourceCommits != 0 {
 		return fmt.Errorf(
-			"%s: the offset save failed and the source was still told to "+
-				"commit", trigger)
+			"%s: saving the offsets failed and the pipeline still told the "+
+				"source it had finished with those messages. A restart would "+
+				"skip them", trigger)
 	}
 	return nil
 }
@@ -273,6 +322,66 @@ func checkDrain(t *testing.T, s PipelineSubject) error {
 	if run.flushes != 1 {
 		return fmt.Errorf("drain: the buffered batch was flushed %d times; want 1",
 			run.flushes)
+	}
+	return nil
+}
+
+// checkOnlyDeliveredRows compares what the pipeline committed with what the
+// destination holds, on a clean run and on a broken one.
+//
+// The pipeline commits offsets on what Flush reports. A run that advances the
+// position while the destination holds nothing has lost those rows, and the
+// consumer group shows no lag while they are gone -- which is #154, found in
+// production rather than by a test.
+func checkOnlyDeliveredRows(t *testing.T, s PipelineSubject, trigger Trigger) error {
+	t.Helper()
+
+	// Deltas, not totals. Every scenario writes to the same destination, so
+	// what matters is what this run added.
+	start := int64(len(s.ReadBack(t)))
+
+	clean := runPipeline(t, s, trigger, faults{})
+	if clean.err != nil {
+		return fmt.Errorf("%s: the pipeline failed with no fault injected: %v",
+			trigger, clean.err)
+	}
+
+	landed := int64(len(s.ReadBack(t))) - start
+	if landed != clean.rows {
+		return fmt.Errorf(
+			"%s: the pipeline gave the sink %d rows and only %d reached the "+
+				"table. It commits offsets for all %d, so the missing rows are "+
+				"never read again",
+			trigger, clean.rows, landed, clean.rows)
+	}
+	if clean.sourceCommits == 0 {
+		return fmt.Errorf(
+			"%s: %d rows reached the table and the pipeline never committed its "+
+				"offsets. Every restart re-reads and re-writes the same batch",
+			trigger, landed)
+	}
+
+	// And the other direction: a destination that took nothing must leave the
+	// position where it was.
+	before := int64(len(s.ReadBack(t)))
+
+	broken := runPipeline(t, s, trigger, faults{flush: true})
+	if broken.err == nil {
+		return fmt.Errorf("%s: the destination was broken and the pipeline did "+
+			"not fail", trigger)
+	}
+	if added := int64(len(s.ReadBack(t))) - before; added != 0 {
+		return fmt.Errorf(
+			"%s: the sink was broken and %d rows reached the table anyway",
+			trigger, added)
+	}
+	if broken.sourceCommits != 0 {
+		return fmt.Errorf(
+			"%s: the sink wrote no rows and the pipeline committed its offsets "+
+				"anyway. After a restart the source resumes past those rows, so "+
+				"they are gone, and the consumer group reports no lag while they "+
+				"are missing",
+			trigger)
 	}
 	return nil
 }
@@ -298,9 +407,9 @@ func checkFlushEventually(t *testing.T, s PipelineSubject) error {
 	}
 	if run.flushes == 0 {
 		return errors.New(
-			"a batch smaller than batchSize never reached the sink; only the " +
-				"flush interval can move it, and a pipeline that waits for a " +
-				"batch that never fills stalls for as long as it runs")
+			"a batch smaller than batchSize never reached the sink. Only the " +
+				"flush interval can move it, so on a quiet topic the rows sit " +
+				"in memory for as long as the process runs")
 	}
 	if run.rows != intervalRows {
 		return fmt.Errorf(
@@ -369,7 +478,22 @@ func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) out
 
 	rec := &Recorder{failOffsets: f.offsets}
 	src := &recordingSource{rec: rec}
-	sink := &recordingSink{rec: rec, fail: f.flush}
+
+	sink := &recordingSink{rec: rec}
+	if s.NewSink != nil {
+		sink.inner = s.NewSink(t)
+	}
+	// Break the destination where there is one, so the flush fails the way it
+	// would in production. Only a subject with nothing to break needs the
+	// harness to fake it.
+	if f.flush {
+		if s.readsBack() {
+			s.Break(t)
+			defer s.Heal(t)
+		} else {
+			sink.fail = true
+		}
+	}
 	var flushed chan struct{}
 
 	// Sized so only the intended trigger can fire. A batch size above the
@@ -599,39 +723,65 @@ func (s *recordingSource) Close() error {
 	return nil
 }
 
-// recordingSink logs its flushes and can fail them.
+// recordingSink logs what the pipeline asked of a sink, and delegates.
+//
+// It wraps the subject's sink where there is one, so the event order and the
+// delivered rows come from the same run. With no inner sink it discards, which
+// is what the double-only subjects want.
 type recordingSink struct {
-	rec  *Recorder
-	fail bool
+	rec   *Recorder
+	inner core.Sink
+	fail  bool
 
 	mu      sync.Mutex
 	rows    int64
 	flushes int
 }
 
-func (s *recordingSink) WriteTable(_ context.Context, batch arrow.Table) error {
+func (s *recordingSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if batch != nil {
 		s.rows += batch.NumRows()
+	}
+	inner := s.inner
+	s.mu.Unlock()
+
+	if inner != nil {
+		return inner.WriteTable(ctx, batch)
 	}
 	return nil
 }
 
-func (s *recordingSink) Flush(context.Context) error {
+func (s *recordingSink) Flush(ctx context.Context) error {
 	s.mu.Lock()
 	s.flushes++
+	inner, fail := s.inner, s.fail
 	s.mu.Unlock()
 
-	if s.fail {
+	// The synthetic failure is for subjects with no destination to break. A
+	// subject that has one gets a real error from a really broken sink.
+	if fail {
 		s.rec.record("flush-failed")
 		return errors.New("conformance: sink is down")
+	}
+	if inner != nil {
+		if err := inner.Flush(ctx); err != nil {
+			s.rec.record("flush-failed")
+			return err
+		}
 	}
 	s.rec.record("flush")
 	return nil
 }
 
-func (s *recordingSink) Batch() (arrow.Table, error) { return nil, nil }
+func (s *recordingSink) Batch() (arrow.Table, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inner != nil {
+		return s.inner.Batch()
+	}
+	return nil, nil
+}
 
 func (s *recordingSink) Rows() int64 {
 	s.mu.Lock()

--- a/internal/sinks/conformance_pipeline_test.go
+++ b/internal/sinks/conformance_pipeline_test.go
@@ -1,0 +1,105 @@
+package sinks
+
+// The consume loop against a real destination.
+//
+// It lives here rather than in internal/core because the Iceberg catalog
+// helpers do, and building one from outside this package would duplicate the
+// property translation the sink already owns.
+//
+// The other pipeline subjects run on doubles and judge the order the loop does
+// things. That is a mechanism: a rewrite that committed optimistically and
+// rolled back would fail those checks while keeping the guarantee. This one
+// judges the guarantee, by counting rows a real Iceberg table actually holds
+// against the position the pipeline committed.
+//
+// No container. The catalog is sqlite and the warehouse is a directory, so the
+// fault is a warehouse the sink cannot write into, and the whole thing runs in
+// the unit pass.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/turbolytics/sql-flow/internal/conformance"
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+func TestPipelineStatefulRealSink_Conformance(t *testing.T) {
+	coverage.Covers(t, "state.durability")
+
+	runPipelineAgainstIceberg(t, "pipeline.stateful", true,
+		func(r *conformance.Recorder) []core.TurbineOption {
+			return []core.TurbineOption{core.WithStateStore(r.Offsets(), r.Tx())}
+		})
+}
+
+// The same loop with no durable state. It still must never commit offsets for
+// rows the sink did not write, so it needs a real destination too: the
+// doubles-based subject can only judge the order of events.
+func TestPipelineStatelessRealSink_Conformance(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+
+	runPipelineAgainstIceberg(t, "pipeline.stateless", false,
+		func(*conformance.Recorder) []core.TurbineOption { return nil })
+}
+
+// runPipelineAgainstIceberg drives one configuration against a real Iceberg
+// table, with its own catalog and warehouse so the configurations cannot see
+// each other's rows.
+func runPipelineAgainstIceberg(t *testing.T, integration string, keepsState bool,
+	options func(*conformance.Recorder) []core.TurbineOption) {
+	t.Helper()
+
+	isolateCatalogLookup(t)
+
+	// Two directories: Break makes the warehouse unwritable, and the catalog
+	// has to stay readable for the read-back to work.
+	warehouse := t.TempDir()
+	catalogDir := t.TempDir()
+
+	const catalogName = "pipelinetest"
+	t.Setenv("PYICEBERG_CATALOG__PIPELINETEST__URI",
+		"sqlite:///"+filepath.Join(catalogDir, "catalog.db"))
+	t.Setenv("PYICEBERG_CATALOG__PIPELINETEST__WAREHOUSE", "file://"+warehouse)
+
+	ctx := context.Background()
+	props, err := icebergCatalogProperties(catalogName)
+	assert.NoError(t, err)
+
+	cat, err := catalog.Load(ctx, catalogName, props)
+	assert.NoError(t, err)
+	assert.NoError(t, cat.CreateNamespace(ctx, catalog.ToIdentifier("default"), nil))
+
+	// The harness's handler emits a single int64 "id" column.
+	schema := iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64},
+	)
+	_, err = cat.CreateTable(ctx, catalog.ToIdentifier("default", "rows"), schema)
+	assert.NoError(t, err)
+
+	conformance.Pipelines(t, conformance.PipelineSubject{
+		Integration: integration,
+		KeepsState:  keepsState,
+		Options:     options,
+
+		NewSink: func(t *testing.T) core.Sink {
+			s, err := NewIcebergSink(ctx, catalogName, "default.rows")
+			assert.NoError(t, err)
+			return s
+		},
+
+		// A warehouse the sink cannot write into: a full volume, a revoked
+		// credential, a read-only mount.
+		Break: func(t *testing.T) { chmodTree(t, warehouse, 0o500) },
+		Heal:  func(t *testing.T) { chmodTree(t, warehouse, 0o700) },
+
+		ReadBack: func(t *testing.T) []conformance.Row {
+			return icebergIDs(t, catalogName)
+		},
+	})
+}


### PR DESCRIPTION
`pipeline.commit.after_flush` asserts the order the loop does things: flush, save-offsets, commit. That is a mechanism, not the claim. A rewrite that committed optimistically and rolled back would keep the guarantee and fail the test, reporting a broken invariant when nothing broke.

## The property, not the sequence

`pipeline.commit.only_delivered_rows` asserts the guarantee itself:

- A clean run puts **every** row it handed the sink into the destination, and commits its offsets.
- A run whose sink could not write puts **nothing** there, and commits nothing.

Both directions, on all four paths that reach a batch.

## How it gets a destination

The recording sink became a decorator. It wraps whatever the subject supplies and records around it, so the event order and the delivered rows come from one run. A subject with a real sink also gets a real failure: the harness breaks the destination instead of setting a flag.

**The destination is Iceberg, and it needs no container.** A sqlite catalog and a temp directory make a real table; `chmod 0500` on the warehouse is a real fault. It runs in the unit pass beside everything else.

toxiproxy could not have done this. It proxies TCP, and this sink writes files. That is why only two of eight subjects use it.

Both configurations get one. The stateless loop must not commit offsets for rows the sink never wrote either, and its doubles-based subject can only judge the order of events.

## Evidence

With the loop mutated to commit before it flushes:

```
--- FAIL: TestPipelineStatefulRealSink_Conformance/pipeline.commit.only_delivered_rows
    batch-full: the sink wrote no rows and the pipeline committed its offsets
    anyway. After a restart the source resumes past those rows, so they are
    gone, and the consumer group reports no lag while they are missing
```

That is #154 stated as a property and caught against a real table.

## The check found a defect in itself first

Every scenario writes to the same table, so the first version compared totals and read 50 rows where 4 had been handed over. It compares deltas now. A real destination reveals that class of mistake; doubles do not.

## Messages say what happens

Every failure message the harness can print was rewritten. "A position covering rows nothing took" told a reader nothing. "A restart resumes past those rows, so they are gone" tells them what they will see.

## State

155 tooling tests and 16 Go packages pass. **Nine invariants enforced.** The gate exits 0 with no gaps, no unattributed tests and no unknown markers.

## Still open

`after_flush` remains a change-detector. It is now redundant with `only_delivered_rows`, which asserts what it was reaching for. Worth removing or reframing, but that is a deletion to make deliberately rather than fold in here.
