### PR TITLE
Stop hand-resolving the generated coverage matrix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# The coverage matrix is generated and checked in, which is deliberate: a
+# coverage change shows up in review rather than nowhere. The cost is that
+# every concurrent branch conflicts on it, because two branches render two
+# different repo states over the same dense regions -- cell counts, the
+# invariant tables, per-feature test lists -- and none of it is an independent
+# edit git can reconcile.
+#
+# Resolving those conflicts by hand is busywork with no judgement in it. The
+# file is derived, so any resolution is provisional: `make coverage-check`
+# regenerates it and fails if what is committed does not match what the suites
+# reported. A wrong auto-resolution cannot reach main, it just stops being a
+# manual step.
+#
+# The driver keeps the current branch's copy and exits. Configure it once with
+# `make setup-dev`, or directly:
+#
+#     git config merge.coverage-generated.driver true
+#
+# Without that config git falls back to a normal merge and conflicts as before,
+# so a fresh clone is never worse off than it is today.
+docs/coverage/matrix.json merge=coverage-generated
+docs/coverage/matrix.md   merge=coverage-generated

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,20 @@ install-tools:
 	@echo "creating resultscache directory... '/tmp/sqlflow/resultscache'"
 	$(shell mkdir -p /tmp/sqlflow/resultscache)
 
+# The merge driver .gitattributes names for the generated coverage matrix.
+#
+# Git resolves a driver by name from local config, which is not something a
+# repository can ship, so this has to be configured per clone. `true` succeeds
+# and leaves the current branch's copy in place; coverage-check regenerates it
+# and fails if that copy is wrong, so the resolution is safe to automate and
+# the manual step buys nothing.
+.PHONY: git-merge-drivers
+git-merge-drivers:
+	git config merge.coverage-generated.name "keep ours; coverage-check regenerates"
+	git config merge.coverage-generated.driver true
+
 .PHONY: setup-dev
-setup-dev: install-tools
+setup-dev: install-tools git-merge-drivers
 
 # The Go checks and the image tests. There is no Python suite: the engine it
 # covered is gone, and what remains of the package is harness for the image


### PR DESCRIPTION
Every concurrent branch conflicts on `docs/coverage/matrix.json` and
`matrix.md`. #238 hit it, and every branch after it will.

The cause is the design, not an accident. The matrix is generated and checked
in, which is deliberate — the Makefile says why:

> the checked-in matrix must match what the suites just reported, the way a
> golden file does. That is what makes a coverage change show up in review
> rather than nowhere.

Two branches then render two different repo states over the same dense regions:
cell counts, the invariant tables, per-feature test lists. None of it is an
independent edit git can reconcile, so it conflicts every time, the way a
lockfile does.

Resolving those by hand is busywork with no judgement in it. The file is
derived, so any resolution is provisional: `coverage-check` regenerates it and
fails if what is committed does not match what the suites reported. A wrong
auto-resolution cannot reach main. It just stops being a manual step.

## What this does

`.gitattributes` points both files at a merge driver that keeps the current
branch's copy and exits.

Git resolves a driver by name from local config, which a repository cannot
ship, so `setup-dev` configures it:

```
git config merge.coverage-generated.driver true
```

Without that config git falls back to a normal merge and conflicts as before,
so a fresh clone is never worse off than it is today. Nothing in CI depends on
it: CI does not merge.

## Verification

Replayed the exact merge that conflicted on #238 — `main` into
`feat/clickhouse-type-table-timestamps`, which conflicted on both files. With
the driver configured it reports "Automatic merge went well", and neither file
carries a conflict marker.

## What it does not do

It does not make the resolution correct. The kept copy is whatever the branch
had, which is usually stale after a merge, and `coverage-check` still fails
until the matrix is regenerated. That failure is the point: it is the check
that already exists, doing the job the manual conflict was pretending to do.
