### PR TITLE
ClickHouse type matrix: TIMESTAMPTZ into a plain DateTime

### DIFF
--- a/docs/coverage/clickhouse-types.mdx
+++ b/docs/coverage/clickhouse-types.mdx
@@ -25,7 +25,7 @@ sqlflow hands each batch to ClickHouse as rows built from the Arrow table DuckDB
 | `TIMESTAMP_MS` | `DateTime64(3)` |  |
 | `TIMESTAMP` | `DateTime64(6)`, `DateTime` | DateTime keeps whole seconds; DateTime64(6) keeps all six digits |
 | `TIMESTAMP_NS` | `DateTime64(9)` |  |
-| `TIMESTAMPTZ` | `DateTime64(6)` | stored as the same UTC instant; the zone is dropped and the column's own zone governs rendering |
+| `TIMESTAMPTZ` | `DateTime64(6)`, `DateTime` | stored as the same UTC instant; the zone is dropped and the column's own zone governs rendering; DateTime keeps whole seconds |
 | `BOOLEAN[]` | `Array(Bool)` |  |
 | `TINYINT[]` | `Array(Int8)` |  |
 | `SMALLINT[]` | `Array(Int16)` |  |

--- a/docs/coverage/integrations/sink.clickhouse.yml
+++ b/docs/coverage/integrations/sink.clickhouse.yml
@@ -177,12 +177,17 @@ types:
 
   # #153's defect, stated as an outcome: the instant survives and the zone
   # does not. The column's own zone governs how the server renders it.
+  # DuckDB's to_timestamp(double) returns this type, so it is what a handler
+  # that converts an epoch field writes. The ClickHouse page's Bluesky example
+  # sends it into a plain DateTime; the table has to prove that pairing too.
   "timestamp[us, tz=*]":
     outcome: coerced
-    rule: stored as the same UTC instant; the zone is dropped and the column's own zone governs rendering
+    rule: stored as the same UTC instant; the zone is dropped and the column's own zone governs rendering; DateTime keeps whole seconds
     columns:
       - type: "DateTime64(6)"
         expect: "2026-09-08 12:00:00.123456"
+      - type: DateTime
+        expect: "2026-09-08 12:00:00"
 
   # #150 added Array(T), the one container the sink converts. Each row's
   # columns mirror its element's row, because ClickHouse's Array(T) takes


### PR DESCRIPTION
Follow-up to #256, same shape. DuckDB's `to_timestamp(double)` returns `TIMESTAMPTZ`, so it is what a handler that converts an epoch field writes. The ClickHouse page's Bluesky example sends it into a plain `DateTime` and the v1.1.0 verification landed 2,000 posts that way; the table proved the pairing only into `DateTime64(6)` (ClickHouse/ClickHouse#117740, the open thread).

One cell declared and proven by `TestIntegrationSinkClickhouse_Types`: `timestamp[us, tz=*]` into `DateTime`, expect `2026-09-08 12:00:00`. The key's coerced rule gains "DateTime keeps whole seconds" beside the zone-drop it already stated. The regenerated page changes exactly that row.