### PR TITLE
fix: StructuredBatch retained storage for every row it ever truncated

### DIFF
--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -668,7 +668,9 @@
             "TestHandlerStructured_ListElementSeesRowsIngestedAfterPrepare",
             "TestHandlerStructured_MultipleRecords",
             "TestHandlerStructured_NestedStruct",
-            "TestHandlerStructured_SingleRecord"
+            "TestHandlerStructured_SingleRecord",
+            "TestStructuredInit_ReleasesTruncatedStorage",
+            "TestStructuredInvoke_DoesNotLeakNativeMemory"
           ]
         },
         "integration": {

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -35,7 +35,7 @@ names every one of them.
 | `sink.retry` | Retries a sink whose destination is not answering, bounded by a deadline. | ✅ | — | — | 71 |
 | `handler.inferred_mem` | Infers a schema per batch and runs the query in memory. | ✅ | — | ✅ | 48 |
 | `handler.inferred_disk` | Infers a schema per batch, staging the batch on disk. | ✅ | — | — | 9 |
-| `handler.structured` | Binds a declared schema, ingesting through Arrow. | ✅ | — | ✅ | 8 |
+| `handler.structured` | Binds a declared schema, ingesting through Arrow. | ✅ | — | ✅ | 10 |
 | `state.durability` | Window state and the offsets that produced it commit together. | ✅ | — | ✅ | 25 |
 | `state.offsets` | Kafka positions are stored in DuckDB and resumed on restart. | ✅ | — | ✅ | 22 |
 | `state.corruption` | A damaged state file fails the start rather than silently resetting. | ✅ | — | ✅ | 6 |

--- a/internal/handlers/structured.go
+++ b/internal/handlers/structured.go
@@ -21,6 +21,7 @@ type StructuredBatchHandler struct {
 	alloc      memory.Allocator
 	conn       adbc.Connection
 	truncStmt  adbc.Statement
+	ckptStmt   adbc.Statement
 	ingestStmt adbc.Statement
 	queryStmt  adbc.Statement
 	logger     *zap.Logger
@@ -37,6 +38,9 @@ func (h *StructuredBatchHandler) Init(ctx context.Context) error {
 
 	if _, err := h.truncStmt.ExecuteUpdate(ctx); err != nil {
 		return err
+	}
+	if _, err := h.ckptStmt.ExecuteUpdate(ctx); err != nil {
+		return fmt.Errorf("checkpoint after truncate: %w", err)
 	}
 	return nil
 }
@@ -308,6 +312,21 @@ func NewStructuredBatchHandler(
 		return nil, fmt.Errorf("set truncate query: %w", err)
 	}
 
+	// TRUNCATE empties the table but leaves its row groups behind, and DuckDB
+	// keeps them until a checkpoint. Without this, an in-memory database
+	// retained about 60 bytes for every row that ever passed through the
+	// table, reported by duckdb_memory() as IN_MEMORY_TABLE for a table with
+	// zero rows, for as long as the process lived. A checkpoint after each
+	// truncate reclaims all of it and leaves the table's identity, and so the
+	// prepared plan, untouched.
+	ckptStmt, err := conn.NewStatement()
+	if err != nil {
+		return nil, fmt.Errorf("new checkpoint statement: %w", err)
+	}
+	if err := ckptStmt.SetSqlQuery("CHECKPOINT;"); err != nil {
+		return nil, fmt.Errorf("set checkpoint query: %w", err)
+	}
+
 	// Pre-create ingest statement with options set once
 	ingestStmt, err := conn.NewStatement()
 	if err != nil {
@@ -339,6 +358,7 @@ func NewStructuredBatchHandler(
 		alloc:      pool,
 		conn:       conn,
 		truncStmt:  truncStmt,
+		ckptStmt:   ckptStmt,
 		ingestStmt: ingestStmt,
 		queryStmt:  queryStmt,
 		schema:     schema,

--- a/internal/handlers/structured_leak_test.go
+++ b/internal/handlers/structured_leak_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+)
+
+// duckdbTableBytes is what DuckDB itself says it is holding for tables on
+// this connection. It is the instrument for the growth that Init's TRUNCATE
+// leaves behind: the rows are gone, but their row groups are not, and DuckDB
+// counts them here until a checkpoint reclaims them.
+func duckdbTableBytes(t *testing.T, conn adbc.Connection) int64 {
+	t.Helper()
+	stmt, err := conn.NewStatement()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+	if err := stmt.SetSqlQuery(`SELECT CAST(coalesce(sum(memory_usage_bytes), 0) AS BIGINT)
+		FROM duckdb_memory() WHERE tag IN ('IN_MEMORY_TABLE', 'BASE_TABLE')`); err != nil {
+		t.Fatal(err)
+	}
+	reader, _, err := stmt.ExecuteQuery(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Release()
+	if !reader.Next() {
+		t.Fatal("duckdb_memory() returned no rows")
+	}
+	return reader.Record().Column(0).(*array.Int64).Value(0)
+}
+
+func newSoakStructuredHandler(t *testing.T) (*StructuredBatchHandler, func() int64) {
+	t.Helper()
+	conn, cleanup := newTestADBCConn(t)
+	t.Cleanup(cleanup)
+
+	createTable(t, conn, `CREATE TABLE soak_src (sensor_id BIGINT, ts VARCHAR, value DOUBLE);`)
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "sensor_id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "ts", Type: arrow.BinaryTypes.String},
+		{Name: "value", Type: arrow.PrimitiveTypes.Float64},
+	}, nil)
+	h, err := NewStructuredBatchHandler(conn,
+		"SELECT sensor_id, COUNT(*) AS n, AVG(value) AS avg_value FROM soak_src GROUP BY sensor_id",
+		"soak_src", schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return h, func() int64 { return duckdbTableBytes(t, conn) }
+}
+
+// driveStructured pushes n batches of batchSize messages through the handler
+// the way the pipeline does: Write, Invoke, Release, Init.
+func driveStructured(t *testing.T, h *StructuredBatchHandler, n, batchSize int) {
+	t.Helper()
+	ctx := context.Background()
+	msg := []byte(`{"sensor_id":3,"ts":"2026-09-11T00:00:00","value":12.5}`)
+	for i := 0; i < n; i++ {
+		for j := 0; j < batchSize; j++ {
+			if err := h.Write(msg); err != nil {
+				t.Fatal(err)
+			}
+		}
+		tbl, err := h.Invoke(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tbl == nil {
+			t.Fatal("expected a table")
+		}
+		tbl.Release()
+		if err := h.Init(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestStructuredInit_ReleasesTruncatedStorage: Init empties the declared
+// table with TRUNCATE, and TRUNCATE leaves the dead row groups in place. On
+// a 60-minute soak at 1,000 messages a second that was about 53 bytes
+// retained per message, reported by duckdb_memory() as IN_MEMORY_TABLE for a
+// table holding zero rows, and it grew for as long as the process lived.
+// A CHECKPOINT after the truncate reclaims all of it. This asserts the
+// storage DuckDB holds for the table does not grow across batches.
+func TestStructuredInit_ReleasesTruncatedStorage(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
+	h, tableBytes := newSoakStructuredHandler(t)
+
+	const batchSize, warmup, iters = 1000, 20, 200
+	driveStructured(t, h, warmup, batchSize)
+	before := tableBytes()
+	driveStructured(t, h, iters, batchSize)
+	after := tableBytes()
+
+	const limit = 4 << 20
+	growth := after - before
+	t.Logf("duckdb table storage: before %d KiB, after %d KiB, growth %d KiB over %d rows through an emptied table",
+		before>>10, after>>10, growth>>10, iters*batchSize)
+	if growth > limit {
+		t.Fatalf("DuckDB kept %d KiB of storage for a table Init had emptied; TRUNCATE without a checkpoint retains dead row groups", growth>>10)
+	}
+}
+
+// TestStructuredInvoke_DoesNotLeakNativeMemory is the process-level view of
+// the same path, the instrument that catches whatever DuckDB's own accounting
+// does not: half a million messages, and the process must not grow.
+func TestStructuredInvoke_DoesNotLeakNativeMemory(t *testing.T) {
+	coverage.Covers(t, "handler.structured")
+	h, _ := newSoakStructuredHandler(t)
+
+	const batchSize, warmup, iters = 1000, 50, 500
+	driveStructured(t, h, warmup, batchSize)
+	settle()
+	before := residentAnonBytes(t)
+	driveStructured(t, h, iters, batchSize)
+	settle()
+	after := residentAnonBytes(t)
+
+	const limit = 8 << 20
+	growth := after - before
+	t.Logf("resident anon memory: before %d MiB, after %d MiB, growth %d MiB over %d messages",
+		before>>20, after>>20, growth>>20, iters*batchSize)
+	if growth > limit {
+		t.Fatalf("process grew %d MiB over %d messages; the structured handler is retaining memory", growth>>20, iters*batchSize)
+	}
+}


### PR DESCRIPTION
`StructuredBatch.Init` empties the declared table with `TRUNCATE`, and `TRUNCATE` leaves the dead row groups in place. DuckDB keeps them until a checkpoint, which an in-memory database run this way never reaches. The table reported zero rows while `duckdb_memory()` reported a growing `IN_MEMORY_TABLE` for it.

## Measured

Isolated 60-minute soak on main (post-#243) at 1,000 messages a second, `batch_size: 5000`, `noop` sink, sampled once a minute with the memory-soak harness:

| min | DuckDB tracked | native | Go retained | consumed |
| --- | --- | --- | --- | --- |
| 1 | 4.1 | 5.3 | 22.1 | 59,769 |
| 2 | 7.1 | 8.7 | 22.6 | 118,768 |
| 3 | 10.8 | 11.8 | 22.7 | 177,768 |
| 4 | 13.8 | 15.2 | 21.3 | 236,768 |

About 53 bytes a message, native tracking DuckDB's own figure exactly, Go flat. Querying the live process: `SELECT count(*) FROM source` returned 0 while `duckdb_memory()` held 18 MiB of `IN_MEMORY_TABLE` for it.

A side container proved the cure: 6.75 MiB held for the empty table went to nothing after a single `CHECKPOINT`.

## Why a checkpoint and not DROP/CREATE

`InferredMemBatch` never hits this because it drops and recreates its table each batch. `StructuredBatch` cannot: DuckDB's ADBC layer keeps the prepared plan until the catalog changes, and a plan built against the empty table folds bad statistics in, so it truncates on purpose. A checkpoint after the truncate reclaims the storage and leaves the table's identity, and therefore the plan, untouched. It is pre-created in the constructor like the other statements and runs once per `Init`.

## Regression tests, both failing first

| test | before | after |
| --- | --- | --- |
| `TestStructuredInit_ReleasesTruncatedStorage`, DuckDB storage after 200,000 rows through an emptied table | **11,776 KiB** | 0 KiB |
| `TestStructuredInvoke_DoesNotLeakNativeMemory`, resident memory over 500,000 messages | **27 MiB** | 0 MiB |

Both run in under a second in the `-short` pass and carry `coverage.Covers(t, "handler.structured")`. The matrix will need regenerating from this run's report artifacts, as with #243.

## Context

This is the second growth on the `StructuredBatch` path. #243 removed the first, an Arrow refcount leak shared with the other handlers. Together they are why the published benchmark's "flat" working set was measured on a build that could not stay flat. The isolated soak that found this is still running as the baseline; the same soak on this branch is the next step before any benchmark figure is republished.

Related: #239, #162.
