### PR TITLE
Two races in the conformance harness, and the detector that finds them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,18 @@ jobs:
       # -json so the coverage job can read this run instead of repeating it.
       # tee keeps the events in the log, where a failure is the line carrying
       # "Action":"fail" and its test name.
+      #
+      # -race because the conformance harness coordinates goroutines, and two
+      # of its races reached main: a WaitGroup whose Add ran on the pipeline's
+      # goroutine while Wait ran on the harness's, and a channel closed by one
+      # goroutine while another was sending on it. The second panicked a CI run
+      # outright, and neither reproduced by re-running. The detector found both
+      # on the first pass.
       - name: Test Unit
         run: |
           mkdir -p .coverage
           set -o pipefail
-          go test -short -json ./... | tee .coverage/go.json
+          go test -short -race -json ./... | tee .coverage/go.json
 
       # always(): a failing suite is exactly when the matrix needs this report,
       # so it can name the feature that broke rather than reporting nothing.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test-image: sqlflow-image
 .PHONY: coverage-matrix
 coverage-matrix: sqlflow-image
 	@mkdir -p .coverage
-	-CGO_ENABLED=1 go test -short -json ./... > .coverage/go.json 2>&1
+	-CGO_ENABLED=1 go test -short -race -json ./... > .coverage/go.json 2>&1
 	-CGO_ENABLED=1 go test -json -run '^TestIntegration' ./... \
 		> .coverage/go-integration.json 2>&1
 	-SQLFLOW_PYTEST_JSON=$(shell pwd)/.coverage/pytest.json \
@@ -281,6 +281,11 @@ test-go:
 	go build ./...
 	go vet ./...
 	@test -z "$$(gofmt -l internal/ cmd/)" || { echo "gofmt needed:"; gofmt -l internal/ cmd/; exit 1; }
+	@# -race on the unit pass, matching CI. The conformance harness coordinates
+	@# goroutines and two of its races reached main, neither reproducible by
+	@# re-running; the detector found both on the first pass. The integration
+	@# pass runs without it, because there the cost is the containers.
+	go test -short -race ./...
 	go test ./...
 
 # The Python engine's image targets are gone with the engine. Published

--- a/internal/conformance/pipeline.go
+++ b/internal/conformance/pipeline.go
@@ -526,7 +526,11 @@ func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) out
 	t.Helper()
 
 	rec := &Recorder{failOffsets: f.offsets}
-	src := &recordingSource{rec: rec}
+	src := newRecordingSource(rec)
+	// Every scenario ends by signalling the source, including the ones that
+	// never call Close themselves: the blocking sender waits on that signal,
+	// and without it the goroutine outlives the run.
+	defer src.Close()
 
 	sink := &recordingSink{rec: rec}
 	if s.NewSink != nil {
@@ -614,7 +618,7 @@ func runPipeline(t *testing.T, s PipelineSubject, trigger Trigger, f faults) out
 
 	if trigger == TriggerDrain {
 		go func() {
-			src.wrote.Wait()
+			<-src.wrote
 			cancel()
 		}()
 	}
@@ -712,9 +716,21 @@ type recordingSource struct {
 	batch []core.Message
 	block bool
 
-	// wrote fires once every message has been handed to the pipeline, so the
+	// wrote closes once the batch has been handed to the pipeline, so the
 	// drain scenario cancels at a point where rows are buffered.
-	wrote sync.WaitGroup
+	//
+	// A channel rather than a WaitGroup. Start runs on the pipeline's
+	// goroutine and the drain watcher waits on the harness's, so an Add in one
+	// raced a Wait in the other -- and a Wait that won saw a zero counter,
+	// returned at once, and cancelled before a single message was written. The
+	// drain trigger was then not testing a drain.
+	wrote chan struct{}
+
+	// closed is what Close signals. The sending goroutine owns ch and is the
+	// only thing that closes it: closing ch from Close while that goroutine is
+	// mid-send panics the sender, and a panic in a harness goroutine takes
+	// every test in the package with it.
+	closed chan struct{}
 
 	mu      sync.Mutex
 	commits int
@@ -722,19 +738,38 @@ type recordingSource struct {
 	once    sync.Once
 }
 
-func (s *recordingSource) Start() error {
-	s.ch = make(chan []core.Message, 1)
-	s.wrote.Add(1)
+// newRecordingSource builds the channels before anything can observe them.
+// Creating ch inside Start raced Close's read of it.
+func newRecordingSource(rec *Recorder) *recordingSource {
+	return &recordingSource{
+		rec:    rec,
+		ch:     make(chan []core.Message, 1),
+		wrote:  make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+}
 
+func (s *recordingSource) Start() error {
 	go func() {
-		s.ch <- s.batch
-		s.wrote.Done()
+		// Abandoned rather than blocked if the run ends before the pipeline
+		// reads: a send with nobody left to receive would hold this goroutine
+		// past the end of the test.
+		select {
+		case s.ch <- s.batch:
+		case <-s.closed:
+		}
+		close(s.wrote)
+
 		if !s.block {
 			close(s.ch)
 			return
 		}
 		// The drain scenario needs the loop still running when the cancel
-		// lands, so the stream stays open.
+		// lands, so the stream stays open until Close says otherwise. Closing
+		// here, on the goroutine that sends, is what makes a send after close
+		// impossible.
+		<-s.closed
+		close(s.ch)
 	}()
 	return nil
 }
@@ -763,12 +798,10 @@ func (s *recordingSource) Commits() int {
 	return s.commits
 }
 
+// Close signals the sending goroutine and returns. It does not touch ch: the
+// goroutine that sends owns it, so there is no close to race a send.
 func (s *recordingSource) Close() error {
-	s.once.Do(func() {
-		if s.block && s.ch != nil {
-			close(s.ch)
-		}
-	})
+	s.once.Do(func() { close(s.closed) })
 	return nil
 }
 

--- a/internal/conformance/pipeline.go
+++ b/internal/conformance/pipeline.go
@@ -742,7 +742,7 @@ type recordingSource struct {
 // Creating ch inside Start raced Close's read of it.
 func newRecordingSource(rec *Recorder) *recordingSource {
 	return &recordingSource{
-		rec:    rec,
+		rec: rec,
 		// Unbuffered, so the send completes only once the loop has taken the
 		// batch. A buffered channel let the send return into the buffer, and
 		// wrote then fired while the pipeline still had nothing: the drain

--- a/internal/conformance/pipeline.go
+++ b/internal/conformance/pipeline.go
@@ -743,7 +743,12 @@ type recordingSource struct {
 func newRecordingSource(rec *Recorder) *recordingSource {
 	return &recordingSource{
 		rec:    rec,
-		ch:     make(chan []core.Message, 1),
+		// Unbuffered, so the send completes only once the loop has taken the
+		// batch. A buffered channel let the send return into the buffer, and
+		// wrote then fired while the pipeline still had nothing: the drain
+		// scenario cancelled before a single row was written, which is the
+		// same vacuous drain the WaitGroup produced by a different route.
+		ch:     make(chan []core.Message),
 		wrote:  make(chan struct{}),
 		closed: make(chan struct{}),
 	}


### PR DESCRIPTION
Fixes two races in `internal/conformance/pipeline.go` and adds `-race` to the
unit pass so they cannot come back.

## Race 1: a WaitGroup used across goroutines that disagree on order

`runPipeline` spawned the drain watcher, which called `wrote.Wait()`, before
`ConsumeLoop` called `Start`, which called `wrote.Add(1)`.

Beyond the data race the semantics were wrong: a `Wait` that won saw a zero
counter, returned at once, and cancelled before a single message was written.
The drain trigger was not testing a drain.

`wrote` is now a channel the constructor makes and the sending goroutine
closes.

## Race 2: a channel closed while another goroutine sent on it

`Start` assigned `s.ch` and spawned a sender; `Close` closed `s.ch`. A `Close`
landing in that window panicked the sender:

```
panic: send on closed channel
  conformance.(*recordingSource).Start.func1()
      internal/conformance/pipeline.go:730
```

A panic in a harness goroutine fails the whole package with no test named,
which is how it presented on CI.

The sending goroutine now owns `ch` and is the only thing that closes it;
`Close` signals a separate `closed` channel. Both channels are made by the
constructor, so neither side can observe one unset. `runPipeline` defers
`Close` so the blocking sender always finishes.

## `-race` on the unit pass

Neither race reproduced by re-running. The detector found both on the first
pass, so it now runs on the unit pass in CI and in `test-go`.

The integration pass stays without it: there the cost is the containers, not
the detector.

## Verification

| Check | Result |
|---|---|
| `go test -short -race ./...` | 16 packages, clean |
| `TestPipelineStatefulRealSink_Conformance` at `-count=3` under `-race` | passes, drain invariant included |

## Blocks

#248 cannot go green until this lands: its CI run hit race 2 as a panic in
`internal/sinks`.
