### PR TITLE
ClickHouse type matrix: TIMESTAMP and VARCHAR into a plain DateTime

### DIFF
--- a/docs/coverage/clickhouse-types.mdx
+++ b/docs/coverage/clickhouse-types.mdx
@@ -18,12 +18,12 @@ sqlflow hands each batch to ClickHouse as rows built from the Arrow table DuckDB
 | `UBIGINT` | `UInt64` |  |
 | `REAL` | `Float32` |  |
 | `DOUBLE` | `Float64` |  |
-| `VARCHAR`, `UUID`, `JSON` | `String`, `LowCardinality(String)`, `DateTime64(3)`, `Enum8('' = 0, 'a' = 1, 'b' = 2)`, `FixedString(36)`, `UUID`, `IPv4`, `Decimal(10, 2)` |  |
+| `VARCHAR`, `UUID`, `JSON` | `String`, `LowCardinality(String)`, `DateTime64(3)`, `DateTime`, `Enum8('' = 0, 'a' = 1, 'b' = 2)`, `FixedString(36)`, `UUID`, `IPv4`, `Decimal(10, 2)` |  |
 | `BLOB`, `BIT`, `VARINT` | `String` |  |
 | `DATE` | `Date`, `Date32` |  |
 | `TIMESTAMP_S` | `DateTime` |  |
 | `TIMESTAMP_MS` | `DateTime64(3)` |  |
-| `TIMESTAMP` | `DateTime64(6)` |  |
+| `TIMESTAMP` | `DateTime64(6)`, `DateTime` | DateTime keeps whole seconds; DateTime64(6) keeps all six digits |
 | `TIMESTAMP_NS` | `DateTime64(9)` |  |
 | `TIMESTAMPTZ` | `DateTime64(6)` | stored as the same UTC instant; the zone is dropped and the column's own zone governs rendering |
 | `BOOLEAN[]` | `Array(Bool)` |  |

--- a/docs/coverage/integrations/sink.clickhouse.yml
+++ b/docs/coverage/integrations/sink.clickhouse.yml
@@ -94,6 +94,12 @@ types:
         value: "2026-09-01 12:00:00.123"
         expect: "2026-09-01 12:00:00.123"
         instant: true
+      # The same shape into a plain DateTime, which is what the page's note
+      # about zone-less strings describes.
+      - type: DateTime
+        value: "2026-09-01 12:00:00"
+        expect: "2026-09-01 12:00:00"
+        instant: true
       # The destinations that parse the text rather than storing it. The
       # hand-written page has claimed all of these since it was measured
       # by hand, and nothing had ever written one: the value belonged to
@@ -152,11 +158,17 @@ types:
     columns:
       - type: "DateTime64(3)"
         expect: "2026-09-08 12:00:00.123"
+  # A plain DateTime is the column most handlers write a TIMESTAMP into, and
+  # the driver keeps its whole seconds. The ClickHouse page's NYC taxi example
+  # is that pairing, and the table has to prove what the example does.
   "timestamp[us]":
-    outcome: exact
+    outcome: coerced
+    rule: DateTime keeps whole seconds; DateTime64(6) keeps all six digits
     columns:
       - type: "DateTime64(6)"
         expect: "2026-09-08 12:00:00.123456"
+      - type: DateTime
+        expect: "2026-09-08 12:00:00"
   "timestamp[ns]":
     outcome: exact
     columns:


### PR DESCRIPTION
The ClickHouse docs page's NYC taxi example casts `TIMESTAMP` into `DateTime` columns, and its note describes a zone-less `VARCHAR` landing in one. Both work; the table listed neither, because the integration test had never tried them. The ClickHouse reviewer read that as two contracts for one sink (ClickHouse/ClickHouse#117740, the open thread).

Two cells declared and proven by `TestIntegrationSinkClickhouse_Types`:

- `timestamp[us]` into `DateTime`, expect `2026-09-08 12:00:00`. The key becomes `coerced` with the rule "DateTime keeps whole seconds; DateTime64(6) keeps all six digits", beside its exact `DateTime64(6)` target.
- `utf8` into `DateTime`, value and expect `2026-09-01 12:00:00`, under the shifted-clock invariant like the `DateTime64(3)` cell next to it.

The regenerated page changes exactly those two rows. Verified locally against a container before opening; CI proves it again.