### PR TITLE
An ignored handler failure left its half-written state to be committed

### DIFF
--- a/docs/coverage/matrix.json
+++ b/docs/coverage/matrix.json
@@ -887,6 +887,7 @@
         "unit": {
           "status": "covered",
           "tests": [
+            "TestCoreConsumeLoop_AnIgnoredHandlerFailureRollsBackItsPartialState",
             "TestCoreConsumeLoop_CommitsOnlyProcessedMarks",
             "TestCoreConsumeLoop_FlushesFinalBatchWhenMaxMsgsReached",
             "TestCoreConsumeLoop_FlushesPartialBatchOnFlushInterval",

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -41,7 +41,7 @@ names every one of them.
 | `state.corruption` | A damaged state file fails the start rather than silently resetting. | ✅ | — | ✅ | 6 |
 | `lifecycle.drain` | SIGTERM writes the buffered batch before exiting. | ✅ | — | ✅ | 2 |
 | `lifecycle.exit_codes` | The process exit status carries the error code a supervisor reads. | ✅ | — | ✅ | 8 |
-| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 29 |
+| `core.consume_loop` | Accumulates a batch, flushes it, and commits in that order. | ✅ | — | — | 30 |
 | `error.taxonomy` | Every failure carries a class.domain.reason code. | ✅ | — | — | 16 |
 | `error.raise` | Policy RAISE stops the pipeline on a bad record. | ✅ | — | — | 1 |
 | `error.ignore` | Policy IGNORE drops a bad record and keeps the pipeline running. | ✅ | — | ✅ | 5 |

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -798,6 +798,19 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 		if policyErr := t.applyErrorPolicy(ctx, err, phaseHandlerInvoke, "Handler invocation failed"); policyErr != nil {
 			return policyErr
 		}
+		// The policy swallowed the failure, so this batch is discarded rather
+		// than fatal -- but the handler's writes up to the point it failed are
+		// still in the open state transaction. Discard them with the batch
+		// they belong to, exactly as the sink-write and flush paths below do.
+		// Committing them would leave state that no replay reproduces, with
+		// nothing logged and no error returned.
+		//
+		// The rollback ends the transaction and the next one begins with it,
+		// so the commit below still saves this batch's offsets: IGNORE means
+		// the batch is dropped, and holding its position would replay it
+		// forever.
+		t.rollbackState(ctx)
+
 		// The batch yielded no table, so there is nothing to write; the
 		// source is still committed so the failed batch is not replayed
 		// forever.

--- a/internal/core/turbine_test.go
+++ b/internal/core/turbine_test.go
@@ -712,6 +712,50 @@ func TestCoreConsumeLoop_ProcessBatchSavesTheProcessedOffsets(t *testing.T) {
 	assert.Equal(t, int64(3), got.Offset)
 }
 
+// failingInvokeHandler fails the way a handler whose SQL is wrong for one
+// batch does: the writes it managed before the failure are already in the open
+// state transaction.
+type failingInvokeHandler struct{ fakeHandler }
+
+func (h *failingInvokeHandler) Invoke(ctx context.Context) (arrow.Table, error) {
+	return nil, errors.New("handler SQL failed halfway")
+}
+
+// A handler failure the error policy swallows must still discard that batch's
+// half-written state.
+//
+// The sink-write and flush paths both roll back for this reason. The Invoke
+// path did not, so under IGNORE or DLQ the pipeline committed whatever SQL had
+// applied before the failure, together with the offsets for the batch that
+// failed. State then differed from what a replay would produce, with nothing
+// logged and no error returned.
+func TestCoreConsumeLoop_AnIgnoredHandlerFailureRollsBackItsPartialState(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+	var events []string
+	src := &markingSource{fakeSource: fakeSource{
+		batches: [][]Message{kafkaMessages("events", 0, 0, 4)},
+	}}
+	store := &fakeOffsetStore{events: &events}
+	conn := &txConn{events: &events}
+
+	tb := NewTurbine(src, &failingInvokeHandler{}, &orderingSink{events: &events}, 4,
+		time.Second, &sync.Mutex{}, PipelineErrorPolicies{Policy: PolicyIgnore},
+		WithStateStore(store, conn))
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	// The rollback comes first, so the commit below cannot adopt the failed
+	// batch's writes. Offsets still advance: IGNORE means the batch is
+	// discarded, and holding its position would replay it forever.
+	assert.Equal(t, []string{"rollback", "flush", "save-offsets", "commit"}, events)
+
+	assert.Equal(t, 1, len(store.saved))
+	got, ok := store.saved[0].Get("events", 0)
+	assert.That(t, ok)
+	assert.Equal(t, int64(3), got.Offset)
+}
+
 // Without a state store the pipeline behaves exactly as before: no
 // transaction calls at all, and the source is still committed.
 func TestCoreConsumeLoop_ProcessBatchNoStateStoreIsUnchanged(t *testing.T) {


### PR DESCRIPTION
Adds one `t.rollbackState(ctx)` to `processBatch`, on the path where the error
policy swallows a handler `Invoke` failure, and a test that pins it.

## What it fixes

A handler's `Invoke` runs inside the open state transaction, so a failure
leaves whatever SQL applied before it in that transaction. Under `on_error`
`IGNORE` or `DLQ` the policy swallows the failure and execution falls through
to `commitState`, which commits those partial writes together with the offsets
for the batch that failed. State ends up in a condition no replay reproduces,
with nothing logged and no error returned.

The sink-write and flush paths already roll back for this reason. The `Invoke`
path did not.

## What it does not change

Offsets still advance past the failed batch. The rollback ends the transaction
and the next begins with it, so the commit still saves this batch's position.
`IGNORE` means the batch is dropped, and holding its position would replay a
batch that fails every time.

`RAISE` is untouched: the failure is still fatal and nothing is committed.

## Test

`TestCoreConsumeLoop_AnIgnoredHandlerFailureRollsBackItsPartialState` asserts
the event order is `[rollback, flush, save-offsets, commit]` and that the saved
offset is the batch's last.

## Note on #166

The issue records this as latent, on the grounds that every `processBatch`
error is fatal. `applyErrorPolicy` is reached from inside `processBatch`, so it
is reachable today by configuration alone.
