### PR TITLE
examples: close tumbling windows against the stream's clock, not wall clock

### DIFF
--- a/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
@@ -15,6 +15,18 @@ tables:
 
       manager:
         # The tumbling window manager will identify records with "closed" windows i.e. windows < now - duration_seconds
+          # A window closes against the stream's own clock, not wall clock.
+          # max(bucket) is the newest window the data has reached, so a window
+          # closes only once the stream has moved past it. That keeps the
+          # result identical whether the data arrives live or as a replay.
+          #
+          # With now() here instead, a pipeline running behind real time by
+          # more than the grace period closes a window whose rows are still
+          # arriving and publishes it in parts, once per poll. Downstream those
+          # parts are indistinguishable from an at-least-once duplicate.
+          #
+          # The trade: the newest window waits for a later one, so a stream
+          # that stops leaves its final window unpublished.
         tumbling_window:
           collect_closed_windows_sql: |
             SELECT 
@@ -22,11 +34,11 @@ tables:
               kind,
               count
             FROM agg_post_kind_count_1_minute
-            WHERE bucket AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND) 
+            WHERE bucket < (SELECT max(bucket) FROM agg_post_kind_count_1_minute) - INTERVAL '60' SECOND
 
           delete_closed_windows_sql: |
             DELETE FROM agg_post_kind_count_1_minute
-            WHERE bucket AT TIME ZONE 'utc' < (now()::timestamptz AT TIME ZONE 'UTC' - INTERVAL '60' SECOND)
+            WHERE bucket < (SELECT max(bucket) FROM agg_post_kind_count_1_minute) - INTERVAL '60' SECOND
 
         sink:
           type: kafka

--- a/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
@@ -38,15 +38,27 @@ tables:
         # last seconds of a window can reach DuckDB up to that long after the
         # window ended. A grace period shorter than the batch wait publishes
         # the window before those events land.
+          # A window closes against the stream's own clock, not wall clock.
+          # max(bucket) is the newest window the data has reached, so a window
+          # closes only once the stream has moved past it. That keeps the
+          # result identical whether the data arrives live or as a replay.
+          #
+          # With now() here instead, a pipeline running behind real time by
+          # more than the grace period closes a window whose rows are still
+          # arriving and publishes it in parts, once per poll. Downstream those
+          # parts are indistinguishable from an at-least-once duplicate.
+          #
+          # The trade: the newest window waits for a later one, so a stream
+          # that stops leaves its final window unpublished.
         tumbling_window:
           poll_interval_seconds: 10
           collect_closed_windows_sql: |
             SELECT bucket, lang, posts
             FROM posts_per_minute_by_lang
-            WHERE bucket + INTERVAL '1 minute' < now()::TIMESTAMP - INTERVAL '60 seconds'
+            WHERE bucket + INTERVAL '1 minute' < (SELECT max(bucket) FROM posts_per_minute_by_lang) - INTERVAL '60 seconds'
           delete_closed_windows_sql: |
             DELETE FROM posts_per_minute_by_lang
-            WHERE bucket + INTERVAL '1 minute' < now()::TIMESTAMP - INTERVAL '60 seconds'
+            WHERE bucket + INTERVAL '1 minute' < (SELECT max(bucket) FROM posts_per_minute_by_lang) - INTERVAL '60 seconds'
 
         sink:
           type: sqlcommand

--- a/dev/config/examples/kafka.stateful.window.yml
+++ b/dev/config/examples/kafka.stateful.window.yml
@@ -22,6 +22,18 @@ tables:
           ON agg_city_count (bucket, city);
 
       manager:
+          # A window closes against the stream's own clock, not wall clock.
+          # max(bucket) is the newest window the data has reached, so a window
+          # closes only once the stream has moved past it. That keeps the
+          # result identical whether the data arrives live or as a replay.
+          #
+          # With now() here instead, a pipeline running behind real time by
+          # more than the grace period closes a window whose rows are still
+          # arriving and publishes it in parts, once per poll. Downstream those
+          # parts are indistinguishable from an at-least-once duplicate.
+          #
+          # The trade: the newest window waits for a later one, so a stream
+          # that stops leaves its final window unpublished.
         tumbling_window:
           poll_interval_seconds: 3600
           collect_closed_windows_sql: |
@@ -30,10 +42,10 @@ tables:
               city,
               count
             FROM agg_city_count
-            WHERE bucket < (now()::timestamptz - INTERVAL '3600' SECOND)
+            WHERE bucket < (SELECT max(bucket) FROM agg_city_count) - INTERVAL '3600' SECOND
           delete_closed_windows_sql: |
             DELETE FROM agg_city_count
-            WHERE bucket < (now()::timestamptz - INTERVAL '3600' SECOND)
+            WHERE bucket < (SELECT max(bucket) FROM agg_city_count) - INTERVAL '3600' SECOND
 
         sink:
           type: console

--- a/dev/config/examples/tumbling.window.yml
+++ b/dev/config/examples/tumbling.window.yml
@@ -10,6 +10,18 @@ tables:
         CREATE UNIQUE INDEX daily_cities_count_idx ON agg_cities_count (bucket, city);
 
       manager:
+          # A window closes against the stream's own clock, not wall clock.
+          # max(bucket) is the newest window the data has reached, so a window
+          # closes only once the stream has moved past it. That keeps the
+          # result identical whether the data arrives live or as a replay.
+          #
+          # With now() here instead, a pipeline running behind real time by
+          # more than the grace period closes a window whose rows are still
+          # arriving and publishes it in parts, once per poll. Downstream those
+          # parts are indistinguishable from an at-least-once duplicate.
+          #
+          # The trade: the newest window waits for a later one, so a stream
+          # that stops leaves its final window unpublished.
         tumbling_window:
           collect_closed_windows_sql: |
             SELECT 
@@ -17,12 +29,12 @@ tables:
               city,
               count
             FROM agg_cities_count
-            WHERE bucket < (now()::timestamptz - INTERVAL '60' SECOND) 
+            WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '60' SECOND
             ORDER BY city
 
           delete_closed_windows_sql: |
             DELETE FROM agg_cities_count 
-            WHERE bucket < (now()::timestamptz - INTERVAL '60' SECOND)
+            WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '60' SECOND
           
         sink:
           type: kafka


### PR DESCRIPTION
Every windowed example closed a window with `now()`. Buckets come from event time, so the two clocks agree only while the pipeline keeps up.

## The failure

Fall behind by more than the grace period and a window closes while its rows are still arriving. It publishes in parts, once per poll.

Measured on v1.0.6: 500 events in one one-minute bucket, consumed over ten seconds against a one-second poll and a 60-second grace.

```
{"iso":"2026-09-01T10:00:00","k":"a","n":100}
{"iso":"2026-09-01T10:00:00","k":"a","n":100}
{"iso":"2026-09-01T10:00:00","k":"a","n":100}
{"iso":"2026-09-01T10:00:00","k":"a","n":100}
{"iso":"2026-09-01T10:00:00","k":"a","n":100}
```

The answer is one row, `n=500`. The same 400,000 events replayed fast enough to finish inside one poll came out as a single correct row, so the output depends on how fast the pipeline ran rather than on the data.

Nothing exotic triggers it: a backfill, a replay, `auto_offset_reset: earliest` against a topic with history, consumer lag under load, or a store-and-forward gateway draining after a link comes back.

## Why no downstream rule fixes it

The parts carry the same key and can be byte-identical, so they cannot be distinguished from an at-least-once duplicate.

Deduplicating keeps one part and drops real counts. A ClickHouse `ReplacingMergeTree` ordered by `(bucket, key)` collapses those five rows to a single row of 100 against a true count of 500, with no error. Summing instead fixes that and double-counts a genuine republish. Both failures are silent, and 100 is a plausible count.

## The change

These four configs now close against `max(bucket)`, the newest window the data has reached:

```sql
WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '60' SECOND
```

A window closes only once the stream has moved past it, which is what a watermark means. The result is the same whether the data arrives live or as a replay.

Each config carries a comment explaining the trade: the newest window waits for a later one, so a stream that stops leaves its final window unpublished. Wall clock closes on time and can fragment. Stream clock is always correct and can wait. The comment says so.

## Verification

- All four validate.
- Against the live Bluesky firehose, `bluesky.kafka.windowed.yml` published two consecutive complete minutes, one row per kind, through a websocket reconnect.
- Under the same ten-second trickle that fragmented the wall-clock version into five rows, the stream-clock version published one complete row per bucket.
- With a six-year-old timestamp and a 3600 second grace, `kafka.stateful.window.yml` under the old predicate published a partial window of 1000 from 2000 consumed messages. Under the new predicate the window correctly stays open.

## Release tests

Three tests use `kafka.stateful.window.yml`, and all three assert on `sum(count)` in the aggregate table, so they need the window to stay open. A predicate that closes later cannot break them.

`test_state_durability_survives_a_restart` documents having to use a current timestamp "because a fixed timestamp goes stale: once it is more than an hour old the manager legitimately closes the window, publishes it and deletes the rows these assertions read." That fragility is gone.

## Scope

Examples and their comments only. No engine change.

Sealing the window so neither predicate can fragment is #203, which this does not replace. It changes the default that people copy.
