### PR TITLE
fix: a handler's result table was retained twice and released once

### DIFF
--- a/.claude/skills/memory-soak/SKILL.md
+++ b/.claude/skills/memory-soak/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: memory-soak
+description: Use when a sqlflow process grows over time, when a change touches Arrow, ADBC, DuckDB, or any cgo boundary, or before tagging a release. Also use when a heap profile shows nothing but the container keeps growing.
+---
+
+# Memory soak
+
+Run a pipeline for twenty minutes under steady load and decompose where
+its memory lives. The decomposition is the point. A Go heap profile
+cannot see a buffer that DuckDB allocated across the ADBC boundary, and
+`duckdb_memory()` does not track it either. Only the process can.
+
+## The rule
+
+**A flat heap profile does not mean no leak.** The leak this skill was
+built to find grew a process from 48 to 90 MiB while `go tool pprof`
+diffed to zero bytes over fifteen minutes. The memory was native.
+
+Decompose every sample into three numbers, from `/proc/1/status` and
+`runtime.MemStats`:
+
+| number | source | what it is |
+| --- | --- | --- |
+| Go retained | `Sys - HeapReleased` | what the Go runtime holds |
+| DuckDB tracked | `duckdb_memory()` on the live connection | what DuckDB accounts for |
+| native | `RssAnon - Go retained` | everything else, and where cgo leaks land |
+
+If native climbs while the other two are flat, the leak is a native
+buffer whose Go handle was released or never existed. Arrow is reference
+counted, so look for a `Retain()` without a matching `Release()`, and for
+`Retain()` called on something a constructor already returned holding one
+reference.
+
+## Run it
+
+```bash
+.claude/skills/memory-soak/soak.sh <image> <config.yml> <minutes> <label>
+```
+
+The script starts the pipeline with `--pprof --metrics=prometheus
+--with-http-debug`, samples the decomposition once a minute into
+`soak-<label>/decomp.csv`, and saves a heap profile per minute. Feed the
+topic yourself at a steady rate; a burst that drains in seconds measures
+nothing. The producer in `producer.sh` paces 500 messages a second.
+
+Then compare a baseline against a candidate:
+
+```bash
+.claude/skills/memory-soak/compare.py soak-v1.0.6/decomp.csv soak-fix/decomp.csv
+```
+
+It prints the native slope per minute for each, after a warm-up window,
+and says whether each plateaued.
+
+## Localize with controls
+
+One soak says whether there is a leak. Controls say where. Run the same
+image against the same topic with the pipeline reduced:
+
+1. source to `InferredMemBatch` to `noop`, no `ATTACH`, no join
+2. add the `ATTACH` and the join back, keep `noop`
+3. the full pipeline with its real sink
+
+Compare growth per message across the three, over the same message
+window, not the same wall clock. A control replaying a backlog runs far
+faster than one at steady state.
+
+## Red flags
+
+| Thought | Reality |
+|---|---|
+| "pprof shows nothing, so it's fine" | pprof shows Go. Check native. |
+| "the benchmark says memory is flat" | The benchmark finishes in under a second. 44 bytes a message is invisible there. |
+| "it's still climbing after the fix" | Warm-up lasts several minutes. Judge the slope from minute 8 on. |
+| "the sink must be leaking" | Run it with `noop` first. The sink was innocent last time. |
+
+## What settles it
+
+A regression test, not a soak. A leak linear in messages needs message
+volume, not wall clock: `internal/handlers/leak_test.go` pushes half a
+million messages through a handler in under a second and asserts
+resident memory does not grow. Write one of those for the path you fixed.
+Keep the soak as a release gate for the class nobody wrote a test for.

--- a/.claude/skills/memory-soak/compare.py
+++ b/.claude/skills/memory-soak/compare.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Compare memory soaks: native slope after warm-up, slope over the final
+third, bytes retained per message, and whether each run plateaued.
+
+    compare.py soak-baseline/decomp.csv soak-candidate/decomp.csv [--warmup 8]
+
+Native is the number that matters; Go retained is printed so a Go-side leak
+shows up too. Two slopes are reported because a run that is still settling
+looks like a slow leak over the whole window and flat over its last third.
+"plateau" means the final-third slope is under 0.25 MiB/min and the last five
+samples span under 3 MiB, the noise floor seen on a 500 msg/s pipeline.
+"""
+import csv
+import os
+import sys
+
+
+def load(path):
+    rows = []
+    with open(path) as f:
+        for r in csv.DictReader(f):
+            row = {}
+            for k, v in r.items():
+                try:
+                    row[k] = float(v)
+                except (TypeError, ValueError):
+                    pass
+            if "min" in row:
+                rows.append(row)
+    return rows
+
+
+def fit(points):
+    n = len(points)
+    if n < 3:
+        return None
+    sx = sum(x for x, _ in points); sy = sum(y for _, y in points)
+    sxx = sum(x * x for x, _ in points); sxy = sum(x * y for x, y in points)
+    d = n * sxx - sx * sx
+    return (n * sxy - sx * sy) / d if d else None
+
+
+def series(rows, key, start):
+    return [(r["min"], r[key]) for r in rows if key in r and r["min"] >= start]
+
+
+def per_message(rows, key):
+    a = [r for r in rows if key in r and r.get("msgs", 0) > 0]
+    if len(a) < 2 or a[-1]["msgs"] <= a[0]["msgs"]:
+        return None
+    return (a[-1][key] - a[0][key]) * 1048576 / (a[-1]["msgs"] - a[0]["msgs"])
+
+
+def fmt(v, spec):
+    return format(v, spec) if v is not None else "n/a"
+
+
+def main():
+    argv = sys.argv[1:]
+    warmup = 8
+    if "--warmup" in argv:
+        i = argv.index("--warmup")
+        warmup = int(argv[i + 1])
+        del argv[i:i + 2]
+    if not argv:
+        print(__doc__); sys.exit(2)
+
+    hdr = f"{'soak':<22} {'n':>3} {'native first':>12} {'native last':>11} {'slope':>7} {'last-third':>10} {'B/msg':>6} {'go slope':>8} {'plateau':>7}"
+    print(hdr)
+    print("-" * len(hdr))
+    for path in argv:
+        rows = load(path)
+        name = os.path.basename(os.path.dirname(path)) or os.path.basename(path)
+        nat = series(rows, "native_mib", 0)
+        if not nat:
+            print(f"{name:<22} no native_mib column"); continue
+        last_min = nat[-1][0]
+        overall = fit(series(rows, "native_mib", warmup))
+        tail = fit(series(rows, "native_mib", max(warmup, last_min * 2 / 3)))
+        go = fit(series(rows, "go_retained_mib", warmup))
+        last5 = [y for _, y in nat[-5:]]
+        plateau = tail is not None and len(last5) == 5 and tail < 0.25 and (max(last5) - min(last5)) < 3.0
+        print(f"{name:<22} {len(rows):>3} {nat[0][1]:>12.1f} {nat[-1][1]:>11.1f} "
+              f"{fmt(overall, '.2f'):>7} {fmt(tail, '.2f'):>10} "
+              f"{fmt(per_message(rows, 'native_mib'), '.0f'):>6} {fmt(go, '.2f'):>8} "
+              f"{'yes' if plateau else 'no':>7}")
+    print("\nslopes are native MiB per minute; B/msg needs a msgs column")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/memory-soak/producer.sh
+++ b/.claude/skills/memory-soak/producer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Feed a topic at a steady rate from inside the Kafka container, so nothing
+# crosses the host boundary and a dropped pipe cannot end the run early.
+#
+#   producer.sh <kafka-container> <topic> <seconds> [msgs-per-second]
+#
+# The payload is a small sensor reading; edit the awk printf for another shape.
+set -euo pipefail
+kafka=${1:?kafka container}; topic=${2:?topic}; seconds=${3:?seconds}; rate=${4:-500}
+docker exec "$kafka" kafka-topics --bootstrap-server "$kafka:19092" --create --topic "$topic" --partitions 1 --replication-factor 1 >/dev/null 2>&1 || true
+docker exec -d "$kafka" sh -c "for t in \$(seq 1 $seconds); do
+  awk -v s=\$t -v n=$rate 'BEGIN{srand(s); for(i=0;i<n;i++){printf \"{\\\"sensor_id\\\":%d,\\\"ts\\\":\\\"2026-09-11T00:00:00\\\",\\\"value\\\":%.2f}\n\", int(rand()*5)+1, rand()*50-10}}'
+  sleep 1
+done | kafka-console-producer --bootstrap-server $kafka:19092 --topic $topic"
+echo "producing $rate msg/s to $topic for ${seconds}s inside $kafka"

--- a/.claude/skills/memory-soak/soak.sh
+++ b/.claude/skills/memory-soak/soak.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Run a pipeline under steady load and decompose its memory once a minute.
+#
+#   soak.sh <image> <config.yml> <minutes> <label>
+#
+# Writes soak-<label>/decomp.csv and one heap profile per minute. Feed the
+# source yourself at a steady rate (see producer.sh); a burst that drains in
+# seconds measures nothing.
+#
+# Environment:
+#   SOAK_NETWORK   docker network the source lives on   (default dev_default)
+#   SOAK_ENV       names of env vars to pass through     (default: every SQLFLOW_*)
+#   SOAK_PPROF     host port for pprof                   (default 6060)
+#   SOAK_METRICS   host port for prometheus              (default 8000)
+set -euo pipefail
+
+image=${1:?image}; config=${2:?config.yml}; minutes=${3:?minutes}; label=${4:?label}
+net=${SOAK_NETWORK:-dev_default}
+pprof_port=${SOAK_PPROF:-6060}; metrics_port=${SOAK_METRICS:-8000}
+name="sqlflow-soak-$label"
+out="soak-$label"; mkdir -p "$out"
+
+env_args=()
+if [ -n "${SOAK_ENV:-}" ]; then
+  for v in $SOAK_ENV; do env_args+=(-e "$v"); done
+else
+  while IFS= read -r v; do env_args+=(-e "$v"); done < <(env | cut -d= -f1 | grep '^SQLFLOW_' || true)
+fi
+
+docker rm -f "$name" >/dev/null 2>&1 || true
+docker run -d --name "$name" --network "$net" \
+  -p "$pprof_port:6060" -p "$metrics_port:8000" \
+  "${env_args[@]}" \
+  -v "$(cd "$(dirname "$config")" && pwd)":/conf \
+  "$image" run "/conf/$(basename "$config")" --pprof --metrics=prometheus --with-http-debug >/dev/null
+echo "started $name from $image; sampling for $minutes minutes into $out/"
+
+# The debug endpoint binds container-localhost, so query it from a sidecar
+# that shares the network namespace.
+ddb_query() {
+  docker run --rm --network "container:$name" curlimages/curl:latest -s --max-time 8 \
+    "http://127.0.0.1:5000/debug?sql=$1" 2>/dev/null
+}
+
+echo "min,rss_anon_mib,rss_file_mib,go_sys_mib,go_released_mib,go_retained_mib,native_mib,heap_alloc_mib,duckdb_mib,goroutines,msgs" > "$out/decomp.csv"
+for m in $(seq 0 "$minutes"); do
+  tag=$(printf %02d "$m")
+  curl -s --max-time 20 "http://localhost:$pprof_port/debug/pprof/heap" > "$out/heap-$tag.pb.gz" 2>/dev/null || true
+  st=$(docker exec "$name" sh -c 'grep -E "^(RssAnon|RssFile)" /proc/1/status' 2>/dev/null || true)
+  ra=$(echo "$st" | awk '/RssAnon/{printf "%.1f", $2/1024}')
+  rf=$(echo "$st" | awk '/RssFile/{printf "%.1f", $2/1024}')
+  ms=$(curl -s --max-time 15 "http://localhost:$pprof_port/debug/pprof/heap?debug=1" 2>/dev/null | tail -40 || true)
+  sys=$(echo "$ms" | awk '/^# Sys =/{printf "%.1f", $4/1048576}')
+  rel=$(echo "$ms" | awk '/^# HeapReleased =/{printf "%.1f", $4/1048576}')
+  ha=$(echo "$ms"  | awk '/^# HeapAlloc =/{printf "%.1f", $4/1048576}')
+  ret=$(awk -v s="${sys:-0}" -v r="${rel:-0}" 'BEGIN{printf "%.1f", s-r}')
+  nat=$(awk -v a="${ra:-0}" -v g="$ret" 'BEGIN{printf "%.1f", a-g}')
+  ddb=$(ddb_query "SELECT%20round(sum(memory_usage_bytes)/1048576.0,2)%20FROM%20duckdb_memory()" | grep -oE '[0-9.]+' | head -1 || true)
+  gor=$(curl -s --max-time 10 "http://localhost:$pprof_port/debug/pprof/goroutine?debug=1" 2>/dev/null | head -1 | grep -oE '[0-9]+' | head -1 || true)
+  msgs=$(docker logs "$name" 2>&1 | grep -oE '"messages_consumed": [0-9]+' | tail -1 | grep -oE '[0-9]+' || true)
+  echo "$m,${ra:-NA},${rf:-NA},${sys:-NA},${rel:-NA},$ret,$nat,${ha:-NA},${ddb:-NA},${gor:-NA},${msgs:-0}" >> "$out/decomp.csv"
+  [ "$m" -lt "$minutes" ] && sleep 60
+done
+echo "done: $out/decomp.csv"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ dist/
 
 # Test output the coverage matrix is generated from.
 .coverage/
+
+# Skills are repo tooling; worktrees and session state stay ignored.
+!.claude/
+.claude/*
+!.claude/skills/

--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -598,7 +598,9 @@
             "TestHandlerInferredMem_TopLevelColumnsStillComeFromFirstRow",
             "TestHandlerInferredMem_UnionsDeeplyNestedStructFields",
             "TestHandlerInferredMem_UnionsNestedStructFieldsAcrossMessages",
-            "TestHandlerInferredMem_UnionsStructValuedFieldAddedLater"
+            "TestHandlerInferredMem_UnionsStructValuedFieldAddedLater",
+            "TestInferredInvoke_DoesNotLeakNativeMemory",
+            "TestInferredInvoke_ReleasesIngestRecord"
           ]
         },
         "integration": {

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -33,7 +33,7 @@ names every one of them.
 | `sink.console` | Writes result rows to stdout as JSON. | ✅ | — | ✅ | 16 |
 | `sink.noop` | Discards every result row, for measuring the engine without a sink. | ✅ | — | — | 3 |
 | `sink.retry` | Retries a sink whose destination is not answering, bounded by a deadline. | ✅ | — | — | 71 |
-| `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 46 |
+| `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 48 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
 | `handler.structured` | Binds a declared schema, ingesting through Arrow. | ✅ | — | ✅ | 8 |
 | `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 25 |

--- a/internal/handlers/inferred.go
+++ b/internal/handlers/inferred.go
@@ -36,7 +36,7 @@ type InferredMemBatchHandler struct {
 	// provenance; empty for sources that do not.
 	metadata []core.Message
 
-	alloc      *memory.GoAllocator
+	alloc      memory.Allocator
 	conn       adbc.Connection
 	ingestStmt adbc.Statement
 	logger     *zap.Logger
@@ -196,8 +196,12 @@ func (h *InferredMemBatchHandler) Invoke(ctx context.Context) (arrow.Table, erro
 		records = append(records, rec)
 	}
 
+	// NewTableFromRecords returns the table holding one reference, and the
+	// records are retained by the table's columns, so releasing them here
+	// leaves the table as the sole owner. Retaining the table again here
+	// leaked every batch: the caller releases once, the count never reached
+	// zero, and the native Arrow buffers behind each row were never freed.
 	result := array.NewTableFromRecords(reader.Schema(), records)
-	result.Retain()
 
 	for _, rec := range records {
 		rec.Release()

--- a/internal/handlers/leak_test.go
+++ b/internal/handlers/leak_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/turbolytics/sql-flow/internal/coverage"
 )
 
 // residentAnonBytes is the process's anonymous resident memory. That is the
@@ -76,6 +77,7 @@ func TestInferredInvoke_DoesNotLeakNativeMemory(t *testing.T) {
 	if testing.Short() {
 		t.Skip("soak-shaped test, skipped under -short")
 	}
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, closeConn := newADBCConn(t)
 	defer closeConn()
 
@@ -135,6 +137,7 @@ func TestInferredInvoke_DoesNotLeakNativeMemory(t *testing.T) {
 // leak above, because those buffers were DuckDB's, not the allocator's. It is
 // here so the other half of the refcount contract is enforced too.
 func TestInferredInvoke_ReleasesIngestRecord(t *testing.T) {
+	coverage.Covers(t, "handler.inferred_mem")
 	conn, closeConn := newADBCConn(t)
 	defer closeConn()
 

--- a/internal/handlers/leak_test.go
+++ b/internal/handlers/leak_test.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+// residentAnonBytes is the process's anonymous resident memory. That is the
+// figure a native leak moves: Go's heap profiler cannot see a buffer that
+// DuckDB allocated across the ADBC boundary, and duckdb_memory() does not
+// track it either, so the only honest instrument is the process itself.
+//
+// Linux reads RssAnon, which excludes file-backed pages and is exact. Other
+// platforms fall back to peak resident size from getrusage, which only ever
+// rises, so it is a weaker signal there; a leak still shows as growth between
+// two measurements, since a steady process has a steady peak.
+func residentAnonBytes(t *testing.T) int64 {
+	t.Helper()
+	if runtime.GOOS == "linux" {
+		f, err := os.Open("/proc/self/status")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := sc.Text()
+			if !strings.HasPrefix(line, "RssAnon:") {
+				continue
+			}
+			fields := strings.Fields(line)
+			kb, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return kb << 10
+		}
+		t.Fatal("RssAnon not found in /proc/self/status")
+	}
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		t.Fatal(err)
+	}
+	maxrss := int64(ru.Maxrss)
+	if runtime.GOOS != "darwin" {
+		maxrss <<= 10 // kilobytes everywhere but darwin, which reports bytes
+	}
+	return maxrss
+}
+
+func settle() {
+	runtime.GC()
+	debug.FreeOSMemory()
+}
+
+// TestInferredInvoke_DoesNotLeakNativeMemory drives batches through the
+// handler the way the pipeline does, Invoke then Release then Init, and
+// asserts the process does not grow.
+//
+// Before the fix every Invoke retained its result table once more than the
+// caller released it. The table was never freed, and with it the Arrow
+// buffers DuckDB handed back for every row. Measured on v1.0.6 that cost
+// about 44 bytes per message and grew for as long as the process lived. This
+// loop pushes half a million messages, which leaked over 20 MiB then, against
+// a threshold of 8 MiB now.
+func TestInferredInvoke_DoesNotLeakNativeMemory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("soak-shaped test, skipped under -short")
+	}
+	conn, closeConn := newADBCConn(t)
+	defer closeConn()
+
+	ctx := context.Background()
+	h, err := NewInferredMemBatchHandler(conn, "SELECT * FROM batch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	msg := []byte(`{"sensor_id":3,"ts":"2026-09-11T00:00:00","value":12.5}`)
+	const batchSize, warmup, iters = 1000, 50, 500
+
+	run := func(n int) {
+		for i := 0; i < n; i++ {
+			for j := 0; j < batchSize; j++ {
+				if err := h.Write(msg); err != nil {
+					t.Fatal(err)
+				}
+			}
+			tbl, err := h.Invoke(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tbl == nil {
+				t.Fatal("expected a table")
+			}
+			tbl.Release()
+			if err := h.Init(ctx); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	run(warmup)
+	settle()
+	before := residentAnonBytes(t)
+
+	run(iters)
+	settle()
+	after := residentAnonBytes(t)
+
+	const limit = 8 << 20
+	growth := after - before
+	t.Logf("resident anon memory: before %d MiB, after %d MiB, growth %d MiB over %d messages",
+		before>>20, after>>20, growth>>20, iters*batchSize)
+	if growth > limit {
+		t.Fatalf("process grew %d MiB over %d messages; the handler is retaining native buffers", growth>>20, iters*batchSize)
+	}
+}
+
+// TestInferredInvoke_ReleasesIngestRecord checks the Go-allocated side with
+// arrow's checked allocator: the record the handler builds to ingest a batch
+// must be fully released once Invoke returns. This did not catch the table
+// leak above, because those buffers were DuckDB's, not the allocator's. It is
+// here so the other half of the refcount contract is enforced too.
+func TestInferredInvoke_ReleasesIngestRecord(t *testing.T) {
+	conn, closeConn := newADBCConn(t)
+	defer closeConn()
+
+	ctx := context.Background()
+	h, err := NewInferredMemBatchHandler(conn, "SELECT * FROM batch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	checked := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	h.alloc = checked
+
+	for i := 0; i < 20; i++ {
+		if err := h.Write([]byte(`{"a":1,"b":"x"}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tbl, err := h.Invoke(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tbl.Release()
+	if err := h.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	checked.AssertSize(t, 0)
+}

--- a/internal/handlers/leak_test.go
+++ b/internal/handlers/leak_test.go
@@ -72,11 +72,10 @@ func settle() {
 // buffers DuckDB handed back for every row. Measured on v1.0.6 that cost
 // about 44 bytes per message and grew for as long as the process lived. This
 // loop pushes half a million messages, which leaked over 20 MiB then, against
-// a threshold of 8 MiB now.
+// a threshold of 8 MiB now. It runs in under a second, so it belongs in the
+// -short pass: a leak linear in messages needs message volume to show, not
+// wall clock, and this is the pass CI runs on every change.
 func TestInferredInvoke_DoesNotLeakNativeMemory(t *testing.T) {
-	if testing.Short() {
-		t.Skip("soak-shaped test, skipped under -short")
-	}
 	coverage.Covers(t, "handler.inferred_mem")
 	conn, closeConn := newADBCConn(t)
 	defer closeConn()

--- a/internal/handlers/structured.go
+++ b/internal/handlers/structured.go
@@ -18,7 +18,7 @@ import (
 type StructuredBatchHandler struct {
 	rawBatch [][]byte
 
-	alloc      *memory.GoAllocator
+	alloc      memory.Allocator
 	conn       adbc.Connection
 	truncStmt  adbc.Statement
 	ingestStmt adbc.Statement
@@ -267,8 +267,12 @@ func (h *StructuredBatchHandler) Invoke(ctx context.Context) (arrow.Table, error
 		records = append(records, rec)
 	}
 
+	// NewTableFromRecords returns the table holding one reference, and the
+	// records are retained by the table's columns, so releasing them here
+	// leaves the table as the sole owner. Retaining the table again here
+	// leaked every batch: the caller releases once, the count never reached
+	// zero, and the native Arrow buffers behind each row were never freed.
 	result := array.NewTableFromRecords(reader.Schema(), records)
-	result.Retain()
 
 	for _, rec := range records {
 		rec.Release()

--- a/internal/managers/tumbling.go
+++ b/internal/managers/tumbling.go
@@ -159,8 +159,12 @@ func (m *Tumbling) collectClosed(ctx context.Context) (arrow.Table, error) {
 		return nil, err
 	}
 
+	// NewTableFromRecords returns the table holding one reference, and the
+	// records are retained by the table's columns, so releasing them here
+	// leaves the table as the sole owner. Retaining the table again here
+	// leaked every batch: the caller releases once, the count never reached
+	// zero, and the native Arrow buffers behind each row were never freed.
 	table := array.NewTableFromRecords(reader.Schema(), records)
-	table.Retain()
 	for _, rec := range records {
 		rec.Release()
 	}


### PR DESCRIPTION
Every handler `Invoke` ended with `array.NewTableFromRecords(...)` followed by `result.Retain()`. The constructor already returns the table holding one reference, so that took the count to two. The pipeline releases its batch once, the count settled at one, and the table was never freed. With it went the Arrow buffers DuckDB handed back for every row.

The same three lines were in `InferredMemBatch`, `StructuredBatch`, and the tumbling window manager's `collectClosed`. All three are removed, with a comment stating the ownership rule so a fourth copy has something to argue with.

## How it was found

A 21-minute soak on v1.0.6 against a TimescaleDB service at 500 messages a second. The container grew from 48 to 90 MiB in a straight line. Everything Go and DuckDB could see was flat the whole time:

| | min 0 | min 10 |
| --- | --- | --- |
| Go retained (`Sys - HeapReleased`) | 23.4 | 23.5 |
| Go `HeapAlloc` | 6.8 | 8.0 |
| goroutines | 19 | 19 |
| `duckdb_memory()` on the live connection | 0.2 | 0.2 |
| **native (`RssAnon` minus Go retained)** | **70.2** | **99.1** |

Fifteen heap profiles diffed with `go tool pprof -base` accounted for **zero bytes**. The leaked memory was native, allocated by DuckDB across the ADBC boundary, so no Go profiler could see it.

Two controls localized it before any code was read. Over the same 62,000-message window, Kafka to `InferredMemBatch` to `noop`, with no `ATTACH` and no join, retained about **44 bytes per message**. That is the smallest pipeline sqlflow can run.

## Why the benchmark never saw it

The published 300,000-message run finishes in under a second and retains about 13 MB, inside the noise of the reported 155 to 181 MiB working set. At 10,000 messages a second the leak is roughly 1.5 GB an hour.

## Verified on the fixed image

Same soak, same service, same decomposition, fixed binary (`v1.0.6-15-g2851686-dirty`, different digest):

| | v1.0.6 | fixed |
| --- | --- | --- |
| native, minute 3 | 82.1 | 25.7 |
| native, minute 6 | 91.4 | 28.6 |
| native, minutes 12 to 18 | 103 → 106 | 31.0 → 31.7 |
| no-attach control, 45,000 messages | climbing | 25.9 → 24.2, falling |
| attach + join control, 45,000 messages | climbing | 52.3 → 52.6, flat |

Accounting stayed exact throughout: 660,000 consumed, 660,000 rows written, 660,000 enriched, consumer lag 0.

One residual to be honest about. The full path with the `sqlcommand` sink still drifts about 0.1 MiB a minute between minutes 12 and 18, decelerating. That is a few bytes a message, on a path whose no-sink controls are flat, and it looks like DuckDB and Postgres extension buffers settling rather than a per-message retention. Twenty minutes cannot prove it is zero. A two-hour run with the harness below can, and that is the next thing to run before tagging.

## Regression tests

`internal/handlers/leak_test.go`:

- `TestInferredInvoke_DoesNotLeakNativeMemory` drives 500,000 messages through the handler the way the pipeline does, Invoke then Release then Init, and asserts anonymous resident memory does not grow. It runs in 0.7 seconds. **With the leak put back it fails by 29 MiB; on this branch it passes by 2 MiB.** A leak linear in messages needs message volume to detect, not wall clock, so this belongs in CI on every PR.
- `TestInferredInvoke_ReleasesIngestRecord` wraps the ingest path in arrow's `CheckedAllocator`. The `alloc` field becomes the `memory.Allocator` interface so a test can inject one.

## The harness, as a skill

`.claude/skills/memory-soak/` is the exact tooling that found this: `soak.sh` starts a pipeline with pprof, prometheus and the DuckDB debug endpoint and samples the three-way decomposition once a minute; `compare.py` reports slopes and bytes per message; `producer.sh` feeds a topic at a steady rate. `.gitignore` now tracks `.claude/skills/` while keeping worktrees ignored.

Fixes #239. Related: #162, since any `max_memory` built on DuckDB's own accounting would have read 0.2 MiB while this process climbed past a gigabyte.
