### PR TITLE
Kafka sink invariants: at-least-once in the harness, and three sink defects

### DIFF
--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -80,9 +80,6 @@ integrations:
       - invariant: sink.flush.honours_context
         reason: has no destination; discarding every row is the contract
         proven_by: TestSinkNoop_DeliversNothingAndSaysSo
-      - invariant: sink.batch.reports_buffer
-        reason: has no destination; discarding every row is the contract
-        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.buffer.reports_depth
         reason: has no destination; it holds nothing, so there is no depth to report
         proven_by: TestSinkNoop_DeliversNothingAndSaysSo

--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -32,11 +32,21 @@ integrations:
     feature: sink.clickhouse
     exempt: []
 
+  # implements listed Prober and the sink has never had a Probe method. The
+  # constructor loads the catalog and the table, so an absent table does fail
+  # the start -- but through NewIcebergSink, not through the interface
+  # sinks.New probes.
   - id: sink.iceberg
     kind: sink
-    implements: [Sink, Prober]
+    implements: [Sink]
     feature: sink.iceberg
     exempt:
+      - invariant: sink.probe.fails_start
+        reason: implements no Prober, so there is no start-time check to fail
+        proven_by: TestSinkIceberg_ImplementsNoProber
+      - invariant: lifecycle.close.idempotent
+        reason: implements no Close; it holds no client to release
+        proven_by: TestSinkIceberg_ImplementsNoCloser
       - invariant: sink.flush.honours_context
         reason: >
           appends through the catalog and the local filesystem, which fail
@@ -64,6 +74,11 @@ integrations:
           returns or fails immediately; no flush can still be running when a
           deadline arrives
         proven_by: TestSinkSqlcommand_FlushCannotOutliveItsContext
+      - invariant: lifecycle.close.idempotent
+        reason: >
+          implements no Close; the DuckDB connection belongs to the pipeline
+          and this sink must not close it
+        proven_by: TestSinkSqlcommand_ImplementsNoCloser
 
   - id: sink.console
     kind: sink
@@ -78,6 +93,11 @@ integrations:
           writes to an io.Writer, which returns or fails immediately; no flush
           can still be running when a deadline arrives
         proven_by: TestSinkConsole_FlushCannotOutliveItsContext
+      - invariant: lifecycle.close.idempotent
+        reason: >
+          implements no Close; the io.Writer belongs to its caller and this
+          sink must not close it
+        proven_by: TestSinkConsole_ImplementsNoCloser
 
   - id: sink.noop
     kind: sink
@@ -115,6 +135,9 @@ integrations:
       - invariant: sink.probe.fails_start
         reason: implements no Prober, so there is no start-time check to fail
         proven_by: TestSinkNoop_ImplementsNoProber
+      - invariant: lifecycle.close.idempotent
+        reason: implements no Close; it holds nothing to release
+        proven_by: TestSinkNoop_ImplementsNoCloser
 
   # The conformance harness's own doubles run under this id.
   #

--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -22,7 +22,7 @@ integrations:
   # --- Sinks ---------------------------------------------------------------
   - id: sink.kafka
     kind: sink
-    implements: [Sink]
+    implements: [Sink, Prober]
     feature: sink.kafka
     exempt: []
 

--- a/docs/coverage/integrations.yml
+++ b/docs/coverage/integrations.yml
@@ -36,7 +36,19 @@ integrations:
     kind: sink
     implements: [Sink, Prober]
     feature: sink.iceberg
-    exempt: []
+    exempt:
+      - invariant: sink.flush.honours_context
+        reason: >
+          appends through the catalog and the local filesystem, which fail
+          immediately; no flush can still be running when a deadline arrives
+        proven_by: TestSinkIceberg_FlushCannotOutliveItsContext
+      # sink.flush.preserves_order is deliberately not exempt, and reads as
+      # missing. The subject cannot observe delivery order -- a scan reads the
+      # table's data files, and each append writes its own file with a
+      # generated name, so a read-back of [id=2, id=1] turned up on roughly one
+      # run in six. That is a limit of the read-back, not a property of the
+      # sink, and an exemption claiming otherwise would be an excuse. The cell
+      # stays missing until the subject can order a scan by arrival.
 
   - id: sink.sqlcommand
     kind: sink
@@ -46,6 +58,12 @@ integrations:
       - invariant: sink.probe.fails_start
         reason: implements no Prober, so there is no start-time check to fail
         proven_by: TestSinkSqlcommand_ImplementsNoProber
+      - invariant: sink.flush.honours_context
+        reason: >
+          runs the user's SQL on the pipeline's own DuckDB connection, which
+          returns or fails immediately; no flush can still be running when a
+          deadline arrives
+        proven_by: TestSinkSqlcommand_FlushCannotOutliveItsContext
 
   - id: sink.console
     kind: sink
@@ -55,6 +73,11 @@ integrations:
       - invariant: sink.probe.fails_start
         reason: implements no Prober, so there is no start-time check to fail
         proven_by: TestSinkConsole_ImplementsNoProber
+      - invariant: sink.flush.honours_context
+        reason: >
+          writes to an io.Writer, which returns or fails immediately; no flush
+          can still be running when a deadline arrives
+        proven_by: TestSinkConsole_FlushCannotOutliveItsContext
 
   - id: sink.noop
     kind: sink
@@ -78,6 +101,9 @@ integrations:
         reason: has no destination; discarding every row is the contract
         proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.flush.honours_context
+        reason: has no destination; discarding every row is the contract
+        proven_by: TestSinkNoop_DeliversNothingAndSaysSo
+      - invariant: sink.flush.empty_is_noop
         reason: has no destination; discarding every row is the contract
         proven_by: TestSinkNoop_DeliversNothingAndSaysSo
       - invariant: sink.buffer.reports_depth

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -43,7 +43,8 @@ invariants:
     applies_to: sink
     claim: >
       A failed Flush leaves every undelivered row buffered. The next Flush
-      re-attempts them.
+      re-attempts them. Delivery is at-least-once, so a row that arrives twice
+      holds the claim and a row that never arrives breaks it.
     verified_by: harness
     requires: []
     enforced: true
@@ -64,7 +65,10 @@ invariants:
     family: resilience
     class: safety
     applies_to: sink
-    claim: Rows reach the destination in WriteTable order, across a retry.
+    claim: >
+      Rows reach the destination in WriteTable order, across a retry. Repeats
+      are permitted, because delivery is at-least-once; a row that overtakes one
+      written before it is not.
     verified_by: harness
     requires: []
 

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -96,14 +96,6 @@ invariants:
     requires: []
     enforced: true
 
-  - id: sink.batch.reports_buffer
-    family: resilience
-    class: safety
-    applies_to: sink
-    claim: Batch returns what is buffered, and nil when nothing is.
-    verified_by: harness
-    requires: []
-
   - id: sink.error.classifies
     family: resilience
     class: safety

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -146,9 +146,12 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkKafka_Conformance",
-            "TestSinkKafka_BatchIsTheLastWrite",
+            "TestSinkKafka_ARecordTimeoutIsUnreachable",
+            "TestSinkKafka_FlushCodesAnUnreachableBroker",
             "TestSinkKafka_FlushHonoursItsContext",
             "TestSinkKafka_FlushReportsProduceErrors",
+            "TestSinkKafka_FlushReturnsWithoutADeadline",
+            "TestSinkKafka_HasADeliveryTimeoutByDefault",
             "TestSinkKafka_NewRejectsAnUnknownSecurityProtocol",
             "TestSinkKafka_NewRequiresATopic",
             "TestSinkKafka_WriteTableBuffersWhateverItsContextSays"
@@ -162,7 +165,11 @@
           "tests": [
             "TestIntegrationSinkKafka_Conformance",
             "TestIntegrationSinkKafka_Conformance/sink.buffer.reports_depth",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.empty_is_noop",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.honours_context",
             "TestIntegrationSinkKafka_Conformance/sink.flush.keeps_batch",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.no_hollow_success",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.preserves_order",
             "TestIntegrationSinkKafka_Conformance/sink.write.buffers_only"
           ]
         },
@@ -189,7 +196,6 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkClickhouse_Conformance",
-            "TestSinkClickhouse_BatchIsNil",
             "TestSinkClickhouse_EmptyTableIsNoop",
             "TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered",
             "TestSinkClickhouse_InsertsArrays",
@@ -207,7 +213,6 @@
           ],
           "skipped": [
             "TestIntegrationSinkClickhouse_Conformance",
-            "TestSinkClickhouse_BatchIsNil",
             "TestSinkClickhouse_EmptyTableIsNoop",
             "TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered",
             "TestSinkClickhouse_InsertsArrays",
@@ -223,7 +228,11 @@
           "tests": [
             "TestIntegrationSinkClickhouse_Conformance",
             "TestIntegrationSinkClickhouse_Conformance/sink.buffer.reports_depth",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.empty_is_noop",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.honours_context",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.keeps_batch",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.no_hollow_success",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.preserves_order",
             "TestIntegrationSinkClickhouse_Conformance/sink.write.buffers_only"
           ]
         },
@@ -248,20 +257,28 @@
           "tests": [
             "TestSinkIceberg_AddsPyicebergsMissingTypeColumn",
             "TestSinkIceberg_AppendsEveryRow",
-            "TestSinkIceberg_BatchIsTheLastWrite",
             "TestSinkIceberg_CatalogPropertiesEnvOverridesFile",
             "TestSinkIceberg_CatalogPropertiesFromPyicebergFile",
             "TestSinkIceberg_CatalogPropertiesRejectAnUnsupportedScheme",
             "TestSinkIceberg_CatalogPropertiesRequireAURI",
             "TestSinkIceberg_Conformance",
             "TestSinkIceberg_Conformance/sink.buffer.reports_depth",
+            "TestSinkIceberg_Conformance/sink.flush.empty_is_noop",
+            "TestSinkIceberg_Conformance/sink.flush.honours_context",
             "TestSinkIceberg_Conformance/sink.flush.keeps_batch",
+            "TestSinkIceberg_Conformance/sink.flush.no_hollow_success",
+            "TestSinkIceberg_Conformance/sink.flush.preserves_order",
             "TestSinkIceberg_Conformance/sink.write.buffers_only",
             "TestSinkIceberg_EmptyBatchAppendsNothing",
+            "TestSinkIceberg_FlushCannotOutliveItsContext",
             "TestSinkIceberg_FlushWithNothingPendingAppendsNothing",
             "TestSinkIceberg_MissingTableFailsTheStart",
             "TestSinkIceberg_NewRequiresCatalogAndTable",
             "TestSinkIceberg_TypeColumnSkipsAnEmptyCatalog"
+          ],
+          "skipped": [
+            "TestSinkIceberg_Conformance/sink.flush.honours_context",
+            "TestSinkIceberg_Conformance/sink.flush.preserves_order"
           ]
         },
         "integration": {
@@ -307,13 +324,17 @@
           "status": "covered",
           "tests": [
             "TestSinkSqlcommand_AccumulatesUntilFlush",
-            "TestSinkSqlcommand_BatchIsTheLastWrite",
             "TestSinkSqlcommand_Conformance",
             "TestSinkSqlcommand_Conformance/sink.buffer.reports_depth",
+            "TestSinkSqlcommand_Conformance/sink.flush.empty_is_noop",
+            "TestSinkSqlcommand_Conformance/sink.flush.honours_context",
             "TestSinkSqlcommand_Conformance/sink.flush.keeps_batch",
+            "TestSinkSqlcommand_Conformance/sink.flush.no_hollow_success",
+            "TestSinkSqlcommand_Conformance/sink.flush.preserves_order",
             "TestSinkSqlcommand_Conformance/sink.write.buffers_only",
             "TestSinkSqlcommand_EachFlushReplacesTheBatchTable",
             "TestSinkSqlcommand_EmptyBatchStillRunsTheSQL",
+            "TestSinkSqlcommand_FlushCannotOutliveItsContext",
             "TestSinkSqlcommand_FlushWithNothingPendingIsANoop",
             "TestSinkSqlcommand_ImplementsNoProber",
             "TestSinkSqlcommand_NewRequiresSQL",
@@ -321,6 +342,9 @@
             "TestSinkSqlcommand_ReportsASQLError",
             "TestSinkSqlcommand_RunsSQLAgainstTheBatch",
             "TestSinkSqlcommand_SubstitutesUUID4"
+          ],
+          "skipped": [
+            "TestSinkSqlcommand_Conformance/sink.flush.honours_context"
           ]
         },
         "integration": {
@@ -344,11 +368,19 @@
           "tests": [
             "TestSinkConsole_Conformance",
             "TestSinkConsole_Conformance/sink.buffer.reports_depth",
+            "TestSinkConsole_Conformance/sink.flush.empty_is_noop",
+            "TestSinkConsole_Conformance/sink.flush.honours_context",
             "TestSinkConsole_Conformance/sink.flush.keeps_batch",
+            "TestSinkConsole_Conformance/sink.flush.no_hollow_success",
+            "TestSinkConsole_Conformance/sink.flush.preserves_order",
             "TestSinkConsole_Conformance/sink.write.buffers_only",
+            "TestSinkConsole_FlushCannotOutliveItsContext",
             "TestSinkConsole_ImplementsNoProber",
             "TestSinkConsole_RowsAsJSONEmptyTable",
             "TestSinkConsole_RowsAsJSONOneObjectPerRow"
+          ],
+          "skipped": [
+            "TestSinkConsole_Conformance/sink.flush.honours_context"
           ]
         },
         "integration": {
@@ -1332,6 +1364,10 @@
         "unit": {
           "status": "covered",
           "tests": [
+            "TestToolingConformanceDelivered_AllowsARepeat",
+            "TestToolingConformanceDelivered_CatchesALostRow",
+            "TestToolingConformanceDelivered_CatchesAReorder",
+            "TestToolingConformanceDelivered_CatchesAnEmptyDestination",
             "TestToolingConformanceDescribe_NamesTheRowsItFound",
             "TestToolingConformancePipelines_AStatelessSubjectSkipsStateInvariants",
             "TestToolingConformancePipelines_CatchesACommitBeforeTheFlush",
@@ -1341,13 +1377,22 @@
             "TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink",
             "TestToolingConformanceSinks_ACorrectSinkPasses",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.buffer.reports_depth",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.empty_is_noop",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.honours_context",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.keeps_batch",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.no_hollow_success",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.preserves_order",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.write.buffers_only",
             "TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly",
+            "TestToolingConformanceSinks_ADuplicatingSinkPasses",
+            "TestToolingConformanceSinks_AHollowSuccessIsCaught",
+            "TestToolingConformanceSinks_ALosingSinkIsCaught",
+            "TestToolingConformanceSinks_AReorderingSinkIsCaught",
             "TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught",
-            "TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught",
             "TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught",
+            "TestToolingConformanceSinks_ASinkThatIgnoresItsContextIsCaught",
             "TestToolingConformanceSinks_ASinkThatMisreportsItsDepthIsCaught",
+            "TestToolingConformanceSinks_ASinkThatNeverDrainsIsCaught",
             "TestToolingConformanceSinks_ASinkThatReportsNoDepthIsSkipped",
             "TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught",
             "TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker",
@@ -1356,9 +1401,14 @@
             "TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped",
             "TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected",
             "TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject",
+            "TestToolingConformanceSinks_AnEagerEmptyFlushIsCaught",
+            "TestToolingConformanceSinks_AnUnorderedReadBackSkipsOrder",
             "TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants",
             "TestToolingConformanceSinks_TheDoublesIntegrationIsNotAShippedSink",
             "TestToolingConformanceSinks_TheDoublesRunUnderATestOnlyIntegration"
+          ],
+          "skipped": [
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.honours_context"
           ]
         },
         "integration": {
@@ -1523,7 +1573,7 @@
       "id": "sink.flush.keeps_batch",
       "family": "resilience",
       "applies_to": "sink",
-      "claim": "A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them.",
+      "claim": "A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. Delivery is at-least-once, so a row that arrives twice holds the claim and a row that never arrives breaks it.",
       "verified_by": "harness",
       "class": "safety",
       "requires": [],
@@ -1647,8 +1697,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1661,8 +1713,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1671,8 +1725,10 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkIceberg_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1685,8 +1741,10 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1699,8 +1757,10 @@
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1737,7 +1797,7 @@
       "id": "sink.flush.preserves_order",
       "family": "resilience",
       "applies_to": "sink",
-      "claim": "Rows reach the destination in WriteTable order, across a retry.",
+      "claim": "Rows reach the destination in WriteTable order, across a retry. Repeats are permitted, because delivery is at-least-once; a row that overtakes one written before it is not.",
       "verified_by": "harness",
       "class": "safety",
       "requires": [],
@@ -1749,8 +1809,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.preserves_order"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1763,8 +1825,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.preserves_order"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1787,8 +1851,10 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.flush.preserves_order"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1801,8 +1867,10 @@
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.flush.preserves_order"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1848,8 +1916,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.honours_context"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1862,8 +1932,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.honours_context"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1872,44 +1944,53 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "appends through the catalog and the local filesystem, which fail immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkIceberg_FlushCannotOutliveItsContext"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "appends through the catalog and the local filesystem, which fail immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkIceberg_FlushCannotOutliveItsContext"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "appends through the catalog and the local filesystem, which fail immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkIceberg_FlushCannotOutliveItsContext"
           }
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "runs the user's SQL on the pipeline's own DuckDB connection, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkSqlcommand_FlushCannotOutliveItsContext"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "runs the user's SQL on the pipeline's own DuckDB connection, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkSqlcommand_FlushCannotOutliveItsContext"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "runs the user's SQL on the pipeline's own DuckDB connection, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkSqlcommand_FlushCannotOutliveItsContext"
           }
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "writes to an io.Writer, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkConsole_FlushCannotOutliveItsContext"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "writes to an io.Writer, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkConsole_FlushCannotOutliveItsContext"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "writes to an io.Writer, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkConsole_FlushCannotOutliveItsContext"
           }
         },
         "sink.noop": {
@@ -1950,8 +2031,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1964,8 +2047,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1974,8 +2059,10 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkIceberg_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1988,8 +2075,10 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -2002,8 +2091,10 @@
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -2016,16 +2107,19 @@
         },
         "sink.noop": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       }
@@ -2134,105 +2228,6 @@
           "release": {
             "status": "exempt",
             "reason": "has no destination; it holds nothing, so there is no depth to report",
-            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
-          }
-        }
-      }
-    },
-    {
-      "id": "sink.batch.reports_buffer",
-      "family": "resilience",
-      "applies_to": "sink",
-      "claim": "Batch returns what is buffered, and nil when nothing is.",
-      "verified_by": "harness",
-      "class": "safety",
-      "requires": [],
-      "enforced": false,
-      "integrations": {
-        "sink.kafka": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.clickhouse": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.iceberg": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.sqlcommand": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.console": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.noop": {
-          "unit": {
-            "status": "exempt",
-            "reason": "has no destination; discarding every row is the contract",
-            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
-          },
-          "integration": {
-            "status": "exempt",
-            "reason": "has no destination; discarding every row is the contract",
-            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
-          },
-          "release": {
-            "status": "exempt",
-            "reason": "has no destination; discarding every row is the contract",
             "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -146,11 +146,16 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkKafka_Conformance",
-            "TestSinkKafka_BatchIsTheLastWrite",
+            "TestSinkKafka_ARecordTimeoutIsUnreachable",
+            "TestSinkKafka_FlushCodesAnUnreachableBroker",
             "TestSinkKafka_FlushHonoursItsContext",
             "TestSinkKafka_FlushReportsProduceErrors",
+            "TestSinkKafka_FlushReturnsWithoutADeadline",
+            "TestSinkKafka_HasADeliveryTimeoutByDefault",
+            "TestSinkKafka_ImplementsProber",
             "TestSinkKafka_NewRejectsAnUnknownSecurityProtocol",
             "TestSinkKafka_NewRequiresATopic",
+            "TestSinkKafka_ProbeFailsAgainstAnUnreachableBroker",
             "TestSinkKafka_WriteTableBuffersWhateverItsContextSays"
           ],
           "skipped": [
@@ -161,8 +166,14 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkKafka_Conformance",
+            "TestIntegrationSinkKafka_Conformance/lifecycle.close.idempotent",
             "TestIntegrationSinkKafka_Conformance/sink.buffer.reports_depth",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.empty_is_noop",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.honours_context",
             "TestIntegrationSinkKafka_Conformance/sink.flush.keeps_batch",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.no_hollow_success",
+            "TestIntegrationSinkKafka_Conformance/sink.flush.preserves_order",
+            "TestIntegrationSinkKafka_Conformance/sink.probe.fails_start",
             "TestIntegrationSinkKafka_Conformance/sink.write.buffers_only"
           ]
         },
@@ -195,7 +206,6 @@
             "TestSinkClickhouse_ANullOfAnUnsupportedTypeStillFails",
             "TestSinkClickhouse_AnEmptyListOfASupportedTypeIsStillEmpty",
             "TestSinkClickhouse_AnEmptyListOfAnUnsupportedTypeFailsWithACode",
-            "TestSinkClickhouse_BatchIsNil",
             "TestSinkClickhouse_EmptyTableIsNoop",
             "TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered",
             "TestSinkClickhouse_InsertsArrays",
@@ -215,7 +225,6 @@
           "skipped": [
             "TestIntegrationSinkClickhouse_Conformance",
             "TestIntegrationSinkClickhouse_Types",
-            "TestSinkClickhouse_BatchIsNil",
             "TestSinkClickhouse_EmptyTableIsNoop",
             "TestSinkClickhouse_FailedFlushKeepsTheBatchBuffered",
             "TestSinkClickhouse_InsertsArrays",
@@ -230,8 +239,14 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkClickhouse_Conformance",
+            "TestIntegrationSinkClickhouse_Conformance/lifecycle.close.idempotent",
             "TestIntegrationSinkClickhouse_Conformance/sink.buffer.reports_depth",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.empty_is_noop",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.honours_context",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.keeps_batch",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.no_hollow_success",
+            "TestIntegrationSinkClickhouse_Conformance/sink.flush.preserves_order",
+            "TestIntegrationSinkClickhouse_Conformance/sink.probe.fails_start",
             "TestIntegrationSinkClickhouse_Conformance/sink.write.buffers_only",
             "TestIntegrationSinkClickhouse_Types",
             "TestIntegrationSinkClickhouse_Types/type.nested",
@@ -262,20 +277,34 @@
           "tests": [
             "TestSinkIceberg_AddsPyicebergsMissingTypeColumn",
             "TestSinkIceberg_AppendsEveryRow",
-            "TestSinkIceberg_BatchIsTheLastWrite",
             "TestSinkIceberg_CatalogPropertiesEnvOverridesFile",
             "TestSinkIceberg_CatalogPropertiesFromPyicebergFile",
             "TestSinkIceberg_CatalogPropertiesRejectAnUnsupportedScheme",
             "TestSinkIceberg_CatalogPropertiesRequireAURI",
             "TestSinkIceberg_Conformance",
+            "TestSinkIceberg_Conformance/lifecycle.close.idempotent",
             "TestSinkIceberg_Conformance/sink.buffer.reports_depth",
+            "TestSinkIceberg_Conformance/sink.flush.empty_is_noop",
+            "TestSinkIceberg_Conformance/sink.flush.honours_context",
             "TestSinkIceberg_Conformance/sink.flush.keeps_batch",
+            "TestSinkIceberg_Conformance/sink.flush.no_hollow_success",
+            "TestSinkIceberg_Conformance/sink.flush.preserves_order",
+            "TestSinkIceberg_Conformance/sink.probe.fails_start",
             "TestSinkIceberg_Conformance/sink.write.buffers_only",
             "TestSinkIceberg_EmptyBatchAppendsNothing",
+            "TestSinkIceberg_FlushCannotOutliveItsContext",
             "TestSinkIceberg_FlushWithNothingPendingAppendsNothing",
+            "TestSinkIceberg_ImplementsNoCloser",
+            "TestSinkIceberg_ImplementsNoProber",
             "TestSinkIceberg_MissingTableFailsTheStart",
             "TestSinkIceberg_NewRequiresCatalogAndTable",
             "TestSinkIceberg_TypeColumnSkipsAnEmptyCatalog"
+          ],
+          "skipped": [
+            "TestSinkIceberg_Conformance/lifecycle.close.idempotent",
+            "TestSinkIceberg_Conformance/sink.flush.honours_context",
+            "TestSinkIceberg_Conformance/sink.flush.preserves_order",
+            "TestSinkIceberg_Conformance/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -321,20 +350,32 @@
           "status": "covered",
           "tests": [
             "TestSinkSqlcommand_AccumulatesUntilFlush",
-            "TestSinkSqlcommand_BatchIsTheLastWrite",
             "TestSinkSqlcommand_Conformance",
+            "TestSinkSqlcommand_Conformance/lifecycle.close.idempotent",
             "TestSinkSqlcommand_Conformance/sink.buffer.reports_depth",
+            "TestSinkSqlcommand_Conformance/sink.flush.empty_is_noop",
+            "TestSinkSqlcommand_Conformance/sink.flush.honours_context",
             "TestSinkSqlcommand_Conformance/sink.flush.keeps_batch",
+            "TestSinkSqlcommand_Conformance/sink.flush.no_hollow_success",
+            "TestSinkSqlcommand_Conformance/sink.flush.preserves_order",
+            "TestSinkSqlcommand_Conformance/sink.probe.fails_start",
             "TestSinkSqlcommand_Conformance/sink.write.buffers_only",
             "TestSinkSqlcommand_EachFlushReplacesTheBatchTable",
             "TestSinkSqlcommand_EmptyBatchStillRunsTheSQL",
+            "TestSinkSqlcommand_FlushCannotOutliveItsContext",
             "TestSinkSqlcommand_FlushWithNothingPendingIsANoop",
+            "TestSinkSqlcommand_ImplementsNoCloser",
             "TestSinkSqlcommand_ImplementsNoProber",
             "TestSinkSqlcommand_NewRequiresSQL",
             "TestSinkSqlcommand_RejectsAnUnknownSubstitution",
             "TestSinkSqlcommand_ReportsASQLError",
             "TestSinkSqlcommand_RunsSQLAgainstTheBatch",
             "TestSinkSqlcommand_SubstitutesUUID4"
+          ],
+          "skipped": [
+            "TestSinkSqlcommand_Conformance/lifecycle.close.idempotent",
+            "TestSinkSqlcommand_Conformance/sink.flush.honours_context",
+            "TestSinkSqlcommand_Conformance/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -357,12 +398,25 @@
           "status": "covered",
           "tests": [
             "TestSinkConsole_Conformance",
+            "TestSinkConsole_Conformance/lifecycle.close.idempotent",
             "TestSinkConsole_Conformance/sink.buffer.reports_depth",
+            "TestSinkConsole_Conformance/sink.flush.empty_is_noop",
+            "TestSinkConsole_Conformance/sink.flush.honours_context",
             "TestSinkConsole_Conformance/sink.flush.keeps_batch",
+            "TestSinkConsole_Conformance/sink.flush.no_hollow_success",
+            "TestSinkConsole_Conformance/sink.flush.preserves_order",
+            "TestSinkConsole_Conformance/sink.probe.fails_start",
             "TestSinkConsole_Conformance/sink.write.buffers_only",
+            "TestSinkConsole_FlushCannotOutliveItsContext",
+            "TestSinkConsole_ImplementsNoCloser",
             "TestSinkConsole_ImplementsNoProber",
             "TestSinkConsole_RowsAsJSONEmptyTable",
             "TestSinkConsole_RowsAsJSONOneObjectPerRow"
+          ],
+          "skipped": [
+            "TestSinkConsole_Conformance/lifecycle.close.idempotent",
+            "TestSinkConsole_Conformance/sink.flush.honours_context",
+            "TestSinkConsole_Conformance/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -390,6 +444,7 @@
           "status": "covered",
           "tests": [
             "TestSinkNoop_DeliversNothingAndSaysSo",
+            "TestSinkNoop_ImplementsNoCloser",
             "TestSinkNoop_ImplementsNoProber"
           ]
         },
@@ -1350,6 +1405,10 @@
             "TestToolingConformanceCanonicalKey_IgnoresChildNamesAndNullability",
             "TestToolingConformanceCanonicalKey_NamesEachConstructor",
             "TestToolingConformanceCanonicalKey_WildcardsTheTimestampZone",
+            "TestToolingConformanceDelivered_AllowsARepeat",
+            "TestToolingConformanceDelivered_CatchesALostRow",
+            "TestToolingConformanceDelivered_CatchesAReorder",
+            "TestToolingConformanceDelivered_CatchesAnEmptyDestination",
             "TestToolingConformanceDescribe_NamesTheRowsItFound",
             "TestToolingConformanceLattice_AUnionNullLivesInItsChild",
             "TestToolingConformanceLattice_BuildsAListWithANullElement",
@@ -1364,22 +1423,39 @@
             "TestToolingConformancePipelines_RunsEveryTrigger",
             "TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink",
             "TestToolingConformanceSinks_ACorrectSinkPasses",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/lifecycle.close.idempotent",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.buffer.reports_depth",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.empty_is_noop",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.honours_context",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.keeps_batch",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.no_hollow_success",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.preserves_order",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.probe.fails_start",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.write.buffers_only",
             "TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly",
+            "TestToolingConformanceSinks_ADuplicatingSinkPasses",
+            "TestToolingConformanceSinks_AHollowSuccessIsCaught",
+            "TestToolingConformanceSinks_ALosingSinkIsCaught",
+            "TestToolingConformanceSinks_AProbeThatCannotFailIsCaught",
+            "TestToolingConformanceSinks_AReorderingSinkIsCaught",
+            "TestToolingConformanceSinks_ASinkThatCannotCloseTwiceIsCaught",
             "TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught",
-            "TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught",
             "TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught",
+            "TestToolingConformanceSinks_ASinkThatIgnoresItsContextIsCaught",
             "TestToolingConformanceSinks_ASinkThatMisreportsItsDepthIsCaught",
+            "TestToolingConformanceSinks_ASinkThatNeverDrainsIsCaught",
             "TestToolingConformanceSinks_ASinkThatReportsNoDepthIsSkipped",
             "TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught",
+            "TestToolingConformanceSinks_ASinkWithNoProbeOrCloseIsSkipped",
             "TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker",
+            "TestToolingConformanceSinks_ASlowProbeIsCaught",
             "TestToolingConformanceSinks_ASubjectMissingReadBackIsRejected",
             "TestToolingConformanceSinks_ASubjectWithBreakAndNoHealIsRejected",
             "TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped",
             "TestToolingConformanceSinks_ASubjectWithoutAnIntegrationIdIsRejected",
             "TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject",
+            "TestToolingConformanceSinks_AnEagerEmptyFlushIsCaught",
+            "TestToolingConformanceSinks_AnUnorderedReadBackSkipsOrder",
             "TestToolingConformanceSinks_JudgesOnlyDeclaredInvariants",
             "TestToolingConformanceSinks_TheDoublesIntegrationIsNotAShippedSink",
             "TestToolingConformanceSinks_TheDoublesRunUnderATestOnlyIntegration",
@@ -1404,6 +1480,11 @@
             "TestToolingConformanceTypes_AnEmptyStringReadBackAsNullIsCaught",
             "TestToolingConformanceTypes_AnUndeclaredTypeThatSucceedsIsCaught",
             "TestToolingConformanceTypes_AnUnsupportedElementInsideAListIsCaught"
+          ],
+          "skipped": [
+            "TestToolingConformanceSinks_ACorrectSinkPasses/lifecycle.close.idempotent",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.honours_context",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -1570,7 +1651,7 @@
       "id": "sink.flush.keeps_batch",
       "family": "resilience",
       "applies_to": "sink",
-      "claim": "A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them.",
+      "claim": "A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. Delivery is at-least-once, so a row that arrives twice holds the claim and a row that never arrives breaks it.",
       "verified_by": "harness",
       "class": "safety",
       "requires": [],
@@ -1694,8 +1775,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1708,8 +1791,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1718,8 +1803,10 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkIceberg_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1732,8 +1819,10 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1746,8 +1835,10 @@
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.flush.no_hollow_success"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1784,7 +1875,7 @@
       "id": "sink.flush.preserves_order",
       "family": "resilience",
       "applies_to": "sink",
-      "claim": "Rows reach the destination in WriteTable order, across a retry.",
+      "claim": "Rows reach the destination in WriteTable order, across a retry. Repeats are permitted, because delivery is at-least-once; a row that overtakes one written before it is not.",
       "verified_by": "harness",
       "class": "safety",
       "requires": [],
@@ -1796,8 +1887,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.preserves_order"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1810,8 +1903,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.preserves_order"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1834,8 +1929,10 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.flush.preserves_order"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1848,8 +1945,10 @@
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.flush.preserves_order"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -1895,8 +1994,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.honours_context"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1909,8 +2010,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.honours_context"
+            ]
           },
           "release": {
             "status": "missing",
@@ -1919,44 +2022,53 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "appends through the catalog and the local filesystem, which fail immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkIceberg_FlushCannotOutliveItsContext"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "appends through the catalog and the local filesystem, which fail immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkIceberg_FlushCannotOutliveItsContext"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "appends through the catalog and the local filesystem, which fail immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkIceberg_FlushCannotOutliveItsContext"
           }
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "runs the user's SQL on the pipeline's own DuckDB connection, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkSqlcommand_FlushCannotOutliveItsContext"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "runs the user's SQL on the pipeline's own DuckDB connection, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkSqlcommand_FlushCannotOutliveItsContext"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "runs the user's SQL on the pipeline's own DuckDB connection, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkSqlcommand_FlushCannotOutliveItsContext"
           }
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "writes to an io.Writer, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkConsole_FlushCannotOutliveItsContext"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "writes to an io.Writer, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkConsole_FlushCannotOutliveItsContext"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "writes to an io.Writer, which returns or fails immediately; no flush can still be running when a deadline arrives\n",
+            "proven_by": "TestSinkConsole_FlushCannotOutliveItsContext"
           }
         },
         "sink.noop": {
@@ -1997,8 +2109,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "release": {
             "status": "missing",
@@ -2011,8 +2125,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "release": {
             "status": "missing",
@@ -2021,8 +2137,10 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkIceberg_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -2035,8 +2153,10 @@
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkSqlcommand_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -2049,8 +2169,10 @@
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestSinkConsole_Conformance/sink.flush.empty_is_noop"
+            ]
           },
           "integration": {
             "status": "missing",
@@ -2063,16 +2185,19 @@
         },
         "sink.noop": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "has no destination; discarding every row is the contract",
+            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
       }
@@ -2181,105 +2306,6 @@
           "release": {
             "status": "exempt",
             "reason": "has no destination; it holds nothing, so there is no depth to report",
-            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
-          }
-        }
-      }
-    },
-    {
-      "id": "sink.batch.reports_buffer",
-      "family": "resilience",
-      "applies_to": "sink",
-      "claim": "Batch returns what is buffered, and nil when nothing is.",
-      "verified_by": "harness",
-      "class": "safety",
-      "requires": [],
-      "enforced": false,
-      "integrations": {
-        "sink.kafka": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.clickhouse": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.iceberg": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.sqlcommand": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.console": {
-          "unit": {
-            "status": "missing",
-            "tests": []
-          },
-          "integration": {
-            "status": "missing",
-            "tests": []
-          },
-          "release": {
-            "status": "missing",
-            "tests": []
-          }
-        },
-        "sink.noop": {
-          "unit": {
-            "status": "exempt",
-            "reason": "has no destination; discarding every row is the contract",
-            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
-          },
-          "integration": {
-            "status": "exempt",
-            "reason": "has no destination; discarding every row is the contract",
-            "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
-          },
-          "release": {
-            "status": "exempt",
-            "reason": "has no destination; discarding every row is the contract",
             "proven_by": "TestSinkNoop_DeliversNothingAndSaysSo"
           }
         }
@@ -2400,8 +2426,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.probe.fails_start"
+            ]
           },
           "release": {
             "status": "missing",
@@ -2414,8 +2442,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.probe.fails_start"
+            ]
           },
           "release": {
             "status": "missing",
@@ -2424,16 +2454,19 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkIceberg_ImplementsNoProber"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkIceberg_ImplementsNoProber"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkIceberg_ImplementsNoProber"
           }
         },
         "sink.sqlcommand": {
@@ -3704,8 +3737,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/lifecycle.close.idempotent"
+            ]
           },
           "release": {
             "status": "missing",
@@ -3718,8 +3753,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/lifecycle.close.idempotent"
+            ]
           },
           "release": {
             "status": "missing",
@@ -3728,58 +3765,70 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds no client to release",
+            "proven_by": "TestSinkIceberg_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds no client to release",
+            "proven_by": "TestSinkIceberg_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds no client to release",
+            "proven_by": "TestSinkIceberg_ImplementsNoCloser"
           }
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the DuckDB connection belongs to the pipeline and this sink must not close it\n",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the DuckDB connection belongs to the pipeline and this sink must not close it\n",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the DuckDB connection belongs to the pipeline and this sink must not close it\n",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoCloser"
           }
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the io.Writer belongs to its caller and this sink must not close it\n",
+            "proven_by": "TestSinkConsole_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the io.Writer belongs to its caller and this sink must not close it\n",
+            "proven_by": "TestSinkConsole_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the io.Writer belongs to its caller and this sink must not close it\n",
+            "proven_by": "TestSinkConsole_ImplementsNoCloser"
           }
         },
         "sink.noop": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds nothing to release",
+            "proven_by": "TestSinkNoop_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds nothing to release",
+            "proven_by": "TestSinkNoop_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds nothing to release",
+            "proven_by": "TestSinkNoop_ImplementsNoCloser"
           }
         }
       }

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -152,8 +152,10 @@
             "TestSinkKafka_FlushReportsProduceErrors",
             "TestSinkKafka_FlushReturnsWithoutADeadline",
             "TestSinkKafka_HasADeliveryTimeoutByDefault",
+            "TestSinkKafka_ImplementsProber",
             "TestSinkKafka_NewRejectsAnUnknownSecurityProtocol",
             "TestSinkKafka_NewRequiresATopic",
+            "TestSinkKafka_ProbeFailsAgainstAnUnreachableBroker",
             "TestSinkKafka_WriteTableBuffersWhateverItsContextSays"
           ],
           "skipped": [
@@ -164,12 +166,14 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkKafka_Conformance",
+            "TestIntegrationSinkKafka_Conformance/lifecycle.close.idempotent",
             "TestIntegrationSinkKafka_Conformance/sink.buffer.reports_depth",
             "TestIntegrationSinkKafka_Conformance/sink.flush.empty_is_noop",
             "TestIntegrationSinkKafka_Conformance/sink.flush.honours_context",
             "TestIntegrationSinkKafka_Conformance/sink.flush.keeps_batch",
             "TestIntegrationSinkKafka_Conformance/sink.flush.no_hollow_success",
             "TestIntegrationSinkKafka_Conformance/sink.flush.preserves_order",
+            "TestIntegrationSinkKafka_Conformance/sink.probe.fails_start",
             "TestIntegrationSinkKafka_Conformance/sink.write.buffers_only"
           ]
         },
@@ -227,12 +231,14 @@
           "status": "covered",
           "tests": [
             "TestIntegrationSinkClickhouse_Conformance",
+            "TestIntegrationSinkClickhouse_Conformance/lifecycle.close.idempotent",
             "TestIntegrationSinkClickhouse_Conformance/sink.buffer.reports_depth",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.empty_is_noop",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.honours_context",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.keeps_batch",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.no_hollow_success",
             "TestIntegrationSinkClickhouse_Conformance/sink.flush.preserves_order",
+            "TestIntegrationSinkClickhouse_Conformance/sink.probe.fails_start",
             "TestIntegrationSinkClickhouse_Conformance/sink.write.buffers_only"
           ]
         },
@@ -262,23 +268,29 @@
             "TestSinkIceberg_CatalogPropertiesRejectAnUnsupportedScheme",
             "TestSinkIceberg_CatalogPropertiesRequireAURI",
             "TestSinkIceberg_Conformance",
+            "TestSinkIceberg_Conformance/lifecycle.close.idempotent",
             "TestSinkIceberg_Conformance/sink.buffer.reports_depth",
             "TestSinkIceberg_Conformance/sink.flush.empty_is_noop",
             "TestSinkIceberg_Conformance/sink.flush.honours_context",
             "TestSinkIceberg_Conformance/sink.flush.keeps_batch",
             "TestSinkIceberg_Conformance/sink.flush.no_hollow_success",
             "TestSinkIceberg_Conformance/sink.flush.preserves_order",
+            "TestSinkIceberg_Conformance/sink.probe.fails_start",
             "TestSinkIceberg_Conformance/sink.write.buffers_only",
             "TestSinkIceberg_EmptyBatchAppendsNothing",
             "TestSinkIceberg_FlushCannotOutliveItsContext",
             "TestSinkIceberg_FlushWithNothingPendingAppendsNothing",
+            "TestSinkIceberg_ImplementsNoCloser",
+            "TestSinkIceberg_ImplementsNoProber",
             "TestSinkIceberg_MissingTableFailsTheStart",
             "TestSinkIceberg_NewRequiresCatalogAndTable",
             "TestSinkIceberg_TypeColumnSkipsAnEmptyCatalog"
           ],
           "skipped": [
+            "TestSinkIceberg_Conformance/lifecycle.close.idempotent",
             "TestSinkIceberg_Conformance/sink.flush.honours_context",
-            "TestSinkIceberg_Conformance/sink.flush.preserves_order"
+            "TestSinkIceberg_Conformance/sink.flush.preserves_order",
+            "TestSinkIceberg_Conformance/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -325,17 +337,20 @@
           "tests": [
             "TestSinkSqlcommand_AccumulatesUntilFlush",
             "TestSinkSqlcommand_Conformance",
+            "TestSinkSqlcommand_Conformance/lifecycle.close.idempotent",
             "TestSinkSqlcommand_Conformance/sink.buffer.reports_depth",
             "TestSinkSqlcommand_Conformance/sink.flush.empty_is_noop",
             "TestSinkSqlcommand_Conformance/sink.flush.honours_context",
             "TestSinkSqlcommand_Conformance/sink.flush.keeps_batch",
             "TestSinkSqlcommand_Conformance/sink.flush.no_hollow_success",
             "TestSinkSqlcommand_Conformance/sink.flush.preserves_order",
+            "TestSinkSqlcommand_Conformance/sink.probe.fails_start",
             "TestSinkSqlcommand_Conformance/sink.write.buffers_only",
             "TestSinkSqlcommand_EachFlushReplacesTheBatchTable",
             "TestSinkSqlcommand_EmptyBatchStillRunsTheSQL",
             "TestSinkSqlcommand_FlushCannotOutliveItsContext",
             "TestSinkSqlcommand_FlushWithNothingPendingIsANoop",
+            "TestSinkSqlcommand_ImplementsNoCloser",
             "TestSinkSqlcommand_ImplementsNoProber",
             "TestSinkSqlcommand_NewRequiresSQL",
             "TestSinkSqlcommand_RejectsAnUnknownSubstitution",
@@ -344,7 +359,9 @@
             "TestSinkSqlcommand_SubstitutesUUID4"
           ],
           "skipped": [
-            "TestSinkSqlcommand_Conformance/sink.flush.honours_context"
+            "TestSinkSqlcommand_Conformance/lifecycle.close.idempotent",
+            "TestSinkSqlcommand_Conformance/sink.flush.honours_context",
+            "TestSinkSqlcommand_Conformance/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -367,20 +384,25 @@
           "status": "covered",
           "tests": [
             "TestSinkConsole_Conformance",
+            "TestSinkConsole_Conformance/lifecycle.close.idempotent",
             "TestSinkConsole_Conformance/sink.buffer.reports_depth",
             "TestSinkConsole_Conformance/sink.flush.empty_is_noop",
             "TestSinkConsole_Conformance/sink.flush.honours_context",
             "TestSinkConsole_Conformance/sink.flush.keeps_batch",
             "TestSinkConsole_Conformance/sink.flush.no_hollow_success",
             "TestSinkConsole_Conformance/sink.flush.preserves_order",
+            "TestSinkConsole_Conformance/sink.probe.fails_start",
             "TestSinkConsole_Conformance/sink.write.buffers_only",
             "TestSinkConsole_FlushCannotOutliveItsContext",
+            "TestSinkConsole_ImplementsNoCloser",
             "TestSinkConsole_ImplementsNoProber",
             "TestSinkConsole_RowsAsJSONEmptyTable",
             "TestSinkConsole_RowsAsJSONOneObjectPerRow"
           ],
           "skipped": [
-            "TestSinkConsole_Conformance/sink.flush.honours_context"
+            "TestSinkConsole_Conformance/lifecycle.close.idempotent",
+            "TestSinkConsole_Conformance/sink.flush.honours_context",
+            "TestSinkConsole_Conformance/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -408,6 +430,7 @@
           "status": "covered",
           "tests": [
             "TestSinkNoop_DeliversNothingAndSaysSo",
+            "TestSinkNoop_ImplementsNoCloser",
             "TestSinkNoop_ImplementsNoProber"
           ]
         },
@@ -1376,18 +1399,22 @@
             "TestToolingConformancePipelines_RunsEveryTrigger",
             "TestToolingConformanceSinks_ABreakThatDoesNotBreakFailsTheSubjectNotTheSink",
             "TestToolingConformanceSinks_ACorrectSinkPasses",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/lifecycle.close.idempotent",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.buffer.reports_depth",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.empty_is_noop",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.honours_context",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.keeps_batch",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.no_hollow_success",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.preserves_order",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.probe.fails_start",
             "TestToolingConformanceSinks_ACorrectSinkPasses/sink.write.buffers_only",
             "TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly",
             "TestToolingConformanceSinks_ADuplicatingSinkPasses",
             "TestToolingConformanceSinks_AHollowSuccessIsCaught",
             "TestToolingConformanceSinks_ALosingSinkIsCaught",
+            "TestToolingConformanceSinks_AProbeThatCannotFailIsCaught",
             "TestToolingConformanceSinks_AReorderingSinkIsCaught",
+            "TestToolingConformanceSinks_ASinkThatCannotCloseTwiceIsCaught",
             "TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught",
             "TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught",
             "TestToolingConformanceSinks_ASinkThatIgnoresItsContextIsCaught",
@@ -1395,7 +1422,9 @@
             "TestToolingConformanceSinks_ASinkThatNeverDrainsIsCaught",
             "TestToolingConformanceSinks_ASinkThatReportsNoDepthIsSkipped",
             "TestToolingConformanceSinks_ASinkThatWritesThroughIsCaught",
+            "TestToolingConformanceSinks_ASinkWithNoProbeOrCloseIsSkipped",
             "TestToolingConformanceSinks_ASkippedVerdictEmitsNoMarker",
+            "TestToolingConformanceSinks_ASlowProbeIsCaught",
             "TestToolingConformanceSinks_ASubjectMissingReadBackIsRejected",
             "TestToolingConformanceSinks_ASubjectWithBreakAndNoHealIsRejected",
             "TestToolingConformanceSinks_ASubjectWithNothingToBreakIsSkipped",
@@ -1408,7 +1437,9 @@
             "TestToolingConformanceSinks_TheDoublesRunUnderATestOnlyIntegration"
           ],
           "skipped": [
-            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.honours_context"
+            "TestToolingConformanceSinks_ACorrectSinkPasses/lifecycle.close.idempotent",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.flush.honours_context",
+            "TestToolingConformanceSinks_ACorrectSinkPasses/sink.probe.fails_start"
           ]
         },
         "integration": {
@@ -2348,8 +2379,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/sink.probe.fails_start"
+            ]
           },
           "release": {
             "status": "missing",
@@ -2362,8 +2395,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/sink.probe.fails_start"
+            ]
           },
           "release": {
             "status": "missing",
@@ -2372,16 +2407,19 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkIceberg_ImplementsNoProber"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkIceberg_ImplementsNoProber"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Prober, so there is no start-time check to fail",
+            "proven_by": "TestSinkIceberg_ImplementsNoProber"
           }
         },
         "sink.sqlcommand": {
@@ -3642,8 +3680,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkKafka_Conformance/lifecycle.close.idempotent"
+            ]
           },
           "release": {
             "status": "missing",
@@ -3656,8 +3696,10 @@
             "tests": []
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "covered",
+            "tests": [
+              "TestIntegrationSinkClickhouse_Conformance/lifecycle.close.idempotent"
+            ]
           },
           "release": {
             "status": "missing",
@@ -3666,58 +3708,70 @@
         },
         "sink.iceberg": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds no client to release",
+            "proven_by": "TestSinkIceberg_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds no client to release",
+            "proven_by": "TestSinkIceberg_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds no client to release",
+            "proven_by": "TestSinkIceberg_ImplementsNoCloser"
           }
         },
         "sink.sqlcommand": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the DuckDB connection belongs to the pipeline and this sink must not close it\n",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the DuckDB connection belongs to the pipeline and this sink must not close it\n",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the DuckDB connection belongs to the pipeline and this sink must not close it\n",
+            "proven_by": "TestSinkSqlcommand_ImplementsNoCloser"
           }
         },
         "sink.console": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the io.Writer belongs to its caller and this sink must not close it\n",
+            "proven_by": "TestSinkConsole_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the io.Writer belongs to its caller and this sink must not close it\n",
+            "proven_by": "TestSinkConsole_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; the io.Writer belongs to its caller and this sink must not close it\n",
+            "proven_by": "TestSinkConsole_ImplementsNoCloser"
           }
         },
         "sink.noop": {
           "unit": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds nothing to release",
+            "proven_by": "TestSinkNoop_ImplementsNoCloser"
           },
           "integration": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds nothing to release",
+            "proven_by": "TestSinkNoop_ImplementsNoCloser"
           },
           "release": {
-            "status": "missing",
-            "tests": []
+            "status": "exempt",
+            "reason": "implements no Close; it holds nothing to release",
+            "proven_by": "TestSinkNoop_ImplementsNoCloser"
           }
         }
       }

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -1229,11 +1229,19 @@
             "TestConfigValidation_ReportsMissingFile"
           ],
           "skipped": [
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/basic.agg.mem.yml",
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/basic.agg.yml",
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/bluesky.kafka.raw.yml",
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/bluesky.kafka.windowed.yml",
             "TestConfigValidation_ExampleConfigsBuildRealComponents/bluesky.postgres.windowed.yml",
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/csv.filesystem.join.yml",
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/csv.mem.join.yml",
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/enrich.yml",
             "TestConfigValidation_ExampleConfigsBuildRealComponents/kafka.clickhouse.yml",
             "TestConfigValidation_ExampleConfigsBuildRealComponents/kafka.mem.iceberg.yml",
             "TestConfigValidation_ExampleConfigsBuildRealComponents/kafka.sasl-tls.yml",
             "TestConfigValidation_ExampleConfigsBuildRealComponents/kafka.structured.disk.yml",
+            "TestConfigValidation_ExampleConfigsBuildRealComponents/tumbling.window.yml",
             "TestConfigValidation_ExampleConfigsBuildRealComponents/udf.yml"
           ]
         },

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -25,13 +25,13 @@ names every one of them.
 | `source.kafka` | Consumes a Kafka topic, tracking offsets and leader epochs. | ✅ | ✅ | ✅ | 28 |
 | `source.webhook` | Accepts records over HTTP, with optional HMAC signature checks. | ✅ | — | — | 15 |
 | `source.websocket` | Consumes a websocket stream, reconnecting on drop. | ✅ | — | ✅ | 6 |
-| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 12 |
-| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 34 |
-| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 17 |
+| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 23 |
+| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 39 |
+| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 25 |
 | `sink.parquet` | Writes result batches as parquet files to a local path. | — | — | ✅ | 1 |
-| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 15 |
-| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 8 |
-| `sink.noop` | Discards every result row, for measuring the engine without a sink. | ✅ | — | — | 2 |
+| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 22 |
+| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 16 |
+| `sink.noop` | Discards every result row, for measuring the engine without a sink. | ✅ | — | — | 3 |
 | `sink.retry` | Retries a sink whose destination is not answering, bounded by a deadline. | ✅ | — | — | 71 |
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
@@ -54,7 +54,7 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
-| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 58 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 79 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 14 |
 
 **34 features declared. 34 have at least one passing test attributed at every level they require, so 0 gap(s).**
@@ -65,7 +65,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**32 invariants declared: 28 safety and 4 liveness. Of 136 (invariant, integration) cells: 31 proven, 85 missing, 0 skipped, 0 failing, 20 exempt. 0 gap(s).**
+**31 invariants declared: 27 safety and 4 liveness. Of 130 (invariant, integration) cells: 51 proven, 51 missing, 0 skipped, 0 failing, 28 exempt. 0 gap(s).**
 
 Safety says nothing bad happens. Liveness says something good
 eventually does, and the two are not interchangeable: a sink that
@@ -77,7 +77,7 @@ does anything at all.
 ## Why invariants, and not the test count
 
 `sink.retry` carries 71 attributed tests, more than anything
-else in the `sink` layer. `sink.flush.no_hollow_success`, an invariant
+else in the `sink` layer. `sink.error.classifies`, an invariant
 of that same layer, is proven on 0 of the 5
 integrations it applies to.
 
@@ -129,15 +129,14 @@ invariant's `requires` is filled in, and none is yet.
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
-| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. *(violated once: #221)* | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
-| `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. *(violated once: #221)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. Delivery is at-least-once, so a row that arrives twice holds the claim and a row that never arrives breaks it. *(violated once: #221)* | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
+| `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. *(violated once: #221)* | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
+| `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. Repeats are permitted, because delivery is at-least-once; a row that overtakes one written before it is not. | ✅ i | ✅ i | ❌ missing | ✅ u | ✅ u | — exempt |
+| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ✅ i | ✅ i | — exempt | — exempt | — exempt | — exempt |
+| `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
 | `sink.buffer.reports_depth` | A sink reports how many rows it is holding, and the count rises when a flush fails and falls to zero when one succeeds. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
-| `sink.batch.reports_buffer` | Batch returns what is buffered, and nil when nothing is. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ✅ i | ✅ i | — exempt | — exempt | — exempt | — exempt |
 
 ## Safety invariants: checkpoint
 
@@ -177,7 +176,7 @@ drains. An invariant holds only if it holds on all four.
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `lifecycle.close.idempotent` | Close twice is safe. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `lifecycle.close.idempotent` | Close twice is safe. | ✅ i | ✅ i | — exempt | — exempt | — exempt | — exempt |
 
 These lifecycle invariants are properties of the consume loop
 rather than of anything a config file names. The columns are

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -25,13 +25,13 @@ names every one of them.
 | `source.kafka` | Consumes a Kafka topic, tracking offsets and leader epochs. | ✅ | ✅ | ✅ | 28 |
 | `source.webhook` | Accepts records over HTTP, with optional HMAC signature checks. | ✅ | — | — | 15 |
 | `source.websocket` | Consumes a websocket stream, reconnecting on drop. | ✅ | — | ✅ | 6 |
-| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 19 |
-| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 24 |
-| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 21 |
+| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 23 |
+| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 26 |
+| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 25 |
 | `sink.parquet` | Writes result batches as parquet files to a local path. | — | — | ✅ | 1 |
-| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 19 |
-| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 13 |
-| `sink.noop` | Discards every result row, for measuring the engine without a sink. | ✅ | — | — | 2 |
+| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 22 |
+| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 16 |
+| `sink.noop` | Discards every result row, for measuring the engine without a sink. | ✅ | — | — | 3 |
 | `sink.retry` | Retries a sink whose destination is not answering, bounded by a deadline. | ✅ | — | — | 71 |
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
@@ -54,7 +54,7 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
-| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 42 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 48 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
 **34 features declared. 34 have at least one passing test attributed at every level they require, so 0 gap(s).**
@@ -65,7 +65,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**31 invariants declared: 27 safety and 4 liveness. Of 130 (invariant, integration) cells: 42 proven, 65 missing, 0 skipped, 0 failing, 23 exempt. 0 gap(s).**
+**31 invariants declared: 27 safety and 4 liveness. Of 130 (invariant, integration) cells: 46 proven, 56 missing, 0 skipped, 0 failing, 28 exempt. 0 gap(s).**
 
 Safety says nothing bad happens. Liveness says something good
 eventually does, and the two are not interchangeable: a sink that
@@ -136,7 +136,7 @@ invariant's `requires` is filled in, and none is yet.
 | `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
 | `sink.buffer.reports_depth` | A sink reports how many rows it is holding, and the count rises when a flush fails and falls to zero when one succeeds. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
 | `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
+| `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ✅ i | ✅ i | — exempt | — exempt | — exempt | — exempt |
 
 ## Safety invariants: checkpoint
 
@@ -176,7 +176,7 @@ drains. An invariant holds only if it holds on all four.
 
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `lifecycle.close.idempotent` | Close twice is safe. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `lifecycle.close.idempotent` | Close twice is safe. | ✅ i | ✅ i | — exempt | — exempt | — exempt | — exempt |
 
 These lifecycle invariants are properties of the consume loop
 rather than of anything a config file names. The columns are

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -25,12 +25,12 @@ names every one of them.
 | `source.kafka` | Consumes a Kafka topic, tracking offsets and leader epochs. | ✅ | ✅ | ✅ | 28 |
 | `source.webhook` | Accepts records over HTTP, with optional HMAC signature checks. | ✅ | — | — | 15 |
 | `source.websocket` | Consumes a websocket stream, reconnecting on drop. | ✅ | — | ✅ | 6 |
-| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 12 |
-| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 21 |
-| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 17 |
+| `sink.kafka` | Publishes result rows to a Kafka topic. | ✅ | ✅ | ✅ | 19 |
+| `sink.clickhouse` | Inserts result batches into a ClickHouse table. | ✅ | ✅ | ✅ | 24 |
+| `sink.iceberg` | Appends result batches to an Iceberg table through a catalog. | ✅ | — | ✅ | 21 |
 | `sink.parquet` | Writes result batches as parquet files to a local path. | — | — | ✅ | 1 |
-| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 15 |
-| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 8 |
+| `sink.sqlcommand` | Runs a SQL command against the pipeline's own DuckDB connection. | ✅ | — | — | 19 |
+| `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 13 |
 | `sink.noop` | Discards every result row, for measuring the engine without a sink. | ✅ | — | — | 2 |
 | `sink.retry` | Retries a sink whose destination is not answering, bounded by a deadline. | ✅ | — | — | 71 |
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
@@ -54,7 +54,7 @@ names every one of them.
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — | 13 |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ | 9 |
 | `cli.version` | The shipped binary reports the version it was built from. | — | — | ✅ | 1 |
-| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 27 |
+| `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — | 42 |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — | 12 |
 
 **34 features declared. 34 have at least one passing test attributed at every level they require, so 0 gap(s).**
@@ -65,7 +65,7 @@ integration behind it keeps a batch it could not deliver, or commits
 offsets only after a flush. Those are invariants, they are counted
 separately below, and the two numbers are not interchangeable.
 
-**32 invariants declared: 28 safety and 4 liveness. Of 136 (invariant, integration) cells: 26 proven, 90 missing, 0 skipped, 0 failing, 20 exempt. 0 gap(s).**
+**31 invariants declared: 27 safety and 4 liveness. Of 130 (invariant, integration) cells: 42 proven, 65 missing, 0 skipped, 0 failing, 23 exempt. 0 gap(s).**
 
 Safety says nothing bad happens. Liveness says something good
 eventually does, and the two are not interchangeable: a sink that
@@ -77,7 +77,7 @@ does anything at all.
 ## Why invariants, and not the test count
 
 `sink.retry` carries 71 attributed tests, more than anything
-else in the `sink` layer. `sink.flush.no_hollow_success`, an invariant
+else in the `sink` layer. `sink.error.classifies`, an invariant
 of that same layer, is proven on 0 of the 5
 integrations it applies to.
 
@@ -129,13 +129,12 @@ invariant's `requires` is filled in, and none is yet.
 | Invariant | Claim | `sink.kafka` | `sink.clickhouse` | `sink.iceberg` | `sink.sqlcommand` | `sink.console` | `sink.noop` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `sink.write.buffers_only` | WriteTable does not reach the destination. Only Flush does. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
-| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. *(violated once: #221)* | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
-| `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. *(violated once: #221)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
-| `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing |
+| `sink.flush.keeps_batch` | A failed Flush leaves every undelivered row buffered. The next Flush re-attempts them. Delivery is at-least-once, so a row that arrives twice holds the claim and a row that never arrives breaks it. *(violated once: #221)* | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
+| `sink.flush.no_hollow_success` | Flush returns nil only when every row since the last success was acknowledged by the destination. *(violated once: #221)* | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
+| `sink.flush.preserves_order` | Rows reach the destination in WriteTable order, across a retry. Repeats are permitted, because delivery is at-least-once; a row that overtakes one written before it is not. | ✅ i | ✅ i | ❌ missing | ✅ u | ✅ u | — exempt |
+| `sink.flush.honours_context` | Flush returns ctx.Err() when the context ends. Rows stay buffered. *(violated once: #219)* | ✅ i | ✅ i | — exempt | — exempt | — exempt | — exempt |
+| `sink.flush.empty_is_noop` | Flush with nothing buffered returns nil and touches nothing. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
 | `sink.buffer.reports_depth` | A sink reports how many rows it is holding, and the count rises when a flush fails and falls to zero when one succeeds. | ✅ i | ✅ i | ✅ u | ✅ u | ✅ u | — exempt |
-| `sink.batch.reports_buffer` | Batch returns what is buffered, and nil when nothing is. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.error.classifies` | The sink's errors classify as unreachable or rejected, so the retry ladder retries the right ones. | ❌ missing | ❌ missing | ❌ missing | ❌ missing | ❌ missing | — exempt |
 | `sink.probe.fails_start` | A Prober whose destination is unreachable fails the start once, without retrying. | ❌ missing | ❌ missing | ❌ missing | — exempt | — exempt | — exempt |
 

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -21,6 +21,7 @@ package conformance
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -142,6 +143,8 @@ const (
 	keepsBatch   = "sink.flush.keeps_batch"
 	reportsDepth = "sink.buffer.reports_depth"
 	emptyIsNoop  = "sink.flush.empty_is_noop"
+
+	honoursContext = "sink.flush.honours_context"
 )
 
 // sinkVerdicts runs one sequence and judges four invariants from it.
@@ -184,6 +187,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			{invariant: buffersOnly, skipped: skip},
 			{invariant: keepsBatch, skipped: skip},
 			{invariant: reportsDepth, skipped: skip},
+			{invariant: honoursContext, skipped: skip},
 		}
 	}
 
@@ -250,9 +254,76 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	}
 
 	s.Break(t)
-	broken, cancel := context.WithTimeout(ctx, flushTimeout)
-	err := sink.Flush(broken)
+
+	// Bounded well inside flushTimeout, so a sink that ignores its deadline is
+	// caught by the gap between the two rather than by hanging the suite.
+	deadline := flushTimeout / 4
+	broken, cancel := context.WithTimeout(ctx, deadline)
+
+	// Run off this goroutine, so a sink that ignores its context fails this
+	// verdict rather than hanging the suite. Judging it after the call returned
+	// would mean never judging it at all.
+	type flushOutcome struct {
+		err     error
+		expired bool
+	}
+	done := make(chan flushOutcome, 1)
+	go func() {
+		e := sink.Flush(broken)
+		// Read before cancel below, which reports Canceled whatever happened.
+		done <- flushOutcome{err: e, expired: broken.Err() != nil}
+	}()
+
+	// Twice the deadline the sink was given. A sink that honours it returns
+	// well inside this; one that ignores it does not return at all.
+	grace := 2 * deadline
+
+	honours := verdict{invariant: honoursContext}
+	var (
+		err     error
+		expired bool
+		hung    bool
+	)
+	select {
+	case out := <-done:
+		err, expired = out.err, out.expired
+	case <-time.After(grace):
+		hung = true
+	}
 	cancel()
+
+	if hung {
+		honours.failure = "Flush did not return within " + grace.String() +
+			" against a context that expired after " + deadline.String() +
+			"; the pipeline's drain reaches the sink only through that context, " +
+			"so a sink that ignores it cannot be stopped"
+		// The flush is still running, so nothing below can be judged against
+		// this sink without racing it.
+		return []verdict{empty, buffers, {
+			invariant: keepsBatch,
+			skipped:   "Flush never returned; honours_context names the defect",
+		}, depth, honours}
+	}
+
+	switch {
+	case err == nil:
+		// Left to keeps_batch below, which explains why a flush into a broken
+		// destination succeeding is a delivery defect rather than a timing one.
+		honours.skipped = "Flush returned nil against a broken destination"
+	case !expired:
+		// The sink failed on its own before the deadline arrived, so no context
+		// ended and there is nothing to honour. Only a fault that hangs
+		// exercises this claim, which is a property of the subject's Break: a
+		// full disk and a dropped table refuse immediately, a partition does
+		// not.
+		honours.skipped = s.Integration + " fails a flush before its context " +
+			"expires, so no deadline was reached to honour; exempt it in " +
+			"integrations.yml or give it a fault that hangs"
+	case !errors.Is(err, context.DeadlineExceeded):
+		honours.failure = "Flush returned " + err.Error() +
+			", which does not wrap context.DeadlineExceeded; a caller cannot " +
+			"tell a sink that gave up on time from one that failed outright"
+	}
 
 	if err == nil {
 		// A flush that succeeds into a broken destination means one of two
@@ -275,7 +346,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			failure: "Flush returned nil while the destination was broken, " +
 				"because the rows had already been delivered by WriteTable; " +
 				"there was nothing left to keep",
-		}, depth}
+		}, depth, honours}
 	}
 
 	if reports && depth.failure == "" {
@@ -299,7 +370,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			keeps.failure = "Flush after Heal failed with " + err.Error() +
 				"; the retry did not deliver what the failed flush kept"
 		}
-		return []verdict{empty, buffers, keeps, depth}
+		return []verdict{empty, buffers, keeps, depth, honours}
 	}
 
 	if reports && depth.failure == "" {
@@ -312,11 +383,28 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	got := s.ReadBack(t)
 	if keeps.failure == "" {
 		want := []Row{{"id": int64(1)}, {"id": int64(2)}}
-		if bad := deliveredInOrder(got, want); bad != "" {
+		if bad := rowsArrived(got, want); bad != "" {
 			keeps.failure = "after a failed Flush and a successful retry, " + bad
 		}
 	}
-	return []verdict{empty, buffers, keeps, depth}
+	return []verdict{empty, buffers, keeps, depth, honours}
+}
+
+// rowsArrived reports the first row of want that never reached the
+// destination, if any.
+//
+// Loss is what keeps_batch claims: a row the sink could not deliver stays
+// buffered and the next Flush re-attempts it. Whether the rows arrived in
+// order is preserves_order's separate claim, and judging both here would blame
+// keeps_batch for an ordering defect and send the reader to the wrong file.
+func rowsArrived(got, want []Row) string {
+	for _, w := range want {
+		if indexOf(got, w) < 0 {
+			return "id=" + format(w["id"]) + " never reached the destination; " +
+				"want " + describe(want) + ", got " + describe(got)
+		}
+	}
+	return ""
 }
 
 // deliveredInOrder judges a read-back against at-least-once delivery.

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -22,6 +22,7 @@ package conformance
 import (
 	"context"
 	"errors"
+	"io"
 	"strconv"
 	"testing"
 	"time"
@@ -157,7 +158,27 @@ const (
 	honoursContext  = "sink.flush.honours_context"
 	noHollowSuccess = "sink.flush.no_hollow_success"
 	preservesOrder  = "sink.flush.preserves_order"
+
+	probeFailsStart = "sink.probe.fails_start"
+	closeIdempotent = "lifecycle.close.idempotent"
 )
+
+// prober mirrors sinks.Prober.
+//
+// Declared here rather than imported because internal/sinks imports this
+// package in its tests, so importing it back would be a cycle in the test
+// binary. Go interfaces are structural, so the two match without a dependency.
+type prober interface {
+	Probe(ctx context.Context) error
+}
+
+// probeTimeout is the deadline a Probe is given against a broken destination.
+//
+// probe() dials once and does not retry: nothing has been consumed yet, so
+// there is nothing to lose by failing now, and the supervisor's restart is
+// already the retry. A prober that ladders runs past twice this and is judged
+// on that, not on whether it used the deadline it was handed.
+const probeTimeout = 3 * time.Second
 
 // sinkVerdicts runs one sequence and judges four invariants from it.
 //
@@ -202,6 +223,8 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			{invariant: honoursContext, skipped: skip},
 			{invariant: noHollowSuccess, skipped: skip},
 			{invariant: preservesOrder, skipped: skip},
+			{invariant: probeFailsStart, skipped: skip},
+			{invariant: closeIdempotent, skipped: skip},
 		}
 	}
 
@@ -319,6 +342,8 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			depth, honours,
 			{invariant: noHollowSuccess, skipped: stuck},
 			{invariant: preservesOrder, skipped: stuck},
+			{invariant: probeFailsStart, skipped: stuck},
+			{invariant: closeIdempotent, skipped: stuck},
 		}
 	}
 
@@ -358,7 +383,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 				"broken and nothing had been delivered, so %s's Break did not "+
 				"break it", s.Integration)
 		}
-		return []verdict{empty, buffers, {
+		return append([]verdict{empty, buffers, {
 			invariant: keepsBatch,
 			failure: "Flush returned nil while the destination was broken, " +
 				"because the rows had already been delivered by WriteTable; " +
@@ -366,7 +391,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 		}, depth, honours,
 			{invariant: noHollowSuccess, skipped: "the rows were delivered on write"},
 			{invariant: preservesOrder, skipped: "the rows were delivered on write"},
-		}
+		}, startAndStop(t, s)...)
 	}
 
 	if reports && depth.failure == "" {
@@ -427,8 +452,9 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			keeps.failure = "Flush after Heal failed with " + err.Error() +
 				"; the retry did not deliver what the failed flush kept"
 		}
-		return []verdict{empty, buffers, keeps, depth, honours, hollow,
-			{invariant: preservesOrder, skipped: "the retry never delivered"}}
+		return append([]verdict{empty, buffers, keeps, depth, honours, hollow,
+			{invariant: preservesOrder, skipped: "the retry never delivered"}},
+			startAndStop(t, s)...)
 	}
 
 	if reports && depth.failure == "" {
@@ -463,7 +489,69 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 		}
 	}
 
-	return []verdict{empty, buffers, keeps, depth, honours, hollow, order}
+	return append([]verdict{empty, buffers, keeps, depth, honours, hollow, order},
+		startAndStop(t, s)...)
+}
+
+// startAndStop judges the two claims the delivery sequence cannot reach: that a
+// Probe fails fast against a destination that is not there, and that Close
+// survives a second call.
+//
+// It builds its own sink, because the one above holds a delivered buffer and
+// both claims are about a sink that has not started yet.
+func startAndStop(t *testing.T, s SinkSubject) []verdict {
+	t.Helper()
+
+	probes := verdict{invariant: probeFailsStart}
+	closes := verdict{invariant: closeIdempotent}
+
+	fresh := s.New(t)
+	s.Break(t)
+	defer s.Heal(t)
+
+	if p, ok := fresh.(prober); !ok {
+		probes.skipped = s.Integration + " implements no Prober, so there is " +
+			"no start-time check to fail; exempt it in integrations.yml"
+	} else {
+		// The deadline is the probe's bound, and reaching it is a legitimate
+		// way to fail: against a destination that hangs, nothing else can end
+		// the wait. What the claim rules out is a probe that ladders past its
+		// deadline, so the verdict measures against a grace well beyond it and
+		// runs off this goroutine to catch one that never returns at all.
+		ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+		done := make(chan error, 1)
+		go func() { done <- p.Probe(ctx) }()
+
+		grace := 2 * probeTimeout
+		select {
+		case err := <-done:
+			if err == nil {
+				probes.failure = "Probe returned nil against a broken " +
+					"destination; a probe that cannot fail certifies a " +
+					"destination that is not there"
+			}
+		case <-time.After(grace):
+			probes.failure = "Probe had not returned " + grace.String() +
+				" after being given a " + probeTimeout.String() + " deadline; " +
+				"it dials once and does not retry, because the supervisor's " +
+				"restart is already the retry"
+		}
+		cancel()
+	}
+
+	if c, ok := fresh.(io.Closer); !ok {
+		closes.skipped = s.Integration + " implements no Close, so there is " +
+			"nothing to close twice; exempt it in integrations.yml"
+	} else {
+		_ = c.Close()
+		if err := c.Close(); err != nil {
+			closes.failure = "the second Close returned " + err.Error() +
+				"; more than one shutdown path reaches Close, and the second " +
+				"must not change the exit status"
+		}
+	}
+
+	return []verdict{probes, closes}
 }
 
 // rowsArrived reports the first row of want that never reached the

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -141,26 +141,38 @@ const (
 	buffersOnly  = "sink.write.buffers_only"
 	keepsBatch   = "sink.flush.keeps_batch"
 	reportsDepth = "sink.buffer.reports_depth"
+	emptyIsNoop  = "sink.flush.empty_is_noop"
 )
 
-// sinkVerdicts runs one sequence and judges three invariants from it.
+// sinkVerdicts runs one sequence and judges four invariants from it.
 //
-//  1. WriteTable(A). The destination must still be empty -- buffers_only --
+//  0. Flush with nothing buffered. The destination must stay empty --
+//     empty_is_noop.
+//  1. WriteTable(A) and Flush. The destination now holds A, and everything
+//     below runs against a destination in the state production runs against.
+//  2. WriteTable(B). The destination must not have gained B -- buffers_only --
 //     and the sink must report one buffered row -- reports_depth.
-//  2. Break, then Flush must fail. The destination must still be empty and the
-//     sink must still report one row: what it could not deliver, it still owes.
-//  3. Heal, then Flush must succeed. The sink must now report none.
-//  4. The destination must hold exactly A, once -- keeps_batch.
+//  3. Break, then Flush must fail. B must still be absent and the sink must
+//     still report one row: what it could not deliver, it still owes.
+//  4. Heal, then Flush must succeed. The sink must now report none.
+//  5. The destination must hold A then B -- keeps_batch.
 //
-// The three are separate because a sink can hold any one without the others,
-// and together they are what the pipeline depends on. A sink that delivers in
-// WriteTable passes step 4 for the wrong reason: the row reached the
-// destination before the fault, so nothing was ever kept, and the failed
+// The judgments are separate because a sink can hold any one without the
+// others, and together they are what the pipeline depends on. A sink that
+// delivers in WriteTable passes step 5 for the wrong reason: the row reached
+// the destination before the fault, so nothing was ever kept, and the failed
 // flush left the pipeline unable to commit offsets for rows that did go out.
-// That is the Kafka sink's shape, and step 1 is what catches it.
+// Step 2 is what catches it.
 //
-// A sink that discards its buffer on a failed flush passes steps 1 and 2 and
-// holds nothing at step 4, which is the defect #221 fixed for ClickHouse.
+// A sink that discards its buffer on a failed flush passes steps 2 and 3 and
+// holds nothing at step 5, which is the defect #221 fixed for ClickHouse.
+//
+// Step 1 is why the sequence starts with a delivery rather than a fault. A
+// transport can behave differently before it has ever succeeded -- franz-go
+// watches a Produce context only while a topic is unknown, so the Kafka sink
+// took an abort path a resolved topic never reaches -- and a sink that only
+// loses rows after its first successful flush is invisible to a sequence that
+// never performs one.
 func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	t.Helper()
 
@@ -168,6 +180,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 		skip := "the subject has nothing to break; exempt " +
 			s.Integration + " in integrations.yml"
 		return []verdict{
+			{invariant: emptyIsNoop, skipped: skip},
 			{invariant: buffersOnly, skipped: skip},
 			{invariant: keepsBatch, skipped: skip},
 			{invariant: reportsDepth, skipped: skip},
@@ -175,18 +188,48 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	}
 
 	sink := s.New(t)
-	row := s.Table(t, 1)
+	ctx := context.Background()
+
+	// Step 0. Nothing is buffered, so nothing may reach the destination. The
+	// pipeline flushes on an interval whether or not a batch arrived, so a sink
+	// that writes here writes on every idle tick.
+	empty := verdict{invariant: emptyIsNoop}
+	if err := sink.Flush(ctx); err != nil {
+		empty.failure = "Flush with nothing buffered returned " + err.Error() +
+			"; an idle flush interval must not fail the pipeline"
+	} else if got := s.ReadBack(t); len(got) != 0 {
+		empty.failure = "the destination holds " + describe(got) +
+			" after a Flush when nothing was buffered"
+	}
+
+	// Step 1. One clean delivery, so every judgment below runs warm.
+	warm := s.Table(t, 1)
+	if err := sink.WriteTable(ctx, warm); err != nil {
+		warm.Release()
+		t.Fatalf("conformance: WriteTable during the pre-warm: %v", err)
+	}
+	if err := sink.Flush(ctx); err != nil {
+		warm.Release()
+		t.Fatalf("conformance: the pre-warm Flush failed against a healthy "+
+			"destination: %v", err)
+	}
+	warm.Release()
+
+	row := s.Table(t, 2)
 	defer row.Release()
 
-	ctx := context.Background()
 	if err := sink.WriteTable(ctx, row); err != nil {
 		t.Fatalf("conformance: WriteTable before any fault: %v", err)
 	}
 
 	// Judged before anything can go wrong, so a write-through sink is named
 	// for what it did rather than for a downstream symptom.
+	//
+	// The test is whether row 2 arrived, not how many rows are present. The
+	// pre-warm already delivered row 1, and a sink that delivers at-least-once
+	// may hold more than one copy of it.
 	buffers := verdict{invariant: buffersOnly}
-	if got := s.ReadBack(t); len(got) != 0 {
+	if got := s.ReadBack(t); indexOf(got, Row{"id": int64(2)}) >= 0 {
 		buffers.failure = "the destination holds " + describe(got) +
 			" after WriteTable and before any Flush; only Flush may deliver, " +
 			"because the pipeline commits offsets on what Flush reports"
@@ -227,7 +270,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 				"broken and nothing had been delivered, so %s's Break did not "+
 				"break it", s.Integration)
 		}
-		return []verdict{buffers, {
+		return []verdict{empty, buffers, {
 			invariant: keepsBatch,
 			failure: "Flush returned nil while the destination was broken, " +
 				"because the rows had already been delivered by WriteTable; " +
@@ -244,7 +287,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	}
 
 	keeps := verdict{invariant: keepsBatch}
-	if got := s.ReadBack(t); len(got) != 0 {
+	if got := s.ReadBack(t); indexOf(got, Row{"id": int64(2)}) >= 0 {
 		keeps.failure = "the destination holds " + describe(got) +
 			" after a Flush that failed; a row the sink could not deliver " +
 			"must stay buffered rather than reach the destination unreported"
@@ -256,7 +299,7 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			keeps.failure = "Flush after Heal failed with " + err.Error() +
 				"; the retry did not deliver what the failed flush kept"
 		}
-		return []verdict{buffers, keeps, depth}
+		return []verdict{empty, buffers, keeps, depth}
 	}
 
 	if reports && depth.failure == "" {
@@ -268,11 +311,12 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 
 	got := s.ReadBack(t)
 	if keeps.failure == "" {
-		if bad := deliveredInOrder(got, []Row{{"id": int64(1)}}); bad != "" {
+		want := []Row{{"id": int64(1)}, {"id": int64(2)}}
+		if bad := deliveredInOrder(got, want); bad != "" {
 			keeps.failure = "after a failed Flush and a successful retry, " + bad
 		}
 	}
-	return []verdict{buffers, keeps, depth}
+	return []verdict{empty, buffers, keeps, depth}
 }
 
 // deliveredInOrder judges a read-back against at-least-once delivery.

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -275,6 +275,55 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	return []verdict{buffers, keeps, depth}
 }
 
+// deliveredInOrder judges a read-back against at-least-once delivery.
+//
+// sqlflow delivers at-least-once end to end: a row reaches the destination one
+// or more times and is never lost. So this asks whether want appears in got as
+// a subsequence. A repeat passes, because the pipeline commits offsets only
+// after a flush returns nil and replays the batch when it does not, and the
+// tumbling manager keeps a closed window in DuckDB until its flush succeeds.
+// A missing row fails, and so does one that overtook a row written before it.
+//
+// It returns "" when the read-back honours the contract, and a sentence naming
+// the failure otherwise.
+func deliveredInOrder(got, want []Row) string {
+	next := 0
+	for _, w := range want {
+		found := -1
+		for j := next; j < len(got); j++ {
+			if got[j]["id"] == w["id"] {
+				found = j
+				break
+			}
+		}
+		if found >= 0 {
+			next = found + 1
+			continue
+		}
+
+		// Absent from the rest of the read-back. Either it never arrived, or it
+		// arrived before a row written before it -- two different defects, and
+		// the message has to send the reader to the right one.
+		if indexOf(got, w) >= 0 {
+			return "id=" + format(w["id"]) + " reached the destination out of " +
+				"order, before a row written earlier; want " + describe(want) +
+				" in that order, got " + describe(got)
+		}
+		return "id=" + format(w["id"]) + " never reached the destination; want " +
+			describe(want) + ", got " + describe(got)
+	}
+	return ""
+}
+
+func indexOf(rows []Row, want Row) int {
+	for i, r := range rows {
+		if r["id"] == want["id"] {
+			return i
+		}
+	}
+	return -1
+}
+
 func describe(rows []Row) string {
 	if len(rows) == 0 {
 		return "no rows"

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -55,9 +55,19 @@ type SinkSubject struct {
 	// Heal reverses Break.
 	Heal func(t *testing.T)
 
-	// ReadBack returns every row the destination holds, in delivery order.
-	// It must not go through whatever Break breaks.
+	// ReadBack returns every row the destination holds. It must not go through
+	// whatever Break breaks.
 	ReadBack func(t *testing.T) []Row
+
+	// OrderedReadBack says ReadBack returns rows in the order they arrived.
+	//
+	// False is the default because a destination that cannot report arrival
+	// order is common and the failure is silent: an Iceberg scan returns rows
+	// in data-file order, and a ClickHouse MergeTree returns them in its
+	// ORDER BY key order, so both would satisfy preserves_order while
+	// preserving nothing. The harness skips that claim rather than reading a
+	// sorted list as evidence, and integrations.yml must carry the exemption.
+	OrderedReadBack bool
 
 	// Table returns a one-row table with an int64 "id" column that the
 	// destination accepts. The subject owns the schema because a ClickHouse
@@ -144,7 +154,9 @@ const (
 	reportsDepth = "sink.buffer.reports_depth"
 	emptyIsNoop  = "sink.flush.empty_is_noop"
 
-	honoursContext = "sink.flush.honours_context"
+	honoursContext  = "sink.flush.honours_context"
+	noHollowSuccess = "sink.flush.no_hollow_success"
+	preservesOrder  = "sink.flush.preserves_order"
 )
 
 // sinkVerdicts runs one sequence and judges four invariants from it.
@@ -188,6 +200,8 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			{invariant: keepsBatch, skipped: skip},
 			{invariant: reportsDepth, skipped: skip},
 			{invariant: honoursContext, skipped: skip},
+			{invariant: noHollowSuccess, skipped: skip},
+			{invariant: preservesOrder, skipped: skip},
 		}
 	}
 
@@ -299,10 +313,13 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			"so a sink that ignores it cannot be stopped"
 		// The flush is still running, so nothing below can be judged against
 		// this sink without racing it.
-		return []verdict{empty, buffers, {
-			invariant: keepsBatch,
-			skipped:   "Flush never returned; honours_context names the defect",
-		}, depth, honours}
+		stuck := "Flush never returned; honours_context names the defect"
+		return []verdict{empty, buffers,
+			{invariant: keepsBatch, skipped: stuck},
+			depth, honours,
+			{invariant: noHollowSuccess, skipped: stuck},
+			{invariant: preservesOrder, skipped: stuck},
+		}
 	}
 
 	switch {
@@ -346,7 +363,10 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			failure: "Flush returned nil while the destination was broken, " +
 				"because the rows had already been delivered by WriteTable; " +
 				"there was nothing left to keep",
-		}, depth, honours}
+		}, depth, honours,
+			{invariant: noHollowSuccess, skipped: "the rows were delivered on write"},
+			{invariant: preservesOrder, skipped: "the rows were delivered on write"},
+		}
 	}
 
 	if reports && depth.failure == "" {
@@ -357,11 +377,48 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 		}
 	}
 
+	// keeps_batch is judged on what the retry delivers, not on what the
+	// destination holds now.
+	//
+	// A failed Flush does not mean nothing arrived. It means nothing was
+	// acknowledged. A produce request can reach the broker and be applied while
+	// the response is lost, which is exactly what a partition looks like from
+	// the client, and the sink cannot tell the two apart. Requiring the row to
+	// be absent here asserts exactly-once against an at-least-once engine, and
+	// a real broker behind a timeout toxic fails it while behaving correctly.
+	//
+	// The defect this used to aim at -- a sink that delivers before Flush --
+	// is buffers_only's, judged above and before the fault.
 	keeps := verdict{invariant: keepsBatch}
-	if got := s.ReadBack(t); indexOf(got, Row{"id": int64(2)}) >= 0 {
-		keeps.failure = "the destination holds " + describe(got) +
-			" after a Flush that failed; a row the sink could not deliver " +
-			"must stay buffered rather than reach the destination unreported"
+
+	// Step 4. A second row arrives while the destination is still broken, so
+	// the retry has two rows to deliver and an order to deliver them in.
+	third := s.Table(t, 3)
+	if err := sink.WriteTable(ctx, third); err != nil {
+		third.Release()
+		t.Fatalf("conformance: WriteTable while the destination was broken: %v", err)
+	}
+	third.Release()
+
+	if reports && depth.failure == "" {
+		if n := reporter.BufferedRows(); n != 2 {
+			depth.failure = "reports " + strconv.Itoa(n) +
+				" buffered rows after a failed Flush and a second WriteTable; " +
+				"want 2, because both rows are still owed"
+		}
+	}
+
+	// Step 5. Flushing into the same fault must fail again. A sink that clears
+	// its error state after reporting returns nil here having delivered
+	// nothing, and the pipeline commits offsets for rows that never landed.
+	hollow := verdict{invariant: noHollowSuccess}
+	secondBroken, cancelSecond := context.WithTimeout(ctx, deadline)
+	secondErr := sink.Flush(secondBroken)
+	cancelSecond()
+	if secondErr == nil && buffers.failure == "" {
+		hollow.failure = "a second Flush into the same broken destination " +
+			"returned nil; Flush may return nil only when every row since the " +
+			"last success reached the destination"
 	}
 
 	s.Heal(t)
@@ -370,7 +427,8 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 			keeps.failure = "Flush after Heal failed with " + err.Error() +
 				"; the retry did not deliver what the failed flush kept"
 		}
-		return []verdict{empty, buffers, keeps, depth, honours}
+		return []verdict{empty, buffers, keeps, depth, honours, hollow,
+			{invariant: preservesOrder, skipped: "the retry never delivered"}}
 	}
 
 	if reports && depth.failure == "" {
@@ -381,13 +439,31 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	}
 
 	got := s.ReadBack(t)
+	want := []Row{{"id": int64(1)}, {"id": int64(2)}, {"id": int64(3)}}
+
 	if keeps.failure == "" {
-		want := []Row{{"id": int64(1)}, {"id": int64(2)}}
 		if bad := rowsArrived(got, want); bad != "" {
 			keeps.failure = "after a failed Flush and a successful retry, " + bad
 		}
 	}
-	return []verdict{empty, buffers, keeps, depth, honours}
+
+	// The same read-back, asked the other question. Loss belongs to
+	// keeps_batch above; this is only about the order the rows arrived in.
+	order := verdict{invariant: preservesOrder}
+	switch {
+	case !s.OrderedReadBack:
+		order.skipped = s.Integration + " reads its destination back in an " +
+			"order that is not the order rows arrived in, so this cannot be " +
+			"judged; exempt it in integrations.yml"
+	case keeps.failure != "":
+		order.skipped = "rows were lost, so there is no order to judge"
+	default:
+		if bad := deliveredInOrder(got, want); bad != "" {
+			order.failure = "after a failed Flush and a successful retry, " + bad
+		}
+	}
+
+	return []verdict{empty, buffers, keeps, depth, honours, hollow, order}
 }
 
 // rowsArrived reports the first row of want that never reached the

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -267,10 +267,10 @@ func sinkVerdicts(t *testing.T, s SinkSubject) []verdict {
 	}
 
 	got := s.ReadBack(t)
-	if keeps.failure == "" && (len(got) != 1 || got[0]["id"] != int64(1)) {
-		keeps.failure = "after a failed Flush and a successful retry the " +
-			"destination holds " + describe(got) +
-			"; want exactly the row the failed flush could not deliver"
+	if keeps.failure == "" {
+		if bad := deliveredInOrder(got, []Row{{"id": int64(1)}}); bad != "" {
+			keeps.failure = "after a failed Flush and a successful retry, " + bad
+		}
 	}
 	return []verdict{buffers, keeps, depth}
 }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -88,6 +89,15 @@ func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
 	v := verdicts(t, subject(&staysDownSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
+}
+
+// A sink that ignores its context cannot be stopped. The pipeline's drain and
+// every other caller reach it only through that context.
+func TestToolingConformanceSinks_ASinkThatIgnoresItsContextIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	v := verdicts(t, subject(&deafSink{memSink: newMemSink()}))[honoursContext]
+
+	assert.True(t, strings.Contains(v.failure, "did not return"))
 }
 
 // A flush with nothing buffered must reach nothing. The pipeline flushes on an
@@ -455,6 +465,22 @@ func (d *duplicatingSink) Flush(context.Context) error {
 	return nil
 }
 
+// deafSink ignores the context it is given: it sleeps past any deadline before
+// reporting the failure.
+//
+// Every caller reaches the sink through that context. A flush interval that
+// elapsed, a cancelled run and a SIGTERM have no other way to stop a flush, so
+// a sink that ignores it cannot be stopped at all.
+type deafSink struct{ *memSink }
+
+func (d *deafSink) Flush(ctx context.Context) error {
+	err := d.memSink.Flush(ctx)
+	if err != nil {
+		time.Sleep(2 * flushTimeout)
+	}
+	return err
+}
+
 // eagerFlushSink writes even when nothing is buffered. The pipeline flushes on
 // an interval whether or not a batch arrived, so this sink writes on every idle
 // tick.
@@ -538,7 +564,7 @@ func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
 	for _, v := range sinkVerdicts(t, s) {
 		out[v.invariant] = v
 	}
-	assert.Equal(t, 4, len(out))
+	assert.Equal(t, 5, len(out))
 	return out
 }
 

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -230,15 +230,6 @@ func (m *memSink) Flush(context.Context) error {
 	return nil
 }
 
-func (m *memSink) Batch() (arrow.Table, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if len(m.buffered) == 0 {
-		return nil, nil
-	}
-	return m.buffered[0], nil
-}
-
 // BufferedRows makes the fakes honest about what they hold, so the harness
 // can judge reports_depth against them the way it does against a real sink.
 func (m *memSink) BufferedRows() int {
@@ -344,7 +335,6 @@ func (n *noDepthSink) WriteTable(ctx context.Context, t arrow.Table) error {
 	return n.inner.WriteTable(ctx, t)
 }
 func (n *noDepthSink) Flush(ctx context.Context) error { return n.inner.Flush(ctx) }
-func (n *noDepthSink) Batch() (arrow.Table, error)     { return n.inner.Batch() }
 func (n *noDepthSink) set(down bool)                   { n.inner.set(down) }
 func (n *noDepthSink) rows() []Row                     { return n.inner.rows() }
 

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -91,6 +91,37 @@ func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
 }
 
+// A second flush into the same fault must fail again. Returning nil tells the
+// pipeline to commit offsets for rows that never landed.
+func TestToolingConformanceSinks_AHollowSuccessIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	v := verdicts(t, subject(&hollowSink{memSink: newMemSink()}))[noHollowSuccess]
+
+	assert.True(t, strings.Contains(v.failure, "returned nil"))
+}
+
+// A sink that delivers its buffer backwards loses nothing, so keeps_batch
+// holds and only the ordering claim catches it.
+func TestToolingConformanceSinks_AReorderingSinkIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	vs := verdicts(t, subject(&reorderingSink{memSink: newMemSink()}))
+
+	assert.Equal(t, "", vs[keepsBatch].failure)
+	assert.True(t, strings.Contains(vs[preservesOrder].failure, "out of order"))
+}
+
+// A subject whose destination cannot report arrival order must skip the
+// ordering claim rather than read a sorted list as evidence.
+func TestToolingConformanceSinks_AnUnorderedReadBackSkipsOrder(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	s := subject(newMemSink())
+	s.OrderedReadBack = false
+
+	vs := verdicts(t, s)
+	assert.True(t, strings.Contains(vs[preservesOrder].skipped, "integrations.yml"))
+	assert.Equal(t, "", vs[preservesOrder].failure)
+}
+
 // A sink that ignores its context cannot be stopped. The pipeline's drain and
 // every other caller reach it only through that context.
 func TestToolingConformanceSinks_ASinkThatIgnoresItsContextIsCaught(t *testing.T) {
@@ -465,6 +496,30 @@ func (d *duplicatingSink) Flush(context.Context) error {
 	return nil
 }
 
+// hollowSink reports success on its second failed flush.
+//
+// #221's defect reached by another route: the first flush records the failure,
+// the second finds an empty error list and returns nil having delivered
+// nothing. The pipeline then commits offsets for rows that never landed.
+type hollowSink struct {
+	*memSink
+	failedWhileDown bool
+}
+
+func (h *hollowSink) Flush(ctx context.Context) error {
+	h.mu.Lock()
+	down, already := h.down, h.failedWhileDown
+	if down {
+		h.failedWhileDown = true
+	}
+	h.mu.Unlock()
+
+	if down && already {
+		return nil
+	}
+	return h.memSink.Flush(ctx)
+}
+
 // deafSink ignores the context it is given: it sleeps past any deadline before
 // reporting the failure.
 //
@@ -552,6 +607,9 @@ func subject(sink breakable) SinkSubject {
 		Heal:        func(*testing.T) { sink.set(false) },
 		ReadBack:    func(*testing.T) []Row { return sink.rows() },
 		Table:       oneRow,
+		// The fakes append in delivery order, so the ordering claim is
+		// judged rather than skipped for every double.
+		OrderedReadBack: true,
 	}
 }
 
@@ -564,7 +622,7 @@ func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
 	for _, v := range sinkVerdicts(t, s) {
 		out[v.invariant] = v
 	}
-	assert.Equal(t, 5, len(out))
+	assert.Equal(t, 7, len(out))
 	return out
 }
 

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -91,6 +91,36 @@ func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
 }
 
+func TestToolingConformanceSinks_ASlowProbeIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	v := verdicts(t, subject(&slowProbeSink{memSink: newMemSink()}))[probeFailsStart]
+
+	assert.True(t, strings.Contains(v.failure, "had not returned"))
+}
+
+func TestToolingConformanceSinks_AProbeThatCannotFailIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	v := verdicts(t, subject(&blindProbeSink{memSink: newMemSink()}))[probeFailsStart]
+
+	assert.True(t, strings.Contains(v.failure, "returned nil"))
+}
+
+func TestToolingConformanceSinks_ASinkThatCannotCloseTwiceIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	v := verdicts(t, subject(&closeOnceSink{memSink: newMemSink()}))[closeIdempotent]
+
+	assert.True(t, strings.Contains(v.failure, "second Close"))
+}
+
+// A sink implementing neither is skipped, and the registry must exempt it.
+func TestToolingConformanceSinks_ASinkWithNoProbeOrCloseIsSkipped(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	vs := verdicts(t, subject(newMemSink()))
+
+	assert.True(t, strings.Contains(vs[probeFailsStart].skipped, "integrations.yml"))
+	assert.True(t, strings.Contains(vs[closeIdempotent].skipped, "integrations.yml"))
+}
+
 // A second flush into the same fault must fail again. Returning nil tells the
 // pipeline to commit offsets for rows that never landed.
 func TestToolingConformanceSinks_AHollowSuccessIsCaught(t *testing.T) {
@@ -496,6 +526,42 @@ func (d *duplicatingSink) Flush(context.Context) error {
 	return nil
 }
 
+// slowProbeSink ladders its probe. probe() dials once and does not retry,
+// because the supervisor's restart is already the retry, so a ladder here only
+// delays the report.
+type slowProbeSink struct{ *memSink }
+
+func (s *slowProbeSink) Probe(context.Context) error {
+	// Past the grace the harness allows, so it is judged for laddering rather
+	// than for using the deadline it was given.
+	time.Sleep(3 * probeTimeout)
+	return errors.New("destination unreachable")
+}
+
+// blindProbeSink cannot fail. A probe that certifies a destination which is not
+// there is worse than no probe: the pipeline starts and the operator is told
+// the dependency is fine.
+type blindProbeSink struct{ *memSink }
+
+func (b *blindProbeSink) Probe(context.Context) error { return nil }
+
+// closeOnceSink fails its second Close. More than one shutdown path reaches
+// Close, and the second must not change the exit status.
+type closeOnceSink struct {
+	*memSink
+	closed bool
+}
+
+func (c *closeOnceSink) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return errors.New("close of closed sink")
+	}
+	c.closed = true
+	return nil
+}
+
 // hollowSink reports success on its second failed flush.
 //
 // #221's defect reached by another route: the first flush records the failure,
@@ -622,7 +688,7 @@ func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
 	for _, v := range sinkVerdicts(t, s) {
 		out[v.invariant] = v
 	}
-	assert.Equal(t, 7, len(out))
+	assert.Equal(t, 9, len(out))
 	return out
 }
 

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -61,12 +61,19 @@ func TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
 	assert.True(t, vs[keepsBatch].failure != "")
 }
 
-// A sink that keeps the batch but never clears it delivers the row twice.
-func TestToolingConformanceSinks_ASinkThatDeliversTwiceIsCaught(t *testing.T) {
+// A sink that never clears its buffer re-delivers everything on every flush.
+//
+// The duplication itself is legal: delivery is at-least-once, so keeps_batch
+// holds. What does not hold is the depth. A buffer that never drains grows
+// without bound, and reports_depth is the claim that catches it -- the count
+// must fall to zero once a flush has succeeded.
+func TestToolingConformanceSinks_ASinkThatNeverDrainsIsCaught(t *testing.T) {
 	coverage.Covers(t, "tooling.conformance")
-	v := verdicts(t, subject(&neverClearSink{memSink: newMemSink()}))[keepsBatch]
+	vs := verdicts(t, subject(&neverClearSink{memSink: newMemSink()}))
 
-	assert.True(t, strings.Contains(v.failure, "id=1, id=1"))
+	assert.Equal(t, "", vs[keepsBatch].failure)
+	assert.True(t, strings.Contains(vs[reportsDepth].failure,
+		"buffered rows after a Flush that succeeded"))
 }
 
 // A retry that fails is not the same defect, and the message must not blame
@@ -76,6 +83,24 @@ func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
 	v := verdicts(t, subject(&staysDownSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
+}
+
+// The contract's positive control, run through the whole harness rather than
+// the comparison alone: a sink that delivers each row twice is conformant.
+func TestToolingConformanceSinks_ADuplicatingSinkPasses(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	vs := verdicts(t, subject(&duplicatingSink{memSink: newMemSink()}))
+
+	assert.Equal(t, "", vs[keepsBatch].failure)
+	assert.Equal(t, "", vs[buffersOnly].failure)
+}
+
+// And a sink that loses the row it could not deliver still fails.
+func TestToolingConformanceSinks_ALosingSinkIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	v := verdicts(t, subject(&losingSink{memSink: newMemSink()}))[keepsBatch]
+
+	assert.True(t, strings.Contains(v.failure, "never reached"))
 }
 
 func TestToolingConformanceSinks_ASinkThatMisreportsItsDepthIsCaught(t *testing.T) {

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -175,6 +175,45 @@ func TestToolingConformanceSinks_AWriteThroughSinkIsNotBlamedOnTheSubject(t *tes
 	assert.True(t, vs[keepsBatch].failure != "")
 }
 
+// At-least-once permits a repeat. Exact equality does not, which is why the
+// harness used to fail a sink that delivered correctly twice.
+func TestToolingConformanceDelivered_AllowsARepeat(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	want := []Row{{"id": int64(1)}, {"id": int64(2)}}
+	got := []Row{{"id": int64(1)}, {"id": int64(2)}, {"id": int64(2)}}
+
+	assert.Equal(t, "", deliveredInOrder(got, want))
+}
+
+// Loss is the failure the contract does not permit.
+func TestToolingConformanceDelivered_CatchesALostRow(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	want := []Row{{"id": int64(1)}, {"id": int64(2)}, {"id": int64(3)}}
+	got := []Row{{"id": int64(1)}, {"id": int64(3)}}
+
+	assert.True(t, strings.Contains(deliveredInOrder(got, want), "never reached"))
+	assert.True(t, strings.Contains(deliveredInOrder(got, want), "id=2"))
+}
+
+// And so is reordering. A row that arrives before one that preceded it is not
+// a duplicate of anything, so a set comparison would miss it.
+func TestToolingConformanceDelivered_CatchesAReorder(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	want := []Row{{"id": int64(1)}, {"id": int64(2)}, {"id": int64(3)}}
+	got := []Row{{"id": int64(1)}, {"id": int64(3)}, {"id": int64(2)}}
+
+	assert.True(t, strings.Contains(deliveredInOrder(got, want), "out of order"))
+}
+
+// An empty destination loses everything, and the message must say so rather
+// than blaming order.
+func TestToolingConformanceDelivered_CatchesAnEmptyDestination(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	want := []Row{{"id": int64(1)}}
+
+	assert.True(t, strings.Contains(deliveredInOrder(nil, want), "never reached"))
+}
+
 func TestToolingConformanceDescribe_NamesTheRowsItFound(t *testing.T) {
 	coverage.Covers(t, "tooling.conformance")
 	assert.Equal(t, "no rows", describe(nil))
@@ -316,6 +355,65 @@ func (n *neverClearSink) Flush(context.Context) error {
 type lyingSink struct{ *memSink }
 
 func (l *lyingSink) BufferedRows() int { return 0 }
+
+// losingSink delivers everything except its most recent row. At-least-once
+// permits a repeat; it does not permit a row that never arrives.
+type losingSink struct{ *memSink }
+
+func (l *losingSink) Flush(context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.down {
+		return errors.New("destination unreachable")
+	}
+	for i, t := range l.buffered {
+		if i < len(l.buffered)-1 {
+			l.delivered = append(l.delivered, ids(t)...)
+		}
+		t.Release()
+	}
+	l.buffered = nil
+	return nil
+}
+
+// reorderingSink delivers its buffer backwards. Kafka orders within a
+// partition, and a sink that requeues a failed row behind a later one breaks
+// that without losing anything, so a set comparison would call it correct.
+type reorderingSink struct{ *memSink }
+
+func (r *reorderingSink) Flush(context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.down {
+		return errors.New("destination unreachable")
+	}
+	for i := len(r.buffered) - 1; i >= 0; i-- {
+		r.delivered = append(r.delivered, ids(r.buffered[i])...)
+		r.buffered[i].Release()
+	}
+	r.buffered = nil
+	return nil
+}
+
+// duplicatingSink delivers every row twice. It is the positive control: the
+// harness must pass it, or the contract has been tightened by accident.
+type duplicatingSink struct{ *memSink }
+
+func (d *duplicatingSink) Flush(context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.down {
+		return errors.New("destination unreachable")
+	}
+	for _, t := range d.buffered {
+		rows := ids(t)
+		d.delivered = append(d.delivered, rows...)
+		d.delivered = append(d.delivered, rows...)
+		t.Release()
+	}
+	d.buffered = nil
+	return nil
+}
 
 // staysDownSink never recovers, so the retry fails rather than delivering.
 type staysDownSink struct{ *memSink }

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -32,7 +32,9 @@ func TestToolingConformanceSinks_ASinkThatDropsItsBatchIsCaught(t *testing.T) {
 	v := verdicts(t, subject(&dropSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, v.failure != "")
-	assert.True(t, strings.Contains(v.failure, "no rows"))
+	// The pre-warm row still arrived, so the read-back is not empty. What is
+	// missing is the row the failed flush was supposed to have kept.
+	assert.True(t, strings.Contains(v.failure, "id=2 never reached"))
 }
 
 // A sink that delivers on WriteTable rather than on Flush: the Kafka sink's
@@ -65,15 +67,18 @@ func TestToolingConformanceSinks_ADroppingSinkStillBuffersOnly(t *testing.T) {
 //
 // The duplication itself is legal: delivery is at-least-once, so keeps_batch
 // holds. What does not hold is the depth. A buffer that never drains grows
-// without bound, and reports_depth is the claim that catches it -- the count
-// must fall to zero once a flush has succeeded.
+// without bound, and reports_depth is the claim that catches it.
+//
+// The pre-warm flush is what exposes it here: that buffer should be empty
+// afterwards, so the row written next is the only one owed. This sink still
+// holds the pre-warm row, and reports two.
 func TestToolingConformanceSinks_ASinkThatNeverDrainsIsCaught(t *testing.T) {
 	coverage.Covers(t, "tooling.conformance")
 	vs := verdicts(t, subject(&neverClearSink{memSink: newMemSink()}))
 
 	assert.Equal(t, "", vs[keepsBatch].failure)
 	assert.True(t, strings.Contains(vs[reportsDepth].failure,
-		"buffered rows after a Flush that succeeded"))
+		"reports 2 buffered rows after one WriteTable"))
 }
 
 // A retry that fails is not the same defect, and the message must not blame
@@ -83,6 +88,16 @@ func TestToolingConformanceSinks_ASinkThatCannotRecoverIsCaught(t *testing.T) {
 	v := verdicts(t, subject(&staysDownSink{memSink: newMemSink()}))[keepsBatch]
 
 	assert.True(t, strings.Contains(v.failure, "Flush after Heal failed"))
+}
+
+// A flush with nothing buffered must reach nothing. The pipeline flushes on an
+// interval whether or not a batch arrived, so a sink that writes here writes on
+// every idle tick.
+func TestToolingConformanceSinks_AnEagerEmptyFlushIsCaught(t *testing.T) {
+	coverage.Covers(t, "tooling.conformance")
+	v := verdicts(t, subject(&eagerFlushSink{memSink: newMemSink()}))[emptyIsNoop]
+
+	assert.True(t, strings.Contains(v.failure, "nothing was buffered"))
 }
 
 // The contract's positive control, run through the whole harness rather than
@@ -440,11 +455,42 @@ func (d *duplicatingSink) Flush(context.Context) error {
 	return nil
 }
 
-// staysDownSink never recovers, so the retry fails rather than delivering.
-type staysDownSink struct{ *memSink }
+// eagerFlushSink writes even when nothing is buffered. The pipeline flushes on
+// an interval whether or not a batch arrived, so this sink writes on every idle
+// tick.
+type eagerFlushSink struct{ *memSink }
 
-func (s *staysDownSink) Flush(context.Context) error {
-	return errors.New("destination unreachable")
+func (e *eagerFlushSink) Flush(ctx context.Context) error {
+	e.mu.Lock()
+	if !e.down && len(e.buffered) == 0 {
+		e.delivered = append(e.delivered, 0)
+	}
+	e.mu.Unlock()
+	return e.memSink.Flush(ctx)
+}
+
+// staysDownSink never recovers, so the retry fails rather than delivering.
+//
+// It fails only once Break has been called. The sequence opens with a clean
+// delivery, and a double that failed that too would abort the run as a broken
+// subject rather than exercising the retry this exists to test.
+type staysDownSink struct {
+	*memSink
+	broken bool
+}
+
+func (s *staysDownSink) Flush(ctx context.Context) error {
+	s.mu.Lock()
+	if s.down {
+		s.broken = true
+	}
+	broken := s.broken
+	s.mu.Unlock()
+
+	if broken {
+		return errors.New("destination unreachable")
+	}
+	return s.memSink.Flush(ctx)
 }
 
 // --- Helpers ---------------------------------------------------------------
@@ -492,7 +538,7 @@ func verdicts(t *testing.T, s SinkSubject) map[string]verdict {
 	for _, v := range sinkVerdicts(t, s) {
 		out[v.invariant] = v
 	}
-	assert.Equal(t, 3, len(out))
+	assert.Equal(t, 4, len(out))
 	return out
 }
 

--- a/internal/conformance/pipeline.go
+++ b/internal/conformance/pipeline.go
@@ -774,15 +774,6 @@ func (s *recordingSink) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (s *recordingSink) Batch() (arrow.Table, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.inner != nil {
-		return s.inner.Batch()
-	}
-	return nil, nil
-}
-
 func (s *recordingSink) Rows() int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -80,7 +80,6 @@ type MetadataWriter interface {
 type Sink interface {
 	WriteTable(ctx context.Context, batch arrow.Table) error
 	Flush(ctx context.Context) error
-	Batch() (arrow.Table, error)
 }
 
 // BufferedRowReporter is implemented by a sink that can say how many rows it

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -120,8 +120,6 @@ func (s *fakeSink) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (s *fakeSink) Batch() (arrow.Table, error) { return nil, nil }
-
 func newTestTurbine(src Source, h Handler, sink Sink, batchSize int) *Turbine {
 	return NewTurbine(src, h, sink, batchSize, time.Second, &sync.Mutex{}, PipelineErrorPolicies{})
 }
@@ -221,8 +219,6 @@ func (s *recordingSink) Flush(ctx context.Context) error {
 	s.flushes++
 	return nil
 }
-
-func (s *recordingSink) Batch() (arrow.Table, error) { return nil, nil }
 
 func mixedMessages(bad string, good int) []Message {
 	msgs := []Message{{Value: []byte(bad)}}
@@ -565,8 +561,6 @@ func (s *orderingSink) Flush(ctx context.Context) error {
 	*s.events = append(*s.events, "flush")
 	return nil
 }
-
-func (s *orderingSink) Batch() (arrow.Table, error) { return nil, nil }
 
 // fakeOffsetStore stands in for the DuckDB-backed store so the ordering test
 // needs no database.

--- a/internal/local/console.go
+++ b/internal/local/console.go
@@ -31,13 +31,6 @@ func (s *ConsoleSink) WriteTable(batch arrow.Table) error {
 	return nil
 }
 
-func (s *ConsoleSink) Batch() (arrow.Table, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return nil, nil
-}
-
 func (s *ConsoleSink) Flush() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/managers/tumbling_test.go
+++ b/internal/managers/tumbling_test.go
@@ -108,8 +108,6 @@ func (s *recordingSink) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (s *recordingSink) Batch() (arrow.Table, error) { return nil, nil }
-
 func (s *recordingSink) counts() (int64, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/sinks/clickhouse.go
+++ b/internal/sinks/clickhouse.go
@@ -143,13 +143,6 @@ func (s *ClickhouseSink) WriteTable(ctx context.Context, batch arrow.Table) erro
 	return nil
 }
 
-// Batch returns nothing. The Python ClickhouseSink alone among the sinks
-// reports no batch: rows go straight to ClickHouse and are not held for a
-// downstream reader.
-func (s *ClickhouseSink) Batch() (arrow.Table, error) {
-	return nil, nil
-}
-
 // Flush delivers the buffered batches, and keeps them buffered if it cannot.
 //
 // The retry ladder calls Flush again after a retryable failure. Discarding the

--- a/internal/sinks/clickhouse_test.go
+++ b/internal/sinks/clickhouse_test.go
@@ -78,18 +78,6 @@ func TestSinkClickhouse_NewRequiresTable(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// Batch mirrors the Python ClickhouseSink, which alone among the sinks
-// returns nothing: the rows go straight to ClickHouse and are not held for a
-// downstream reader.
-func TestSinkClickhouse_BatchIsNil(t *testing.T) {
-	coverage.Covers(t, "sink.clickhouse")
-	s := newLiveClickhouseSink(t, "")
-
-	batch, err := s.Batch()
-	assert.NoError(t, err)
-	assert.Nil(t, batch)
-}
-
 // clickhouseTestDSN points the live tests at the dev-stack ClickHouse.
 func clickhouseTestDSN() string {
 	if dsn := os.Getenv("SQLFLOW_CLICKHOUSE_DSN"); dsn != "" {

--- a/internal/sinks/conformance_iceberg_test.go
+++ b/internal/sinks/conformance_iceberg_test.go
@@ -70,6 +70,11 @@ func TestSinkIceberg_Conformance(t *testing.T) {
 		},
 
 		Table: func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+
+		// OrderedReadBack stays false. A scan reads the table's data files, and
+		// each append writes its own file with a generated name, so the rows
+		// come back in file order rather than append order. Observed: a
+		// read-back of [id=2, id=1] on roughly one run in six.
 	})
 }
 

--- a/internal/sinks/conformance_kafka_test.go
+++ b/internal/sinks/conformance_kafka_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/testcontainers/testcontainers-go"
 	tckafka "github.com/testcontainers/testcontainers-go/modules/kafka"
 	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/turbolytics/sql-flow/internal/config"
@@ -47,8 +48,14 @@ func TestIntegrationSinkKafka_Conformance(t *testing.T) {
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = nw.Remove(context.Background()) })
 
+	// One partition, because Kafka orders within a partition and nothing else.
+	// franz-go's default UniformBytesPartitioner switches partition every
+	// 64 KiB, so on a multi-partition topic preserves_order would be
+	// untestable rather than false. The sink lets the broker auto-create the
+	// topic, so the partition count is the broker's default to set.
 	broker, err := tckafka.Run(ctx, sinkBrokerImage,
 		network.WithNetwork([]string{"kafka"}, nw),
+		testcontainers.WithEnv(map[string]string{"KAFKA_NUM_PARTITIONS": "1"}),
 	)
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = broker.Terminate(context.Background()) })
@@ -91,6 +98,11 @@ func TestIntegrationSinkKafka_Conformance(t *testing.T) {
 		},
 
 		Table: func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+
+		// consumeIDs reads the topic from the earliest offset, and the topic
+		// has one partition, so the read-back is offset order -- which is the
+		// order the broker acknowledged the records in.
+		OrderedReadBack: true,
 	})
 }
 

--- a/internal/sinks/conformance_local_test.go
+++ b/internal/sinks/conformance_local_test.go
@@ -83,6 +83,9 @@ func TestSinkConsole_Conformance(t *testing.T) {
 		Heal:        func(*testing.T) { w.set(false) },
 		ReadBack:    func(t *testing.T) []conformance.Row { return w.rows(t) },
 		Table:       func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+		// The writer is a byte stream decoded front to back, so the read-back
+		// is the order the rows were written in.
+		OrderedReadBack: true,
 	})
 }
 
@@ -123,6 +126,8 @@ func TestSinkSqlcommand_Conformance(t *testing.T) {
 			return queryIDs(t, conn, "SELECT id FROM "+target+" ORDER BY arrived")
 		},
 		Table: func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
+		// arrived is a sequence, so ordering by it is arrival order.
+		OrderedReadBack: true,
 	})
 }
 

--- a/internal/sinks/conformance_local_test.go
+++ b/internal/sinks/conformance_local_test.go
@@ -91,8 +91,14 @@ func TestSinkSqlcommand_Conformance(t *testing.T) {
 	stamp := time.Now().UnixNano()
 	target := fmt.Sprintf("conformance_target_%d", stamp)
 	gate := fmt.Sprintf("conformance_gate_%d", stamp)
+	seq := fmt.Sprintf("conformance_seq_%d", stamp)
 
-	exec(t, conn, "CREATE TABLE "+target+" (id BIGINT)")
+	// arrived orders the read-back by when a row landed rather than by its id.
+	// ORDER BY id sorts, so a sink that delivered [3, 2, 1] would read back
+	// [1, 2, 3] and satisfy preserves_order without preserving anything.
+	exec(t, conn, "CREATE SEQUENCE "+seq+" START 1")
+	exec(t, conn, "CREATE TABLE "+target+
+		" (id BIGINT, arrived BIGINT DEFAULT nextval('"+seq+"'))")
 	exec(t, conn, "CREATE TABLE "+gate+" (open BOOLEAN)")
 	exec(t, conn, "INSERT INTO "+gate+" VALUES (true)")
 
@@ -104,7 +110,7 @@ func TestSinkSqlcommand_Conformance(t *testing.T) {
 		Integration: "sink.sqlcommand",
 		New: func(t *testing.T) core.Sink {
 			s, err := NewSQLCommandSink(conn,
-				"INSERT INTO "+target+" SELECT b.id FROM "+sinkBatchTable+" b, "+gate, nil)
+				"INSERT INTO "+target+" (id) SELECT b.id FROM "+sinkBatchTable+" b, "+gate, nil)
 			assert.NoError(t, err)
 			return s
 		},
@@ -114,7 +120,7 @@ func TestSinkSqlcommand_Conformance(t *testing.T) {
 			exec(t, conn, "INSERT INTO "+gate+" VALUES (true)")
 		},
 		ReadBack: func(t *testing.T) []conformance.Row {
-			return queryIDs(t, conn, "SELECT id FROM "+target+" ORDER BY id")
+			return queryIDs(t, conn, "SELECT id FROM "+target+" ORDER BY arrived")
 		},
 		Table: func(t *testing.T, id int64) arrow.Table { return oneRowTable(t, id) },
 	})

--- a/internal/sinks/conformance_test.go
+++ b/internal/sinks/conformance_test.go
@@ -147,6 +147,10 @@ func TestIntegrationSinkClickhouse_Conformance(t *testing.T) {
 			defer rec.Release()
 			return array.NewTableFromRecords(schema, []arrow.Record{rec})
 		},
+
+		// The conformance table uses the Log engine, which appends and reads
+		// sequentially, so a select with no ORDER BY returns insertion order.
+		OrderedReadBack: true,
 	})
 }
 

--- a/internal/sinks/conformance_test.go
+++ b/internal/sinks/conformance_test.go
@@ -88,8 +88,18 @@ func TestIntegrationSinkClickhouse_Conformance(t *testing.T) {
 	// The harness's own reads must not cross the fault it injects, or a
 	// broken destination would look like an empty one.
 	direct := mustDirectSink(t, ch, table)
+	// Log rather than MergeTree, because the read-back has to observe the order
+	// rows arrived in. MergeTree stores a part sorted by its ORDER BY key, so
+	// on a MergeTree table a sink that delivered [3, 2, 1] reads back [1, 2, 3]
+	// and satisfies preserves_order without preserving anything. An arrival
+	// timestamp does not rescue it: now64() can resolve to the same value for
+	// every row of one insert block, and the sink flushes a batch as one block.
+	//
+	// Log appends and reads sequentially, so insertion order survives. The sink
+	// builds INSERT INTO <table> (<columns>) from the Arrow schema and does not
+	// care which engine backs the table.
 	assert.NoError(t, direct.conn.Exec(ctx,
-		"CREATE TABLE "+table+" (id Int64) ENGINE = MergeTree() ORDER BY id"))
+		"CREATE TABLE "+table+" (id Int64) ENGINE = Log"))
 
 	dsn := clickhouseDSN(proxy.Addr)
 
@@ -107,8 +117,10 @@ func TestIntegrationSinkClickhouse_Conformance(t *testing.T) {
 		Heal:  proxy.Heal,
 
 		ReadBack: func(t *testing.T) []conformance.Row {
+			// No ORDER BY: the Log engine returns rows in the order they were
+			// inserted, which is the order this read-back has to report.
 			rows, err := direct.conn.Query(context.Background(),
-				"SELECT id FROM "+table+" ORDER BY id")
+				"SELECT id FROM "+table)
 			assert.NoError(t, err)
 			defer rows.Close()
 

--- a/internal/sinks/console.go
+++ b/internal/sinks/console.go
@@ -22,7 +22,6 @@ type ConsoleSink struct {
 	mu      sync.Mutex
 	out     io.Writer
 	pending []byte
-	batch   arrow.Table
 }
 
 func NewConsoleSink() *ConsoleSink {
@@ -45,7 +44,6 @@ func (s *ConsoleSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.batch = batch
 	for _, row := range rows {
 		s.pending = append(s.pending, row...)
 		s.pending = append(s.pending, '\n')
@@ -79,12 +77,6 @@ func (s *ConsoleSink) Flush(ctx context.Context) error {
 		return io.ErrShortWrite
 	}
 	return nil
-}
-
-func (s *ConsoleSink) Batch() (arrow.Table, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.batch, nil
 }
 
 // BufferedRows reports the rows this sink is holding that no flush has

--- a/internal/sinks/iceberg.go
+++ b/internal/sinks/iceberg.go
@@ -68,16 +68,6 @@ func (s *IcebergSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	return nil
 }
 
-func (s *IcebergSink) Batch() (arrow.Table, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if len(s.tables) == 0 {
-		return nil, nil
-	}
-	return s.tables[len(s.tables)-1], nil
-}
-
 // Flush appends the buffered batches, and keeps whatever it could not append.
 //
 // The retry ladder calls Flush again after a retryable failure. Discarding the

--- a/internal/sinks/iceberg_test.go
+++ b/internal/sinks/iceberg_test.go
@@ -309,27 +309,6 @@ func TestSinkIceberg_EmptyBatchAppendsNothing(t *testing.T) {
 	assert.Equal(t, int64(0), icebergRowCount(t, catalogName, tableName))
 }
 
-// Batch is what the tumbling-window manager reads back after a write.
-func TestSinkIceberg_BatchIsTheLastWrite(t *testing.T) {
-	coverage.Covers(t, "sink.iceberg")
-	catalogName, tableName := newLocalIcebergTable(t)
-
-	s, err := NewIcebergSink(context.Background(), catalogName, tableName)
-	assert.NoError(t, err)
-
-	batch, err := s.Batch()
-	assert.NoError(t, err)
-	assert.Nil(t, batch)
-
-	table := newTestTable(t, []string{"nyc", "sfo"}, []int64{1, 2})
-	defer table.Release()
-	assert.NoError(t, s.WriteTable(context.Background(), table))
-
-	batch, err = s.Batch()
-	assert.NoError(t, err)
-	assert.Equal(t, int64(2), batch.NumRows())
-}
-
 // A table the catalog does not have must fail the start. Discovering it on the
 // first flush instead loses the batch and every offset behind it.
 func TestSinkIceberg_MissingTableFailsTheStart(t *testing.T) {

--- a/internal/sinks/init.go
+++ b/internal/sinks/init.go
@@ -24,11 +24,6 @@ func (n *NoopSink) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (n *NoopSink) Batch() (arrow.Table, error) {
-	// No operation performed, return nil
-	return nil, nil
-}
-
 // Option configures how a sink is built.
 type Option func(*options)
 

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/errs"
 	tkafka "github.com/turbolytics/sql-flow/internal/kafka"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
@@ -27,6 +28,22 @@ import (
 // fails and reports rather than being killed mid-flush. Kafka's own
 // delivery.timeout.ms default of two minutes is far past that.
 const recordDeliveryTimeout = 20 * time.Second
+
+// kafkaSinkError codes a flush failure, teaching sinkError the two franz-go
+// errors it cannot recognise.
+//
+// isUnreachable matches syscall and net errors. A record that expired waiting
+// for a broker that never answered carries neither, and a client closed out
+// from under a flush carries neither. Both are the same partition a refused
+// connection is, reported by a timer or a shutdown rather than by the kernel.
+// Coding them as a rejected write exits 1 and labels the error metric for a
+// bug, which is what the bare fmt.Errorf here used to do.
+func kafkaSinkError(err error, format string, args ...any) error {
+	if errors.Is(err, kgo.ErrRecordTimeout) || errors.Is(err, kgo.ErrClientClosed) {
+		return errs.Wrap(errs.CodeSinkUnreachable, err, format, args...)
+	}
+	return sinkError(err, format, args...)
+}
 
 // KafkaSink produces one message per result row, JSON encoded, matching the
 // Python KafkaSink.
@@ -181,8 +198,8 @@ func (s *KafkaSink) Flush(ctx context.Context) error {
 	if firstErr == nil {
 		firstErr = errors.New("not acknowledged")
 	}
-	return fmt.Errorf("kafka sink: %d of %d rows not acknowledged, first: %w",
-		len(keep), len(pending), firstErr)
+	return kafkaSinkError(firstErr, "kafka sink: %d of %d rows not acknowledged",
+		len(keep), len(pending))
 }
 
 func (s *KafkaSink) Close() error {

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -212,8 +212,23 @@ func (s *KafkaSink) Flush(ctx context.Context) error {
 //
 // Ping asks the seed brokers for metadata, which is the cheapest request that
 // proves one of them answered.
+//
+// It runs off this goroutine because Ping does not reliably return when its
+// context ends. Against a broker that accepts the connection and then never
+// answers -- a partition rather than a refusal -- it was still running six
+// seconds after a three second deadline. probe() runs before the pipeline has
+// consumed anything, so a probe that cannot be bounded hangs the start instead
+// of failing it, which is the failure the probe exists to prevent.
 func (s *KafkaSink) Probe(ctx context.Context) error {
-	return s.client.Ping(ctx)
+	done := make(chan error, 1)
+	go func() { done <- s.client.Ping(ctx) }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (s *KafkaSink) Close() error {

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -21,7 +21,6 @@ type KafkaSink struct {
 	mu sync.Mutex
 	// pending holds the encoded rows that Flush has not yet had acknowledged.
 	pending [][]byte
-	batch   arrow.Table
 }
 
 // NewKafkaSink builds the sink. Extra client options are appended last, so a
@@ -73,7 +72,6 @@ func (s *KafkaSink) WriteTable(ctx context.Context, batch arrow.Table) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.batch = batch
 	s.pending = append(s.pending, rows...)
 	return nil
 }
@@ -168,12 +166,6 @@ func (s *KafkaSink) Flush(ctx context.Context) error {
 	}
 	return fmt.Errorf("kafka sink: %d of %d rows not acknowledged, first: %w",
 		len(keep), len(pending), firstErr)
-}
-
-func (s *KafkaSink) Batch() (arrow.Table, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.batch, nil
 }
 
 func (s *KafkaSink) Close() error {

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -202,6 +202,20 @@ func (s *KafkaSink) Flush(ctx context.Context) error {
 		len(keep), len(pending))
 }
 
+// Probe checks the broker before the first batch arrives.
+//
+// Without it a wrong broker list produces a pipeline that starts normally,
+// logs "consumer loop starting", and fails at the first flush. With a long
+// flush interval that is minutes later, and a supervisor reports the pipeline
+// healthy for every one of them. sinks.New probes any sink implementing
+// Prober, so implementing it here is the whole change.
+//
+// Ping asks the seed brokers for metadata, which is the cheapest request that
+// proves one of them answered.
+func (s *KafkaSink) Probe(ctx context.Context) error {
+	return s.client.Ping(ctx)
+}
+
 func (s *KafkaSink) Close() error {
 	s.client.Close()
 	return nil

--- a/internal/sinks/kafka.go
+++ b/internal/sinks/kafka.go
@@ -5,12 +5,28 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/turbolytics/sql-flow/internal/config"
 	tkafka "github.com/turbolytics/sql-flow/internal/kafka"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
+
+// recordDeliveryTimeout bounds how long franz-go may hold a record the broker
+// has not acknowledged.
+//
+// franz-go retries a produce indefinitely by default, and no caller bounds the
+// wait: the tumbling manager's context is cancellable but carries no deadline,
+// and the pipeline's drain strips the deadline with context.WithoutCancel. So
+// a flush against a hung broker blocked until the run was cancelled. A
+// windowed pipeline stopped publishing every window with nothing logged, and
+// shutdown waited for SIGKILL.
+//
+// Shorter than a supervisor's usual 30s termination grace period, so the drain
+// fails and reports rather than being killed mid-flush. Kafka's own
+// delivery.timeout.ms default of two minutes is far past that.
+const recordDeliveryTimeout = 20 * time.Second
 
 // KafkaSink produces one message per result row, JSON encoded, matching the
 // Python KafkaSink.
@@ -41,6 +57,7 @@ func NewKafkaSink(conf config.KafkaSink, extra ...kgo.Opt) (*KafkaSink, error) {
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(brokers...),
 		kgo.AllowAutoTopicCreation(),
+		kgo.RecordDeliveryTimeout(recordDeliveryTimeout),
 	}
 
 	securityOpts, err := tkafka.SecurityOptions(conf.SecurityProtocol, conf.SSL, conf.SASL)

--- a/internal/sinks/kafka_test.go
+++ b/internal/sinks/kafka_test.go
@@ -146,21 +146,3 @@ func TestSinkKafka_FlushReportsProduceErrors(t *testing.T) {
 	assert.NoError(t, s.WriteTable(context.Background(), table))
 	assert.Error(t, flushWithin(t, s, ctx, 10*time.Second))
 }
-
-// Batch is what the tumbling-window manager reads back after a write.
-func TestSinkKafka_BatchIsTheLastWrite(t *testing.T) {
-	coverage.Covers(t, "sink.kafka")
-	s := newUnreachableKafkaSink(t)
-
-	batch, err := s.Batch()
-	assert.NoError(t, err)
-	assert.Nil(t, batch)
-
-	table := newTestTable(t, []string{"nyc", "sfo"}, []int64{1, 2})
-	defer table.Release()
-	assert.NoError(t, s.WriteTable(context.Background(), table))
-
-	batch, err = s.Batch()
-	assert.NoError(t, err)
-	assert.Equal(t, int64(2), batch.NumRows())
-}

--- a/internal/sinks/kafka_test.go
+++ b/internal/sinks/kafka_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/zeebo/assert"
 )
@@ -173,6 +174,44 @@ func TestSinkKafka_HasADeliveryTimeoutByDefault(t *testing.T) {
 	// Longer than recordDeliveryTimeout, so a sink with no default hangs here.
 	assert.Error(t, flushWithin(t, s, context.Background(),
 		recordDeliveryTimeout+10*time.Second))
+}
+
+// A dead broker must exit 12, not 1.
+//
+// errs.CodeOf falls back to system.internal.unexpected for an uncoded error, so
+// a bare fmt.Errorf tells a supervisor the pipeline hit a bug and labels the
+// error metric the same way. Both are wrong, and both are what an operator
+// reads first.
+func TestSinkKafka_FlushCodesAnUnreachableBroker(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
+	s := newUnreachableKafkaSink(t)
+
+	table := newTestTable(t, []string{"nyc"}, []int64{1})
+	defer table.Release()
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := flushWithin(t, s, ctx, 10*time.Second)
+	assert.Error(t, err)
+	assert.Equal(t, errs.CodeSinkUnreachable, errs.CodeOf(err))
+	assert.Equal(t, errs.ExitSinkUnreachable, errs.ExitCode(err))
+}
+
+// A record that expired waiting for a broker that never answered is the same
+// failure as a refused connection.
+//
+// isUnreachable matches syscall and net errors and has no reason to know
+// franz-go's sentinel, so the sink classifies it. Coding it as a rejected write
+// would exit 1 again -- and the delivery timeout makes this the common error
+// against a broker that is down.
+func TestSinkKafka_ARecordTimeoutIsUnreachable(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
+	err := kafkaSinkError(kgo.ErrRecordTimeout, "kafka sink: %d rows", 1)
+
+	assert.Equal(t, errs.CodeSinkUnreachable, errs.CodeOf(err))
+	assert.Equal(t, errs.ExitSinkUnreachable, errs.ExitCode(err))
 }
 
 // Produce errors must not be swallowed. The pipeline commits its offsets only

--- a/internal/sinks/kafka_test.go
+++ b/internal/sinks/kafka_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/core"
 	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/errs"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -212,6 +213,31 @@ func TestSinkKafka_ARecordTimeoutIsUnreachable(t *testing.T) {
 
 	assert.Equal(t, errs.CodeSinkUnreachable, errs.CodeOf(err))
 	assert.Equal(t, errs.ExitSinkUnreachable, errs.ExitCode(err))
+}
+
+// A broker list that names nothing must fail the start.
+//
+// Without a probe the pipeline starts, logs "consumer loop starting", and
+// discovers the broker at the first flush. With a long flush interval that is
+// minutes later, and a supervisor calls the pipeline healthy for every one of
+// them.
+func TestSinkKafka_ProbeFailsAgainstAnUnreachableBroker(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
+	s := newUnreachableKafkaSink(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	assert.Error(t, s.Probe(ctx))
+}
+
+// And it must be reachable through the interface, or sinks.New never calls it.
+func TestSinkKafka_ImplementsProber(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
+	var s core.Sink = newUnreachableKafkaSink(t)
+
+	_, ok := s.(Prober)
+	assert.True(t, ok)
 }
 
 // Produce errors must not be swallowed. The pipeline commits its offsets only

--- a/internal/sinks/kafka_test.go
+++ b/internal/sinks/kafka_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/zeebo/assert"
 )
 
@@ -128,6 +129,50 @@ func TestSinkKafka_WriteTableBuffersWhateverItsContextSays(t *testing.T) {
 	pending := len(s.pending)
 	s.mu.Unlock()
 	assert.Equal(t, 1, pending)
+}
+
+// A flush with no deadline must still return.
+//
+// Every production caller passes one. The tumbling manager's context is
+// cancellable but carries no deadline (run/root.go), and the pipeline's drain
+// strips the deadline along with the cancellation via context.WithoutCancel.
+// If only the context could stop a flush, an outage would stop a windowed
+// pipeline publishing with nothing logged, and shutdown would wait for the
+// supervisor to kill the process.
+func TestSinkKafka_FlushReturnsWithoutADeadline(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
+
+	// franz-go rejects a record timeout below a second, so this is the floor
+	// rather than a round number.
+	s, err := NewKafkaSink(config.KafkaSink{
+		Brokers: []string{unreachableBroker},
+		Topic:   "sink-test",
+	}, kgo.RecordDeliveryTimeout(time.Second))
+	assert.NoError(t, err)
+	t.Cleanup(func() { s.Close() })
+
+	table := newTestTable(t, []string{"nyc"}, []int64{1})
+	defer table.Release()
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+
+	assert.Error(t, flushWithin(t, s, context.Background(), 10*time.Second))
+
+	// And the row is still owed, so the next attempt re-sends it.
+	assert.Equal(t, 1, s.BufferedRows())
+}
+
+// The default has to be set, or the test above only proves the option exists.
+func TestSinkKafka_HasADeliveryTimeoutByDefault(t *testing.T) {
+	coverage.Covers(t, "sink.kafka")
+	s := newUnreachableKafkaSink(t)
+
+	table := newTestTable(t, []string{"nyc"}, []int64{1})
+	defer table.Release()
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+
+	// Longer than recordDeliveryTimeout, so a sink with no default hangs here.
+	assert.Error(t, flushWithin(t, s, context.Background(),
+		recordDeliveryTimeout+10*time.Second))
 }
 
 // Produce errors must not be swallowed. The pipeline commits its offsets only

--- a/internal/sinks/probe_test.go
+++ b/internal/sinks/probe_test.go
@@ -24,7 +24,6 @@ type probeSink struct {
 
 func (s *probeSink) WriteTable(ctx context.Context, b arrow.Table) error { return nil }
 func (s *probeSink) Flush(ctx context.Context) error                     { return nil }
-func (s *probeSink) Batch() (arrow.Table, error)                         { return nil, nil }
 
 func (s *probeSink) Probe(ctx context.Context) error {
 	s.probes++

--- a/internal/sinks/retry.go
+++ b/internal/sinks/retry.go
@@ -72,8 +72,6 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 	}
 }
 
-func (r *retrying) Batch() (arrow.Table, error) { return r.inner.Batch() }
-
 // WriteTable is not retried. It buffers into the sink rather than reaching the
 // destination, so there is nothing here for a backoff to wait on.
 func (r *retrying) WriteTable(ctx context.Context, batch arrow.Table) error {

--- a/internal/sinks/retry_test.go
+++ b/internal/sinks/retry_test.go
@@ -35,7 +35,6 @@ func (s *flakySink) WriteTable(ctx context.Context, batch arrow.Table) error {
 	s.buffered++
 	return nil
 }
-func (s *flakySink) Batch() (arrow.Table, error) { return nil, nil }
 
 func (s *flakySink) Flush(ctx context.Context) error {
 	s.attempts++

--- a/internal/sinks/sqlcommand.go
+++ b/internal/sinks/sqlcommand.go
@@ -46,16 +46,6 @@ func (s *SQLCommandSink) WriteTable(ctx context.Context, batch arrow.Table) erro
 	return nil
 }
 
-func (s *SQLCommandSink) Batch() (arrow.Table, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if len(s.tables) == 0 {
-		return nil, nil
-	}
-	return s.tables[len(s.tables)-1], nil
-}
-
 // Flush runs the sink SQL over the buffered rows, and keeps them buffered if
 // it cannot.
 //

--- a/internal/sinks/sqlcommand_test.go
+++ b/internal/sinks/sqlcommand_test.go
@@ -291,24 +291,3 @@ func TestSinkSqlcommand_ReportsASQLError(t *testing.T) {
 	assert.NoError(t, s.WriteTable(context.Background(), table))
 	assert.Error(t, s.Flush(context.Background()))
 }
-
-// Batch is what the tumbling-window manager reads back after a write.
-func TestSinkSqlcommand_BatchIsTheLastWrite(t *testing.T) {
-	coverage.Covers(t, "sink.sqlcommand")
-	conn := newSinkTestConn(t)
-
-	s, err := NewSQLCommandSink(conn, "SELECT 1", nil)
-	assert.NoError(t, err)
-
-	batch, err := s.Batch()
-	assert.NoError(t, err)
-	assert.Nil(t, batch)
-
-	table := newTestTable(t, []string{"nyc", "sfo"}, []int64{1, 2})
-	defer table.Release()
-	assert.NoError(t, s.WriteTable(context.Background(), table))
-
-	batch, err = s.Batch()
-	assert.NoError(t, err)
-	assert.Equal(t, int64(2), batch.NumRows())
-}

--- a/internal/sinks/structural_test.go
+++ b/internal/sinks/structural_test.go
@@ -63,11 +63,6 @@ func TestSinkNoop_DeliversNothingAndSaysSo(t *testing.T) {
 	assert.NoError(t, s.WriteTable(ctx, table))
 	assert.NoError(t, s.Flush(ctx))
 
-	// Nothing buffered, nothing reported, nothing to lose.
-	batch, err := s.Batch()
-	assert.NoError(t, err)
-	assert.Nil(t, batch)
-
 	// And it cannot fail, so there is never a batch to keep.
 	assert.NoError(t, s.Flush(ctx))
 }

--- a/internal/sinks/structural_test.go
+++ b/internal/sinks/structural_test.go
@@ -2,7 +2,9 @@ package sinks
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -65,6 +67,77 @@ func TestSinkNoop_DeliversNothingAndSaysSo(t *testing.T) {
 
 	// And it cannot fail, so there is never a batch to keep.
 	assert.NoError(t, s.Flush(ctx))
+}
+
+// The three sinks below are exempt from sink.flush.honours_context, and these
+// tests prove the premise rather than asserting it in prose.
+//
+// The claim is that Flush returns ctx.Err() when the context ends. A sink whose
+// failing write returns immediately never reaches a deadline, so there is no
+// context to honour. The conformance harness skips the claim for them, and
+// integrations.yml names these tests.
+//
+// Each one breaks the destination, flushes under a generous deadline, and holds
+// that the flush failed while the context was still live.
+
+func TestSinkConsole_FlushCannotOutliveItsContext(t *testing.T) {
+	coverage.Covers(t, "sink.console")
+	w := &breakableWriter{}
+	s := NewConsoleSinkTo(w)
+
+	table := oneRowTable(t, 1)
+	defer table.Release()
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+	w.set(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	assert.Error(t, s.Flush(ctx))
+	assert.NoError(t, ctx.Err())
+}
+
+func TestSinkSqlcommand_FlushCannotOutliveItsContext(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
+	conn := newSinkTestConn(t)
+	target := fmt.Sprintf("outlive_target_%d", time.Now().UnixNano())
+	exec(t, conn, "CREATE TABLE "+target+" (id BIGINT)")
+
+	// The SQL names a table that does not exist, so the statement fails as soon
+	// as DuckDB parses it.
+	s, err := NewSQLCommandSink(conn,
+		"INSERT INTO "+target+" SELECT b.id FROM "+sinkBatchTable+" b, missing_table", nil)
+	assert.NoError(t, err)
+
+	table := oneRowTable(t, 1)
+	defer table.Release()
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	assert.Error(t, s.Flush(ctx))
+	assert.NoError(t, ctx.Err())
+}
+
+func TestSinkIceberg_FlushCannotOutliveItsContext(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
+	catalogName, tableName := newLocalIcebergTable(t)
+
+	s, err := NewIcebergSink(context.Background(), catalogName, tableName)
+	assert.NoError(t, err)
+
+	// The table declares city and count. A batch of one int64 id does not
+	// match it, so the append fails locally without reaching any storage.
+	table := oneRowTable(t, 1)
+	defer table.Release()
+	assert.NoError(t, s.WriteTable(context.Background(), table))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	assert.Error(t, s.Flush(ctx))
+	assert.NoError(t, ctx.Err())
 }
 
 func oneRowTable(t *testing.T, id int64) arrow.Table {

--- a/internal/sinks/structural_test.go
+++ b/internal/sinks/structural_test.go
@@ -3,6 +3,7 @@ package sinks
 import (
 	"context"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -45,6 +46,63 @@ func TestSinkNoop_ImplementsNoProber(t *testing.T) {
 	coverage.Covers(t, "sink.noop")
 	var s core.Sink = &NoopSink{}
 	_, ok := s.(Prober)
+	assert.That(t, !ok)
+}
+
+// integrations.yml claimed sink.iceberg implements Prober and it never has.
+// NewIcebergSink loads the catalog and the table, so an absent table fails the
+// start -- but through the constructor, not through the interface sinks.New
+// probes.
+func TestSinkIceberg_ImplementsNoProber(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
+	catalogName, tableName := newLocalIcebergTable(t)
+
+	built, err := NewIcebergSink(context.Background(), catalogName, tableName)
+	assert.NoError(t, err)
+
+	var s core.Sink = built
+	_, ok := s.(Prober)
+	assert.That(t, !ok)
+}
+
+// The four sinks that hold nothing to release. lifecycle.close.idempotent is
+// exempt for each, and these prove the premise: there is no Close to call
+// twice. ClickHouse and Kafka own a client and do implement it.
+
+func TestSinkConsole_ImplementsNoCloser(t *testing.T) {
+	coverage.Covers(t, "sink.console")
+	var s core.Sink = NewConsoleSink()
+	_, ok := s.(io.Closer)
+	assert.That(t, !ok)
+}
+
+func TestSinkSqlcommand_ImplementsNoCloser(t *testing.T) {
+	coverage.Covers(t, "sink.sqlcommand")
+	conn := newSinkTestConn(t)
+	built, err := NewSQLCommandSink(conn, "SELECT 1", nil)
+	assert.NoError(t, err)
+
+	var s core.Sink = built
+	_, ok := s.(io.Closer)
+	assert.That(t, !ok)
+}
+
+func TestSinkNoop_ImplementsNoCloser(t *testing.T) {
+	coverage.Covers(t, "sink.noop")
+	var s core.Sink = &NoopSink{}
+	_, ok := s.(io.Closer)
+	assert.That(t, !ok)
+}
+
+func TestSinkIceberg_ImplementsNoCloser(t *testing.T) {
+	coverage.Covers(t, "sink.iceberg")
+	catalogName, tableName := newLocalIcebergTable(t)
+
+	built, err := NewIcebergSink(context.Background(), catalogName, tableName)
+	assert.NoError(t, err)
+
+	var s core.Sink = built
+	_, ok := s.(io.Closer)
 	assert.That(t, !ok)
 }
 


### PR DESCRIPTION
Proves nine of the ten sink invariants for `sink.kafka`. The matrix goes from **24 proven cells to 46**, and the gate passes with no gaps.

## The false positive this started from

`sink.flush.keeps_batch` read green for `sink.kafka`, and shouldn't have. The harness broke the destination before the topic had ever resolved, and franz-go watches a `Produce` context only while a topic is unknown — so the record took an abort path a warm topic never reaches.

Warming the destination first exposed a read-back of `[1 2 2]`. But that is **correct**: sqlflow delivers at-least-once end to end. `turbine.go:849` says so for the crash window, and the tumbling manager says so by keeping a window in DuckDB until its flush succeeds.

So the defect was in the harness, not the sink. `sinkVerdicts` required the destination to hold exactly one row — exactly-once, asserted against an at-least-once engine. Checked for loss instead, `Flush` keeps every row whose promise did not fire clean: **the sink has no loss defect**.

Five separate places made that same mistake, two of them in this branch's own first drafts. A live broker caught what reasoning missed: the read-back held `id=2` after a *failed* flush, because the broker applied the produce and only the response was lost.

## Three real defects, each found by a new invariant

1. **An unbounded flush.** No production caller passes a context that expires — `managerCtx` is `WithCancel(Background())`, and the drain strips the deadline with `WithoutCancel` — and `RecordDeliveryTimeout` defaults to off. Measured: still blocked after 25s. A windowed pipeline stopped publishing every window with nothing logged, and shutdown waited for SIGKILL.
2. **Uncoded errors.** A dead broker exited 1, not 12. Fixing it required teaching the classifier `kgo.ErrRecordTimeout`, or (1) would have recreated the bug.
3. **`Probe` ignored its context.** franz-go's `Ping` was still running 6s after a 3s deadline, which hangs startup — the failure a probe exists to prevent.

## Registry corrections

- `sink.iceberg` was declared as implementing `Prober`. It never has.
- `Batch()` was on `core.Sink` with no caller since the Go rewrite; its invariant is retired with it.

## What stays missing, deliberately

- `sink.error.classifies` — needs a Reject seam this work doesn't build. Its value sits with the laddered sinks, and Kafka isn't laddered.
- `sink.flush.preserves_order` for `sink.iceberg` — a scan returns rows in data-file order (`[id=2, id=1]` on ~1 run in 6). That's a limit of the read-back, not the sink, so an exemption would be an excuse.

## Review notes

Two commits **loosen** assertions (`8f75ad7`, `933ff68`). That's the point, but loosening is where coverage dies quietly — each ships doubles that still fail: a sink that loses a row, one that reorders, one that ladders its probe, one that can't close twice.

Verified: build, vet, gofmt, full unit pass, and every container-backed subject green against real Kafka and ClickHouse.

13 commits, 29 files, +1379/−441. The design spec and implementation plan are on `main`, not in this branch.
