### PR TITLE
TurboStats v1: the document a process reports about itself

### DIFF
--- a/.claude/skills/memory-soak/soak.sh
+++ b/.claude/skills/memory-soak/soak.sh
@@ -13,6 +13,10 @@
 #                  set to "" to pass nothing)
 #   SOAK_PPROF     host port for pprof                   (default 6060)
 #   SOAK_METRICS   host port for prometheus              (default 8000)
+#   SOAK_FLAGS     extra run flags, e.g. "--turbostats"  (default none)
+#   SOAK_POLL      path polled once a second for the whole run, e.g.
+#                  "/turbostats/v1". A read path that allocates is a leak
+#                  the sampler's own once-a-minute scrape would never find.
 set -euo pipefail
 
 image=${1:?image}; config=${2:?config.yml}; minutes=${3:?minutes}; label=${4:?label}
@@ -33,8 +37,26 @@ docker run -d --name "$name" --network "$net" \
   -p "$pprof_port:6060" -p "$metrics_port:8000" \
   ${env_args[@]+"${env_args[@]}"} \
   -v "$(cd "$(dirname "$config")" && pwd)":/conf \
-  "$image" run "/conf/$(basename "$config")" --pprof --metrics=prometheus --with-http-debug >/dev/null
+  "$image" run "/conf/$(basename "$config")" --pprof --metrics=prometheus --with-http-debug \
+  ${SOAK_FLAGS:-} >/dev/null
 echo "started $name from $image; sampling for $minutes minutes into $out/"
+
+# Poll a read path for the whole run, if one was named. A handler that
+# allocates per request leaks in proportion to requests, and a sampler that
+# scrapes once a minute would take hours to show it.
+poll_pid=""
+if [ -n "${SOAK_POLL:-}" ]; then
+  (
+    while true; do
+      curl -s --max-time 5 -o /dev/null \
+        "http://localhost:$metrics_port$SOAK_POLL" 2>/dev/null || true
+      sleep 1
+    done
+  ) &
+  poll_pid=$!
+  trap 'kill $poll_pid 2>/dev/null || true' EXIT
+  echo "polling $SOAK_POLL once a second"
+fi
 
 # The debug endpoint binds container-localhost, so query it from a sidecar
 # that shares the network namespace.
@@ -62,4 +84,5 @@ for m in $(seq 0 "$minutes"); do
   echo "$m,${ra:-NA},${rf:-NA},${sys:-NA},${rel:-NA},$ret,$nat,${ha:-NA},${ddb:-NA},${gor:-NA},${msgs:-0}" >> "$out/decomp.csv"
   [ "$m" -lt "$minutes" ] && sleep 60
 done
+[ -n "$poll_pid" ] && kill "$poll_pid" 2>/dev/null || true
 echo "done: $out/decomp.csv"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+The conventions are in CONTRIBUTING.md. Paste output, not adjectives: a
+reviewer should be able to re-run every claim below.
+-->
+
+## What this changes
+
+<!-- The defect or the gap, then the fix. What breaks if the change is wrong. -->
+
+## Verification
+
+<!-- Delete a row only if it genuinely does not apply, and say why. -->
+
+- [ ] `go test -short -race ./...`
+- [ ] `uv run --locked pytest tests/tooling -q`
+- [ ] `make coverage-page && git status --short docs/coverage` is clean
+- [ ] `uv run --locked pytest tests/release -q` — required when the CLI
+      surface, a flag, the Dockerfile, or anything stamped at build time
+      changed
+- [ ] `make soak` — required when the change touches Arrow, ADBC, DuckDB,
+      cgo, the consume loop, a handler, a sink, the metrics recording path,
+      or anything that allocates per message or per request
+
+### Soak verdict
+
+<!--
+Paste the block, not a summary. It carries the window, the message count and
+the bytes per message, which is what makes it checkable.
+
+window        minutes 3-10, 41,203,884 messages
+native        3.9 -> 4.1 MiB
+go retained   22.4 -> 22.6 MiB
+native slope  +0.021 MiB/min
+per message   +0.005 B/msg (threshold 1.0)
+
+PASS  memory is flat over 41,203,884 messages
+-->
+
+```
+```
+
+## Notes for the reviewer
+
+<!-- Anything you decided rather than derived, and any deviation from a spec. -->

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ dist/
 !.claude/
 .claude/*
 !.claude/skills/
+
+# Memory soak output. The verdict goes in the PR body; the samples are local.
+soak-*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing
+
+## Verification conventions
+
+A pull request carries evidence, not assertions. "Tests pass" is not evidence;
+the command and its output are. Every claim in a PR body should be one a
+reviewer could re-run.
+
+Five checks. The first four run on every PR. The fifth runs when the change
+could touch memory, and the rule for that is below.
+
+### 1. The Go suite, with the race detector
+
+```bash
+go test -short -race ./...
+```
+
+Race detection is not optional. Two races in the conformance harness reached
+`main`, one of which panicked a CI run outright, and neither reproduced by
+re-running.
+
+### 2. The tooling suite
+
+```bash
+uv run --locked pytest tests/tooling -q
+```
+
+The coverage generator gates every merge, so a wrong generator is a wrong
+gate.
+
+### 3. The coverage gate
+
+```bash
+make coverage-page && git status --short docs/coverage
+```
+
+Clean means the committed page matches the status files and the registries. A
+new feature needs an entry in `docs/coverage/features.yml` and a marker on the
+tests that prove it, or the gate reports it missing.
+
+### 4. The release suite, when the artifact changes
+
+```bash
+make sqlflow-image
+SQLFLOW_IMAGE=turbolytics/sql-flow:$(git describe --tags --always --dirty) \
+  uv run --locked pytest tests/release -q
+```
+
+Required when the change touches the CLI surface, a flag, the Dockerfile, or
+anything stamped at build time. The image is what users run, and a broken
+entrypoint or a missing `libduckdb` passes every unit test.
+
+### 5. The memory soak
+
+```bash
+make start-backing-services
+make sqlflow-image
+make soak
+```
+
+Ten minutes against a saturated topic, polling `/turbostats/v1` once a second,
+sampling the memory decomposition once a minute. It prints PASS or FAIL and
+the numbers behind it.
+
+**Required when the change touches** Arrow, ADBC, DuckDB, cgo, the consume
+loop, a handler, a sink, the metrics recording path, or anything that
+allocates per message or per request. When in doubt, run it: ten minutes is
+cheaper than the alternative.
+
+**Paste the verdict block into the PR body.** Not "memory is flat" — the
+window, the message count, and the bytes per message.
+
+#### Why this shape
+
+Go's heap profiler cannot see a buffer DuckDB allocated across the ADBC
+boundary, and `duckdb_memory()` does not track it either. Only the process
+can. A leak that grew a pipeline from 48 to 90 MiB diffed to zero bytes in
+`go tool pprof` over fifteen minutes.
+
+The judgement is **bytes retained per message**, not megabytes per minute. A
+leak is linear in messages, so per-message growth is comparable between a
+saturated run and a trickle, and between a fast machine and a slow one. The
+leak this gate exists to catch was 44 bytes a message: invisible in a
+benchmark that finishes in a second, and 90 MiB over a day in production. The
+threshold is 1 B/msg, and a healthy run measures near zero.
+
+Volume is part of the gate, not an accident of it. The run fails if fewer than
+a million messages reached the window, because below that the per-message
+number is noise and a pass would mean nothing. A saturated ten minutes clears
+that by two orders of magnitude.
+
+The first three minutes are discarded. Allocator arenas are bought once and
+reused, so the opening minutes grow and then stop; judging from minute zero
+reads that as a slow leak.
+
+`/turbostats/v1` is polled for the whole run because it builds a bundle per
+request. A handler that allocates per request leaks in proportion to requests,
+which a sampler scraping once a minute would take hours to surface.
+
+#### What a soak is not
+
+A soak is a gate, not a diagnosis. When one fails, the leak is found with a
+regression test that pushes message volume in seconds, not by staring at
+another soak: see `internal/handlers/leak_test.go`, which drives half a
+million messages through a handler in under a second. Add one of those for the
+path you fixed, and keep the soak for the class nobody has written a test for.
+
+## Writing
+
+All prose follows Google's Technical Writing One. Active voice, one idea per
+sentence, no hedging, the important thing first. Commit messages name the
+defect, the fix, and the evidence, and say what breaks if the change is wrong.
+
+Code comments explain why. The code already shows what.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY internal ./internal
 # CGO_ENABLED=1 is required: the ADBC driver manager reaches libduckdb through
 # cgo, so a static pure-Go build cannot talk to DuckDB at all.
 RUN CGO_ENABLED=1 go build \
-    -ldflags "-X github.com/turbolytics/sql-flow/internal/cli.Version=${VERSION} -X github.com/turbolytics/sql-flow/internal/cli.Commit=${COMMIT}" \
+    -ldflags "-X github.com/turbolytics/sql-flow/internal/buildinfo.Version=${VERSION} -X github.com/turbolytics/sql-flow/internal/buildinfo.Commit=${COMMIT}" \
     -o /out/sqlflow ./cmd/sqlflow/
 
 FROM ${RUNTIME_IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ SQLFLOW_IMAGE ?= turbolytics/sql-flow:$(VERSION)
 DIST_DIR ?= dist
 
 GO_MODULE := github.com/turbolytics/sql-flow
-GO_LDFLAGS := -X $(GO_MODULE)/internal/cli.Version=$(VERSION) \
-	-X $(GO_MODULE)/internal/cli.Commit=$(GIT_COMMIT)
+GO_LDFLAGS := -X $(GO_MODULE)/internal/buildinfo.Version=$(VERSION) \
+	-X $(GO_MODULE)/internal/buildinfo.Commit=$(GIT_COMMIT)
 
 # Every Python entry point goes through uv, so the release suite and the
 # coverage generator run against the versions in uv.lock rather than whatever

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,20 @@ test-release: sqlflow-image
 	TC_KAFKA_LIMIT_BROKER_TO_FIRST_HOST=true \
 	$(PY) pytest tests/release
 
+# The memory gate a pull request has to pass. See CONTRIBUTING.md.
+#
+# Ten minutes against a saturated topic, polling /turbostats/v1 once a second,
+# judged on bytes retained per message rather than megabytes per minute: a leak
+# is linear in messages, so per-message growth compares across machines and
+# rates and MiB/min does not.
+#
+# Needs the dev stack and the image: `make start-backing-services` and
+# `make sqlflow-image` first. SOAK_MINUTES shortens it for a smoke test, but
+# the gate is ten.
+.PHONY: soak
+soak:
+	./scripts/soak.sh $(or $(SOAK_MINUTES),10) $(or $(SOAK_LABEL),pr)
+
 .PHONY: start-backing-services
 start-backing-services:
 	docker-compose -f dev/kafka-single.yml up -d

--- a/README.md
+++ b/README.md
@@ -1117,6 +1117,10 @@ registries alone, so `make coverage-page` regenerates it in a second, with no
 Docker and no test run. Test names and counts are in the coverage report CI
 publishes on every run.
 
+[**Contributing**](CONTRIBUTING.md) — the verification a pull request carries,
+including the ten-minute memory soak (`make soak`) required of any change that
+allocates per message or per request.
+
 `make test-go` and `make test-image` are what CI runs on every push.
 Kafka-backed integration tests are deliberately excluded from `test-go`; they
 run from the dev stack. Backing services for local development:

--- a/dev/config/soak/inferred.clickhouse.yml
+++ b/dev/config/soak/inferred.clickhouse.yml
@@ -1,0 +1,35 @@
+# The full pipeline with a real stateful sink: source -> InferredMemBatch ->
+# ClickHouse. The paired control is inferred.noop.yml, the same source and
+# handler writing to nothing. What grows here and not there is the sink's.
+#
+# Rows pass through rather than aggregate, so every message reaches the sink.
+# An aggregate would send five rows a batch and measure the sink barely at all.
+#
+# Values are matched to columns by name, so these three must match
+# soak.readings: sensor_id Int64, ts DateTime, value Float64.
+pipeline:
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default(500) }}
+
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('kafka1:19092') }}]
+      group_id: {{ SQLFLOW_GROUP_ID|default('soak-clickhouse') }}
+      auto_offset_reset: earliest
+      topics:
+        - "{{ SQLFLOW_TOPIC|default('soak-input') }}"
+
+  handler:
+    type: "handlers.InferredMemBatch"
+    sql: |
+      SELECT
+        sensor_id,
+        CAST(ts AS TIMESTAMP) as ts,
+        value
+      FROM batch;
+
+  sink:
+    type: clickhouse
+    clickhouse:
+      dsn: {{ SQLFLOW_CLICKHOUSE_DSN|default('clickhouse://clickhouse:8123/soak') }}
+      table: readings

--- a/dev/config/soak/inferred.noop.yml
+++ b/dev/config/soak/inferred.noop.yml
@@ -1,0 +1,29 @@
+# Control 1 from the memory-soak skill: source -> InferredMemBatch -> noop.
+# No ATTACH, no join, no sink that can hold anything. What grows here grows in
+# the handler or the consume loop, and nowhere else.
+#
+# The SQL matches the payload producer.sh emits: sensor_id, ts, value.
+pipeline:
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default(500) }}
+
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('kafka1:19092') }}]
+      group_id: {{ SQLFLOW_GROUP_ID|default('soak-inferred') }}
+      auto_offset_reset: earliest
+      topics:
+        - "{{ SQLFLOW_TOPIC|default('soak-input') }}"
+
+  handler:
+    type: "handlers.InferredMemBatch"
+    sql: |
+      SELECT
+        sensor_id,
+        COUNT(*) as readings,
+        AVG(value) as mean_value
+      FROM batch
+      GROUP BY sensor_id;
+
+  sink:
+    type: noop

--- a/docs/coverage/features.yml
+++ b/docs/coverage/features.yml
@@ -169,6 +169,10 @@ features:
     description: Exports pipeline counters and histograms over Prometheus.
     requires: [unit]
 
+  - id: observability.turbostats
+    description: Reports the process's own state as one versioned document, served at /turbostats/v1.
+    requires: [unit, release]
+
   - id: observability.debug_api
     description: Serves ad-hoc SQL against the live DuckDB connection.
     requires: [unit]

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -52,6 +52,7 @@ added, and this page changes only when a status does.
 | `validate.template` | Reports referenced, provided, missing, and unused template variables. | ✅ | — | — |
 | `validate.schema` | Validates a rendered config against the config JSON Schema, naming the line. | ✅ | — | — |
 | `observability.metrics` | Exports pipeline counters and histograms over Prometheus. | ✅ | — | — |
+| `observability.turbostats` | Reports the process's own state as one versioned document, served at /turbostats/v1. | ✅ | — | ✅ |
 | `observability.debug_api` | Serves ad-hoc SQL against the live DuckDB connection. | ✅ | — | — |
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ |
@@ -59,7 +60,7 @@ added, and this page changes only when a status does.
 | `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — |
 
-**36 features declared. 36 have at least one passing test attributed at every level they require, so 0 gap(s).**
+**37 features declared. 37 have at least one passing test attributed at every level they require, so 0 gap(s).**
 
 That sentence counts attribution, not proof. A feature is green here when
 a test named for it ran and passed; it says nothing about whether the

--- a/docs/coverage/status/features.yml
+++ b/docs/coverage/status/features.yml
@@ -18,6 +18,7 @@ lifecycle.exit_codes: {unit: covered, integration: not_required, release: covere
 manager.tumbling_window: {unit: covered, integration: not_required, release: covered}
 observability.debug_api: {unit: covered, integration: not_required, release: not_required}
 observability.metrics: {unit: covered, integration: not_required, release: not_required}
+observability.turbostats: {unit: covered, integration: not_required, release: covered}
 sink.clickhouse: {unit: covered, integration: covered, release: covered}
 sink.console: {unit: covered, integration: not_required, release: covered}
 sink.iceberg: {unit: covered, integration: not_required, release: covered}

--- a/docs/superpowers/plans/2026-09-10-turbostats-v1-pr1.md
+++ b/docs/superpowers/plans/2026-09-10-turbostats-v1-pr1.md
@@ -1,0 +1,1518 @@
+# TurboStats v1, PR 1: the document and the endpoint
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A sqlflow process builds one versioned document about itself from the same instruments Prometheus reads, and serves it at `GET /turbostats/v1`.
+
+**Architecture:** A new leaf package `internal/turbostats` owns the `Bundle` type and the one function that builds it, `Collect`, which reads an OTel manual reader plus the runtime and `/proc`. The run command attaches that manual reader to the meter provider always, attaches the Prometheus exporter only on request, and mounts the package's HTTP handler on the existing `:8000` mux behind a new `--turbostats` flag. Version and commit move to a leaf package so `run` can read them without importing `cli`.
+
+**Tech Stack:** Go 1.25, OTel SDK metrics (`sdkmetric.ManualReader`, `metricdata`), cobra, `github.com/zeebo/assert`; pytest and testcontainers for the release test.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-turbostats-v1-design.md`. The reporter, the `pipeline.turbostats` config block, and the final bundle on drain are PR 2 and are not in this plan.
+
+## Global Constraints
+
+- The document is exactly the one in the spec's "The document" section. Field names are the OTel instrument names, never the Prometheus series names.
+- Counters are totals since `process.started_at`. Gauges are the value now. Histograms are never in the bundle.
+- `state_db_size_bytes` is omitted, not zero, when the pipeline has no state path.
+- A bundle marshals to under 1 KiB. A test holds that bound.
+- Timestamps are RFC 3339, UTC, whole seconds.
+- Media type: `application/vnd.turbolytics.turbostats.v1+json`.
+- `--turbostats` and `--metrics=prometheus` are independent. Either starts the HTTP server on `:8000`. Neither is on by default.
+- Every new test carries `coverage.Covers(t, "observability.turbostats")` in Go, or `@pytest.mark.covers("observability.turbostats")` in Python, or the coverage gate reports the feature missing.
+- All prose follows the repo's `CLAUDE.md`. Comments explain why. Commit messages name the defect, the fix and the evidence, and carry no attribution lines.
+- Go tests run with `go test -short ./...`; the Python tooling suite with `uv run --locked pytest tests/tooling -q`. Commit after every task.
+
+## How to read the code you will touch
+
+- `internal/cli/run/root.go` is the run command. `RunE` loads the config, opens DuckDB, builds the meter provider through `newMeterProvider` in `metrics.go`, then the source, sink, handler and turbine. Flags are declared at the bottom of `NewCommand`.
+- `internal/cli/run/metrics.go` builds the meter provider only for `--metrics=prometheus` and starts the HTTP server inside that branch. `newHTTPMux` registers `/metrics` and `/stats`.
+- `internal/core/metrics.go` declares the pipeline's instruments by name. `internal/core/counting.go` declares `sink_rows_accepted` and `sink_rows_written`, each with attributes `sink` and `role`; the DLQ sink records with `role=dlq`.
+- `internal/conformance/conformance.go`, function `deliveredRows`, is an existing example of reading a counter's total out of a `sdkmetric.ManualReader`. `Collect` generalizes it.
+- `internal/handlers/leak_test.go`, function `residentAnonBytes`, already reads `RssAnon` from `/proc/self/status`. It moves.
+- `tests/release/test_image.py` drives the shipped image. `test_lifecycle_drain_writes_the_buffered_batch_on_sigterm` is the model for starting the container detached against the `stack` fixture and waiting on a log line.
+
+---
+
+### Task 0: Start the record on the Bluesky host, today
+
+No code, and not in this repository. The Bluesky instance's uptime clock is
+running and nothing is recording it. History does not backfill, so this
+happens before Task 1, not after Task 7.
+
+**Files:** none in the repo. One crontab entry on the Bluesky host.
+
+- [ ] **Step 1: Find the process**
+
+On the host:
+
+```bash
+pgrep -f 'sqlflow run' | head -1
+```
+
+Expected: one PID. If the instance runs in Docker, use `docker inspect --format '{{.State.Pid}}' <container>` instead; the rest is the same.
+
+- [ ] **Step 2: Add the cron line**
+
+`crontab -e`, then:
+
+```cron
+* * * * * P=$(pgrep -f 'sqlflow run' | head -1); if [ -n "$P" ]; then echo "$(date -u +\%FT\%TZ) up $(ps -o lstart= -p $P | xargs -I{} date -u -d '{}' +\%FT\%TZ) $(ps -o rss= -p $P)" >> $HOME/sqlflow-uptime.log; else echo "$(date -u +\%FT\%TZ) down" >> $HOME/sqlflow-uptime.log; fi
+```
+
+Each line is: sample time, `up` with the process start time and RSS in KiB, or `down`. The `\%` escapes are cron's, not the shell's. On macOS `date -d` is `date -j -f`; the Bluesky host is assumed Linux.
+
+- [ ] **Step 3: Confirm one line landed**
+
+After a minute:
+
+```bash
+tail -2 $HOME/sqlflow-uptime.log
+```
+
+Expected: a line ending in a start time and a number. That file is what Task 6's status row and the control plane's store get backfilled from, and when Task 5 ships to this host the line changes to `curl -s localhost:8000/turbostats/v1 >> $HOME/sqlflow-turbostats.jsonl`.
+
+---
+
+### Task 1: Version and commit move to a leaf package
+
+`run` cannot import `internal/cli` without a cycle, and the bundle needs the stamped version. A leaf package both can import fixes it. Three build scripts stamp the variables by fully qualified name and all three change.
+
+**Files:**
+- Create: `internal/buildinfo/buildinfo.go`
+- Create: `internal/buildinfo/buildinfo_test.go`
+- Modify: `internal/cli/version.go`
+- Modify: `Makefile` lines 11-12
+- Modify: `Dockerfile` line 42
+- Modify: `scripts/release-binaries.sh` line 48
+
+**Interfaces:**
+- Produces: package `buildinfo` with `var Version = "dev"` and `var Commit = "unknown"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/buildinfo/buildinfo_test.go`:
+
+```go
+package buildinfo
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// An unstamped build must still identify itself, because a bundle from a
+// developer's binary should say "dev" rather than an empty string.
+func TestBuildInfo_UnstampedDefaults(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	assert.Equal(t, "dev", Version)
+	assert.Equal(t, "unknown", Commit)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test -short ./internal/buildinfo/`
+Expected: build failure, `no Go files in .../internal/buildinfo` or `undefined: Version`.
+
+- [ ] **Step 3: Create the package**
+
+Create `internal/buildinfo/buildinfo.go`:
+
+```go
+// Package buildinfo carries what the build stamped into the binary.
+//
+// A leaf package on purpose: internal/cli prints these and internal/cli/run
+// reports them in the TurboStats bundle, and run cannot import cli without a
+// cycle. Both import this.
+package buildinfo
+
+// Version and Commit are stamped at link time by the Makefile, the Dockerfile
+// and the release script:
+//
+//	go build -ldflags "-X github.com/turbolytics/sql-flow/internal/buildinfo.Version=v1.0.0"
+//
+// A plain `go build ./cmd/sqlflow/` leaves the defaults below, which is how an
+// unreleased local binary identifies itself.
+var (
+	Version = "dev"
+	Commit  = "unknown"
+)
+```
+
+- [ ] **Step 4: Point `internal/cli/version.go` at it**
+
+Replace the whole file with:
+
+```go
+package cli
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"github.com/turbolytics/sql-flow/internal/buildinfo"
+)
+
+// Version and Commit live in internal/buildinfo, so the run command can
+// report them without importing this package. These names stay exported
+// because nothing outside the module should have to know that moved.
+var (
+	Version = buildinfo.Version
+	Commit  = buildinfo.Commit
+)
+
+// versionString is what both `sqlflow version` and `sqlflow --version` print.
+func versionString() string {
+	return fmt.Sprintf(
+		"sqlflow %s\ncommit: %s\ngo:     %s\n",
+		buildinfo.Version, buildinfo.Commit, runtime.Version(),
+	)
+}
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the sqlflow version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprint(cmd.OutOrStdout(), versionString())
+		},
+	}
+}
+```
+
+`versionString` reads `buildinfo` directly rather than the local copies, because `-X` sets `buildinfo.Version` at link time and the local `var` above is initialized from it in package-init order, which is fine for a print but is one more thing to reason about. The locals exist only so `cmd.Version = Version` in `root.go` keeps compiling.
+
+- [ ] **Step 5: Change the three stamping sites**
+
+In `Makefile`, lines 11-12:
+
+```make
+GO_LDFLAGS := -X $(GO_MODULE)/internal/buildinfo.Version=$(VERSION) \
+	-X $(GO_MODULE)/internal/buildinfo.Commit=$(GIT_COMMIT)
+```
+
+In `Dockerfile`, line 42, replace both `internal/cli.` with `internal/buildinfo.`:
+
+```
+    -ldflags "-X github.com/turbolytics/sql-flow/internal/buildinfo.Version=${VERSION} -X github.com/turbolytics/sql-flow/internal/buildinfo.Commit=${COMMIT}" \
+```
+
+In `scripts/release-binaries.sh`, line 48:
+
+```bash
+LDFLAGS="-X ${GO_MODULE}/internal/buildinfo.Version=${VERSION} -X ${GO_MODULE}/internal/buildinfo.Commit=${COMMIT}"
+```
+
+- [ ] **Step 6: Run the tests and prove the stamp still lands**
+
+Run: `go test -short ./internal/buildinfo/ ./internal/cli/`
+Expected: PASS.
+
+Run: `make sqlflow && ./bin/sqlflow version`
+Expected: the first line is `sqlflow v1.1.0-N-gHASH` or similar from `git describe`, not `sqlflow dev`. If it prints `dev`, the Makefile path is wrong.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/buildinfo internal/cli/version.go Makefile Dockerfile scripts/release-binaries.sh
+git commit -m "buildinfo: version and commit move to a leaf package
+
+The TurboStats bundle reports the stamped version, and the run command
+that builds it cannot import internal/cli without a cycle. Version and
+Commit now live in internal/buildinfo, which both import. The three
+stamping sites change with them; the release suite's version test is
+what catches a site that was missed."
+```
+
+---
+
+### Task 2: The rendered config text, and its hash
+
+`config.Load` renders the template and throws the bytes away. The bundle's `config_hash` needs them. One new function returns both, and `Load` becomes a wrapper so nothing else changes.
+
+**Files:**
+- Modify: `internal/config/load.go` function `Load`
+- Test: `internal/config/load_test.go`
+- Create: `internal/turbostats/hash.go`
+- Create: `internal/turbostats/hash_test.go`
+
+**Interfaces:**
+- Produces: `config.LoadRendered(path string, overrides map[string]string) (*Conf, []byte, error)`.
+- Produces: `turbostats.HashConfig(rendered []byte) string`, returning `sha256:` plus 64 hex digits.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/config/load_test.go`:
+
+```go
+// The rendered text is what the TurboStats bundle hashes, so a config that
+// renders differently under two environments hashes differently. Load used
+// to discard it.
+func TestLoadRendered_ReturnsTheTextTheConfWasParsedFrom(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	path := filepath.Join(t.TempDir(), "p.yml")
+	src := "pipeline:\n  name: {{ SQLFLOW_NAME|default('demo') }}\n  source:\n    type: kafka\n  handler:\n    type: handlers.InferredMemBatch\n    sql: SELECT 1\n  sink:\n    type: noop\n"
+	assert.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	conf, rendered, err := LoadRendered(path, map[string]string{"SQLFLOW_NAME": "x"})
+	assert.NoError(t, err)
+	assert.Equal(t, "x", conf.Pipeline.Name)
+	assert.That(t, strings.Contains(string(rendered), "name: x"))
+	assert.That(t, !strings.Contains(string(rendered), "{{"))
+}
+```
+
+Add `"os"`, `"path/filepath"` and `"strings"` to that file's imports if absent, and `"github.com/turbolytics/sql-flow/internal/coverage"`.
+
+Create `internal/turbostats/hash_test.go`:
+
+```go
+package turbostats
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+func TestHashConfig_IsSHA256OfTheRenderedText(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	got := HashConfig([]byte("pipeline:\n  name: x\n"))
+	// sha256 of that exact text, computed once with
+	// printf 'pipeline:\n  name: x\n' | shasum -a 256
+	assert.Equal(t, "sha256:2d1b7510db148fa0dfa4e13e50f1bd30c4ccceeae5dc5f5f20cce0c8034c6fcd", got)
+}
+
+func TestHashConfig_DiffersWhenTheTextDoes(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	assert.That(t, HashConfig([]byte("a")) != HashConfig([]byte("b")))
+	assert.Equal(t, 7+64, len(HashConfig([]byte("a"))))
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test -short ./internal/config/ ./internal/turbostats/`
+Expected: `undefined: LoadRendered` and `no Go files` or `undefined: HashConfig`.
+
+- [ ] **Step 3: Implement both**
+
+In `internal/config/load.go`, replace `Load` with:
+
+```go
+// LoadRendered renders the file and parses it, returning both. The rendered
+// text is what the TurboStats bundle hashes: two instances running the same
+// file under different environments are running different configs, and the
+// hash should say so.
+func LoadRendered(path string, overrides map[string]string) (*Conf, []byte, error) {
+	rendered, err := RenderTemplate(path, overrides)
+	if err != nil {
+		// Returned as-is. The inner error already names the file and the
+		// stage that failed, so another "rendering config failed" prefix adds
+		// a word and no information.
+		return nil, nil, err
+	}
+
+	var conf Conf
+	// Decoded strictly: the config schema sets additionalProperties: false, so
+	// an unrecognized key is a typo the user wants to hear about rather than a
+	// setting silently dropped.
+	dec := yaml.NewDecoder(bytes.NewReader(rendered))
+	dec.KnownFields(true)
+	if err := dec.Decode(&conf); err != nil {
+		return nil, nil, errs.Wrap(errs.CodeConfigParseFailed, err, "parsing YAML failed")
+	}
+	return &conf, rendered, nil
+}
+
+// Load is LoadRendered for callers that do not need the text.
+func Load(path string, overrides map[string]string) (*Conf, error) {
+	conf, _, err := LoadRendered(path, overrides)
+	return conf, err
+}
+```
+
+Create `internal/turbostats/hash.go`:
+
+```go
+package turbostats
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// HashConfig identifies a rendered config by content.
+//
+// Hashed after templating and before parsing, so the same file under two
+// environments hashes differently: those are two configs. The prefix names
+// the algorithm so a stored hash stays readable when the algorithm changes.
+func HashConfig(rendered []byte) string {
+	sum := sha256.Sum256(rendered)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test -short ./internal/config/ ./internal/turbostats/`
+Expected: PASS, including every existing `config` test, since `Load` still exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/load.go internal/config/load_test.go internal/turbostats/hash.go internal/turbostats/hash_test.go
+git commit -m "config: Load keeps the rendered text, and turbostats hashes it
+
+The bundle's config_hash identifies what an instance is running, and the
+same file renders differently under two environments. Load rendered and
+discarded the text. LoadRendered returns it beside the Conf, Load wraps
+it, and HashConfig is sha256 with the algorithm named in the prefix."
+```
+
+---
+
+### Task 3: The bundle, and the one function that builds it
+
+**Files:**
+- Create: `internal/turbostats/bundle.go`
+- Create: `internal/turbostats/collect.go`
+- Create: `internal/turbostats/collect_test.go`
+
+**Interfaces:**
+- Consumes: `HashConfig` is not used here; `core.StateStats` from `internal/core/stats.go` with field `SizeBytes int64`.
+- Produces: types `Bundle`, `Instance`, `Process`, `Pipeline`, `Exit`, `Static`; `const MediaType`; `func Collect(ctx context.Context, s Static, r *sdkmetric.ManualReader, stats func() (*core.StateStats, error)) (Bundle, error)`.
+
+One refinement to the spec surfaces here. The spec says an instrument with attributes is summed across them. `sink_rows_accepted` and `sink_rows_written` carry a `role` attribute, and the DLQ sink records with `role=dlq` precisely so its rows never sum into the pipeline's delivered series. Summing across `role` would undo that. So: sum across every attribute except `role`, where only `role=pipeline` counts. Task 7 adds that sentence to the spec.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/turbostats/collect_test.go`:
+
+```go
+package turbostats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// A provider with the engine's real instruments, driven a known distance.
+func provider(t *testing.T) (*sdkmetric.ManualReader, *core.Metrics, metric.Meter) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m, err := core.NewMetrics(mp)
+	assert.NoError(t, err)
+	return reader, m, mp.Meter("sqlflow")
+}
+
+var static = Static{
+	ID:         "pi-01",
+	Pipeline:   "demo",
+	Version:    "v1.2.3",
+	Commit:     "abc1234",
+	ConfigHash: "sha256:00",
+	StartedAt:  time.Date(2026, 9, 1, 8, 12, 44, 0, time.UTC),
+}
+
+func TestCollect_CountersAreTotalsSinceStart(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.MessageCount.Add(ctx, 3)
+	m.MessageCount.Add(ctx, 4)
+	m.ErrorCount.Add(ctx, 1)
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(7), b.Pipeline.MessageCount)
+	assert.Equal(t, int64(1), b.Pipeline.ErrorCount)
+}
+
+// consumer_lag is recorded per partition. The bundle carries one number.
+func TestCollect_AGaugeIsSummedAcrossItsAttributes(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.ConsumerLag.Record(ctx, 5, metric.WithAttributes(attribute.Int("partition", 0)))
+	m.ConsumerLag.Record(ctx, 7, metric.WithAttributes(attribute.Int("partition", 1)))
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(12), b.Pipeline.ConsumerLag)
+}
+
+// The DLQ records its rows with role=dlq so they never sum into the
+// pipeline's delivered series. The bundle must not undo that.
+func TestCollect_SinkRowsCountThePipelineRoleOnly(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, meter := provider(t)
+	ctx := context.Background()
+	written, err := meter.Int64Counter("sink_rows_written")
+	assert.NoError(t, err)
+	written.Add(ctx, 10, metric.WithAttributes(
+		attribute.String("sink", "console"), attribute.String("role", "pipeline")))
+	written.Add(ctx, 4, metric.WithAttributes(
+		attribute.String("sink", "console"), attribute.String("role", "dlq")))
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(10), b.Pipeline.SinkRowsWritten)
+}
+
+func TestCollect_HistogramsAreNotInTheBundle(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.SinkFlushLatency.Record(ctx, 0.25)
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	raw, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.That(t, !strings.Contains(string(raw), "latency"))
+	assert.That(t, !strings.Contains(string(raw), "bucket"))
+}
+
+// Absent state and empty state are different facts, the same rule /stats
+// follows.
+func TestCollect_StateSizeIsOmittedWithoutAStateDatabase(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+
+	b, err := Collect(context.Background(), static, reader, nil)
+	assert.NoError(t, err)
+	raw, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.That(t, !strings.Contains(string(raw), "state_db_size_bytes"))
+}
+
+func TestCollect_StateSizeComesFromTheStatsFunction(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+	stats := func() (*core.StateStats, error) {
+		return &core.StateStats{SizeBytes: 4096}, nil
+	}
+
+	b, err := Collect(context.Background(), static, reader, stats)
+	assert.NoError(t, err)
+	assert.That(t, b.Pipeline.StateDBSizeBytes != nil)
+	assert.Equal(t, int64(4096), *b.Pipeline.StateDBSizeBytes)
+}
+
+// A stats failure is the bundle's failure. A monitoring system must see it
+// rather than a healthy-looking document with a field quietly missing.
+func TestCollect_AStatsFailureFailsTheBundle(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+	stats := func() (*core.StateStats, error) { return nil, errors.New("unreadable") }
+
+	_, err := Collect(context.Background(), static, reader, stats)
+	assert.Error(t, err)
+}
+
+func TestCollect_CarriesTheStaticFactsAndTheRuntime(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+
+	b, err := Collect(context.Background(), static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, b.V)
+	assert.Equal(t, "pi-01", b.Instance.ID)
+	assert.Equal(t, "demo", b.Instance.Pipeline)
+	assert.Equal(t, "v1.2.3", b.Instance.Version)
+	assert.Equal(t, "abc1234", b.Instance.Commit)
+	assert.Equal(t, "sha256:00", b.Instance.ConfigHash)
+	assert.That(t, strings.Contains(b.Instance.Arch, "/"))
+	assert.Equal(t, static.StartedAt, b.Process.StartedAt)
+	assert.That(t, b.Process.Goroutines > 0)
+	assert.That(t, b.Process.RSSBytes > 0)
+	assert.That(t, b.Exit == nil)
+	assert.That(t, !b.SentAt.IsZero())
+	assert.Equal(t, 0, b.SentAt.Nanosecond())
+}
+
+func TestCollect_TheBundleIsUnderOneKiB(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, meter := provider(t)
+	ctx := context.Background()
+	// Nine-digit totals, the size a year of the Bluesky firehose reaches.
+	m.MessageCount.Add(ctx, 184203311)
+	m.HandlerRowsRead.Add(ctx, 184203311)
+	m.SinkFlushCount.Add(ctx, 1842033)
+	m.StateCommitCount.Add(ctx, 1842033)
+	for _, name := range []string{"sink_rows_accepted", "sink_rows_written"} {
+		c, err := meter.Int64Counter(name)
+		assert.NoError(t, err)
+		c.Add(ctx, 184203311, metric.WithAttributes(
+			attribute.String("sink", "clickhouse"), attribute.String("role", "pipeline")))
+	}
+	size := int64(4194304)
+	stats := func() (*core.StateStats, error) { return &core.StateStats{SizeBytes: size}, nil }
+
+	b, err := Collect(ctx, static, reader, stats)
+	assert.NoError(t, err)
+	b.Exit = &Exit{Reason: "SIGTERM", Code: 0}
+	raw, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.That(t, len(raw) < 1024)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test -short ./internal/turbostats/`
+Expected: `undefined: Static`, `undefined: Collect`.
+
+- [ ] **Step 3: Write the types**
+
+Create `internal/turbostats/bundle.go`:
+
+```go
+// Package turbostats is the document a sqlflow process reports about itself.
+//
+// One bundle, built by one function, carried by two transports: the HTTP
+// handler in this package serves it to whatever can reach the process, and
+// the reporter posts it outbound to a control plane that cannot. Neither
+// transport computes anything.
+//
+// Field names are the OTel instrument names in internal/core, not the
+// Prometheus series names those instruments render as. The bundle reads the
+// instrument; the suffixes belong to one exporter.
+package turbostats
+
+import "time"
+
+// MediaType names the version on the wire, so v1 and v2 are distinguishable
+// without parsing.
+const MediaType = "application/vnd.turbolytics.turbostats.v1+json"
+
+// Version is the document version, carried in the body so a bundle stored or
+// forwarded without its URL still says what it is.
+const Version = 1
+
+// Bundle is one report. The spec at
+// docs/superpowers/specs/2026-09-10-turbostats-v1-design.md defines every
+// field; the comments here say only what is not obvious from the name.
+type Bundle struct {
+	V        int       `json:"v"`
+	SentAt   time.Time `json:"sent_at"`
+	Instance Instance  `json:"instance"`
+	Process  Process   `json:"process"`
+	Pipeline Pipeline  `json:"pipeline"`
+	// Exit is present only in the last bundle a clean shutdown sends. A
+	// bundle without it is an instance still running, or one that died
+	// without saying so.
+	Exit *Exit `json:"exit,omitempty"`
+}
+
+// Instance is what the operator and the build said this process is.
+type Instance struct {
+	// ID is the operator's name for the instance. Empty until the reporter
+	// config exists, which is why it is omitempty here and required there.
+	ID         string `json:"id,omitempty"`
+	Pipeline   string `json:"pipeline,omitempty"`
+	Version    string `json:"version"`
+	Commit     string `json:"commit"`
+	Arch       string `json:"arch"`
+	ConfigHash string `json:"config_hash"`
+}
+
+// Process is what the runtime and the kernel say about this process.
+type Process struct {
+	StartedAt  time.Time `json:"started_at"`
+	RSSBytes   int64     `json:"rss_bytes"`
+	Goroutines int       `json:"goroutines"`
+}
+
+// Pipeline carries one field per counter or dimensionless gauge the engine
+// declares. Counters are totals since Process.StartedAt; gauges are the value
+// now. Histograms are deliberately absent: they are most of a scrape by bytes
+// and nothing on the first page reads them.
+type Pipeline struct {
+	MessageCount     int64 `json:"message_count"`
+	HandlerRowsRead  int64 `json:"handler_rows_read"`
+	ErrorCount       int64 `json:"error_count"`
+	SinkFlushCount   int64 `json:"sink_flush_count"`
+	SinkRowsAccepted int64 `json:"sink_rows_accepted"`
+	SinkRowsWritten  int64 `json:"sink_rows_written"`
+	StateCommitCount int64 `json:"state_commit_count"`
+	ConsumerLag      int64 `json:"consumer_lag"`
+	// A pointer so a pipeline with no state path omits the field: absent
+	// state and empty state are different facts.
+	StateDBSizeBytes *int64 `json:"state_db_size_bytes,omitempty"`
+}
+
+// Exit is how a clean shutdown ended.
+type Exit struct {
+	Reason string `json:"reason"`
+	Code   int    `json:"code"`
+}
+
+// Static is what the run command knows once, at startup, and the package
+// cannot learn on its own.
+type Static struct {
+	ID, Pipeline, Version, Commit, ConfigHash string
+	StartedAt                                 time.Time
+}
+```
+
+- [ ] **Step 4: Write `Collect`**
+
+Create `internal/turbostats/collect.go`:
+
+```go
+package turbostats
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// Collect builds one bundle. It is the only function that does.
+//
+// It allocates one bundle and touches nothing shared, so the HTTP handler and
+// the reporter can call it at once. stats may be nil for a pipeline with no
+// state path; a stats error is the bundle's error, because a document with a
+// field quietly missing reads as healthy.
+func Collect(ctx context.Context, s Static, r *sdkmetric.ManualReader,
+	stats func() (*core.StateStats, error)) (Bundle, error) {
+
+	var rm metricdata.ResourceMetrics
+	if err := r.Collect(ctx, &rm); err != nil {
+		return Bundle{}, fmt.Errorf("turbostats: collecting instruments: %w", err)
+	}
+	totals := sumByName(rm)
+
+	rss, err := ResidentAnonBytes()
+	if err != nil {
+		return Bundle{}, fmt.Errorf("turbostats: reading resident memory: %w", err)
+	}
+
+	b := Bundle{
+		V:      Version,
+		SentAt: time.Now().UTC().Truncate(time.Second),
+		Instance: Instance{
+			ID:         s.ID,
+			Pipeline:   s.Pipeline,
+			Version:    s.Version,
+			Commit:     s.Commit,
+			Arch:       runtime.GOOS + "/" + runtime.GOARCH,
+			ConfigHash: s.ConfigHash,
+		},
+		Process: Process{
+			StartedAt:  s.StartedAt.UTC().Truncate(time.Second),
+			RSSBytes:   rss,
+			Goroutines: runtime.NumGoroutine(),
+		},
+		Pipeline: Pipeline{
+			MessageCount:     totals["message_count"],
+			HandlerRowsRead:  totals["handler_rows_read"],
+			ErrorCount:       totals["error_count"],
+			SinkFlushCount:   totals["sink_flush_count"],
+			SinkRowsAccepted: totals["sink_rows_accepted"],
+			SinkRowsWritten:  totals["sink_rows_written"],
+			StateCommitCount: totals["state_commit_count"],
+			ConsumerLag:      totals["consumer_lag"],
+		},
+	}
+
+	if stats != nil {
+		st, err := stats()
+		if err != nil {
+			return Bundle{}, fmt.Errorf("turbostats: reading state stats: %w", err)
+		}
+		if st != nil {
+			size := st.SizeBytes
+			b.Pipeline.StateDBSizeBytes = &size
+		}
+	}
+	return b, nil
+}
+
+// roleKey is the attribute the sink counters carry to keep the DLQ's rows out
+// of the pipeline's delivered series. The bundle keeps them out too.
+var roleKey = attribute.Key("role")
+
+// sumByName folds every int64 counter and gauge into one total per name,
+// summed across attribute sets, except that a point with a role other than
+// "pipeline" is skipped. Histograms and float instruments are ignored: the
+// bundle carries none.
+func sumByName(rm metricdata.ResourceMetrics) map[string]int64 {
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch data := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range data.DataPoints {
+					if pipelineRole(dp.Attributes) {
+						out[m.Name] += dp.Value
+					}
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range data.DataPoints {
+					if pipelineRole(dp.Attributes) {
+						out[m.Name] += dp.Value
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func pipelineRole(set attribute.Set) bool {
+	v, ok := set.Value(roleKey)
+	return !ok || v.AsString() == "pipeline"
+}
+```
+
+`ResidentAnonBytes` does not exist yet; Task 4 creates it. To make this task's tests runnable on their own, create it now in its final form as part of this task (Task 4 then only moves the leak test onto it). Create `internal/turbostats/rss.go`:
+
+```go
+package turbostats
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ResidentAnonBytes is the process's anonymous resident memory.
+//
+// That is the figure a native leak moves: Go's heap profiler cannot see a
+// buffer DuckDB allocated across the ADBC boundary, and duckdb_memory() does
+// not track it either, so the only honest instrument is the process itself.
+//
+// Linux reads RssAnon, which excludes file-backed pages and is exact. Other
+// platforms fall back to peak resident size from getrusage, which only ever
+// rises, so it is a weaker signal there; a leak still shows as growth between
+// two readings, since a steady process has a steady peak.
+func ResidentAnonBytes() (int64, error) {
+	if runtime.GOOS == "linux" {
+		f, err := os.Open("/proc/self/status")
+		if err != nil {
+			return 0, err
+		}
+		defer f.Close()
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := sc.Text()
+			if !strings.HasPrefix(line, "RssAnon:") {
+				continue
+			}
+			fields := strings.Fields(line)
+			kb, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return 0, err
+			}
+			return kb << 10, nil
+		}
+		return 0, fmt.Errorf("RssAnon not found in /proc/self/status")
+	}
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0, err
+	}
+	maxrss := int64(ru.Maxrss)
+	if runtime.GOOS != "darwin" {
+		maxrss <<= 10 // kilobytes everywhere but darwin, which reports bytes
+	}
+	return maxrss, nil
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test -short ./internal/turbostats/`
+Expected: PASS, all nine.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/turbostats/bundle.go internal/turbostats/collect.go internal/turbostats/rss.go internal/turbostats/collect_test.go
+git commit -m "turbostats: the bundle, and Collect, the one function that builds it
+
+A process reports its own state as one versioned document: what it is,
+when it started, its resident memory, and every counter's total since
+start, read from the same instruments Prometheus reads. Histograms are
+out, so the bundle stays under 1 KiB, and a test holds it there.
+
+The sink row counters carry role=dlq for the DLQ so its rows never sum
+into the delivered series. Summing across attributes blindly would have
+undone that; a test now proves the bundle counts the pipeline role only."
+```
+
+---
+
+### Task 4: The leak test reads memory through the package
+
+The reading moved. The test that made it should use the moved copy, so there is one implementation and not two that drift.
+
+**Files:**
+- Modify: `internal/handlers/leak_test.go` lines 18-59
+
+- [ ] **Step 1: Replace the helper with a wrapper**
+
+In `internal/handlers/leak_test.go`, delete the `residentAnonBytes` function and its comment (lines 18-59) and replace with:
+
+```go
+// residentAnonBytes is turbostats.ResidentAnonBytes, which moved there so
+// the bundle and this test read the same number, with the test's failure
+// semantics.
+func residentAnonBytes(t *testing.T) int64 {
+	t.Helper()
+	n, err := turbostats.ResidentAnonBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+```
+
+Add `"github.com/turbolytics/sql-flow/internal/turbostats"` to the imports, and remove `"bufio"`, `"os"`, `"strconv"`, `"strings"` and `"syscall"` if nothing else in the file uses them. `"runtime"` stays for `settle`.
+
+- [ ] **Step 2: Run the package's tests**
+
+Run: `go test -short ./internal/handlers/ -run 'Leak|Release'`
+Expected: PASS. `TestInferredInvoke_DoesNotLeakNativeMemory` logs the same `resident anon memory:` line it did before.
+
+Run: `go vet ./internal/handlers/`
+Expected: clean. An unused import is the likely failure.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/handlers/leak_test.go
+git commit -m "handlers: the leak test reads memory through turbostats
+
+One implementation of the RssAnon read, not two that drift. The test
+keeps its t.Fatal semantics in a three-line wrapper."
+```
+
+---
+
+### Task 5: The handler, the always-present reader, and the flag
+
+**Files:**
+- Create: `internal/turbostats/handler.go`
+- Create: `internal/turbostats/handler_test.go`
+- Modify: `internal/cli/run/metrics.go` (`newHTTPMux`, `newMeterProvider`)
+- Modify: `internal/cli/run/metrics_test.go` (four `newHTTPMux` call sites)
+- Modify: `internal/cli/run/root.go` (flag, `started_at`, `LoadRendered`, `Static`, the provider call)
+
+**Interfaces:**
+- Consumes: `turbostats.Collect`, `turbostats.Static`, `turbostats.MediaType`, `config.LoadRendered`, `turbostats.HashConfig`, `buildinfo.Version`, `buildinfo.Commit`.
+- Produces: `turbostats.Handler(collect func(context.Context) (Bundle, error)) http.Handler`.
+- Produces: `newHTTPMux(registry *prom.Registry, stats statsFunc, collect func(context.Context) (turbostats.Bundle, error)) *http.ServeMux`.
+- Produces: `newMeterProvider(exporter string, serveTurbostats bool, static turbostats.Static, l *zap.Logger, stats statsFunc) (metric.MeterProvider, error)`.
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `internal/turbostats/handler_test.go`:
+
+```go
+package turbostats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+func TestHandler_ServesOneBundleWithTheMediaType(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	h := Handler(func(context.Context) (Bundle, error) {
+		return Bundle{V: Version, Instance: Instance{Version: "v9"}}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, MediaType, rec.Header().Get("Content-Type"))
+	var got Bundle
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, 1, got.V)
+	assert.Equal(t, "v9", got.Instance.Version)
+}
+
+// A collection failure is a server error, not an empty success: a monitoring
+// system must see it rather than a healthy-looking blank.
+func TestHandler_ReportsACollectionFailure(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	h := Handler(func(context.Context) (Bundle, error) {
+		return Bundle{}, errors.New("reader closed")
+	})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandler_RejectsAnythingButGET(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	h := Handler(func(context.Context) (Bundle, error) { return Bundle{V: Version}, nil })
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test -short ./internal/turbostats/ -run Handler`
+Expected: `undefined: Handler`.
+
+- [ ] **Step 3: Write the handler**
+
+Create `internal/turbostats/handler.go`:
+
+```go
+package turbostats
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Handler serves one bundle per GET. The run command mounts it at
+// /turbostats/v1; the path is the caller's, the media type is this
+// package's.
+func Handler(collect func(context.Context) (Bundle, error)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		b, err := collect(r.Context())
+		if err != nil {
+			http.Error(w, fmt.Sprintf("building bundle: %v", err),
+				http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", MediaType)
+		if err := json.NewEncoder(w).Encode(b); err != nil {
+			return
+		}
+	})
+}
+```
+
+- [ ] **Step 4: Run the handler tests**
+
+Run: `go test -short ./internal/turbostats/`
+Expected: PASS.
+
+- [ ] **Step 5: Restructure the meter provider and the mux**
+
+In `internal/cli/run/metrics.go`, add to the imports:
+
+```go
+	"context"
+
+	"github.com/turbolytics/sql-flow/internal/turbostats"
+```
+
+Replace `newHTTPMux` with:
+
+```go
+// newHTTPMux builds the server the pipeline exposes: Prometheus scraping, a
+// JSON view of durable state, and the TurboStats bundle.
+//
+// All on one mux deliberately. DuckDB takes an exclusive lock on the state
+// file, so no other process can read it while the pipeline runs -- not even
+// read-only. A running pipeline is the only thing that can report its own
+// state, which makes these the live half of observability rather than a
+// convenience.
+//
+// Each route is registered only when its provider is non-nil, so a route that
+// would answer with nothing is absent rather than half-working.
+func newHTTPMux(registry *prom.Registry, stats statsFunc,
+	collect func(context.Context) (turbostats.Bundle, error)) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	if registry != nil {
+		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	}
+
+	if stats != nil {
+		mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+			state, err := stats()
+			if err != nil {
+				// A monitoring system must see the failure, not a
+				// healthy-looking blank.
+				http.Error(w, fmt.Sprintf("collecting state stats: %v", err),
+					http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			// state is nil for a pipeline with no state database, which
+			// encodes as null: absent state and empty state are different
+			// facts and a dashboard should be able to tell them apart.
+			if err := json.NewEncoder(w).Encode(map[string]any{"state": state}); err != nil {
+				return
+			}
+		})
+	}
+
+	if collect != nil {
+		mux.Handle("/turbostats/v1", turbostats.Handler(collect))
+	}
+
+	return mux
+}
+```
+
+Replace `newMeterProvider` with:
+
+```go
+// newMeterProvider builds the provider every instrument records into, and
+// starts the HTTP server when anything needs it.
+//
+// The manual reader is attached always: it is what /turbostats/v1 reads, and
+// the outbound reporter after it. The Prometheus exporter is a second reader,
+// attached only for --metrics=prometheus. Both read the same instruments,
+// which is the property the design exists for. Before this, the provider
+// existed only for Prometheus and every counter recorded into nothing without
+// it.
+func newMeterProvider(exporter string, serveTurbostats bool,
+	static turbostats.Static, l *zap.Logger, stats statsFunc) (metric.MeterProvider, error) {
+
+	reader := sdkmetric.NewManualReader()
+	opts := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+
+	var registry *prom.Registry
+	switch strings.ToLower(strings.TrimSpace(exporter)) {
+	case "":
+	case "prometheus":
+		registry = prom.NewRegistry()
+		exp, err := prometheus.New(prometheus.WithRegisterer(registry))
+		if err != nil {
+			return nil, fmt.Errorf("prometheus exporter: %w", err)
+		}
+		opts = append(opts, sdkmetric.WithReader(exp))
+	default:
+		return nil, fmt.Errorf("unsupported --metrics exporter: %q (supported: prometheus)", exporter)
+	}
+
+	mp := sdkmetric.NewMeterProvider(opts...)
+
+	if registry == nil && !serveTurbostats {
+		return mp, nil
+	}
+
+	var collect func(context.Context) (turbostats.Bundle, error)
+	if serveTurbostats {
+		collect = func(ctx context.Context) (turbostats.Bundle, error) {
+			return turbostats.Collect(ctx, static, reader, stats)
+		}
+	}
+	mux := newHTTPMux(registry, stats, collect)
+
+	go func() {
+		routes := []string{}
+		if registry != nil {
+			routes = append(routes, "/metrics")
+		}
+		if serveTurbostats {
+			routes = append(routes, "/turbostats/v1")
+		}
+		l.Info("serving http", zap.String("addr", metricsPort), zap.Strings("routes", routes))
+		if err := http.ListenAndServe(metricsPort, mux); err != nil {
+			l.Error("http server stopped", zap.Error(err))
+		}
+	}()
+
+	return mp, nil
+}
+```
+
+- [ ] **Step 6: Update the four existing mux tests**
+
+In `internal/cli/run/metrics_test.go`, every `newHTTPMux(nil, ...)` call gains a third argument `nil`. Four sites: lines 38, 65, 81 and 94 become
+
+```go
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return want, nil }, nil)
+```
+
+and the equivalent for the other three.
+
+Then append one test:
+
+```go
+// /turbostats/v1 is present only when asked for, like /stats: a route that
+// answers with nothing is worse than none.
+func TestObservabilityTurbostats_RouteAbsentWithoutACollector(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	mux := newHTTPMux(nil, nil, nil)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestObservabilityTurbostats_RouteServesTheBundle(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	mux := newHTTPMux(nil, nil, func(context.Context) (turbostats.Bundle, error) {
+		return turbostats.Bundle{V: turbostats.Version}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, turbostats.MediaType, rec.Header().Get("Content-Type"))
+}
+
+// Attaching the manual reader must not change what Prometheus exports. The
+// series list is what the README documents and dashboards depend on.
+func TestObservabilityTurbostats_ManualReaderLeavesExportedNamesAlone(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	coverage.Covers(t, "observability.metrics")
+	reg := prom.NewRegistry()
+	exp, err := prometheus.New(prometheus.WithRegisterer(reg))
+	assert.NoError(t, err)
+	manual := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(manual), sdkmetric.WithReader(exp))
+
+	m, err := core.NewMetrics(mp)
+	assert.NoError(t, err)
+	m.MessageCount.Add(context.Background(), 1)
+
+	families, err := reg.Gather()
+	assert.NoError(t, err)
+	found := false
+	for _, f := range families {
+		if f.GetName() == "message_count_messages_total" {
+			found = true
+		}
+	}
+	assert.That(t, found)
+}
+```
+
+Add `"github.com/turbolytics/sql-flow/internal/turbostats"` to that file's imports.
+
+- [ ] **Step 7: Wire the run command**
+
+In `internal/cli/run/root.go`:
+
+Add to the imports:
+
+```go
+	"github.com/turbolytics/sql-flow/internal/buildinfo"
+	"github.com/turbolytics/sql-flow/internal/turbostats"
+```
+
+In `NewCommand`, after `var withHTTPDebug bool` add:
+
+```go
+	var serveTurbostats bool
+```
+
+At the top of `RunE`, immediately after the logger is built (after `l := logger.Named("sqlflow.run")` and its error check), add:
+
+```go
+			// Taken here, once. It is the bundle's started_at, and a restart
+			// is the control plane seeing it change.
+			startedAt := time.Now().UTC()
+```
+
+Replace the config load:
+
+```go
+			conf, rendered, err := config.LoadRendered(configPath, map[string]string{})
+			if err != nil {
+				// Returned as-is: the error already names the file, the stage and the
+				// code, so another prefix adds a word and no information.
+				return err
+			}
+```
+
+Replace the `newMeterProvider` call:
+
+```go
+			static := turbostats.Static{
+				Pipeline:   conf.Pipeline.Name,
+				Version:    buildinfo.Version,
+				Commit:     buildinfo.Commit,
+				ConfigHash: turbostats.HashConfig(rendered),
+				StartedAt:  startedAt,
+			}
+			meterProvider, err := newMeterProvider(metricsExporter, serveTurbostats, static, l, statsFn)
+			if err != nil {
+				return err
+			}
+```
+
+`static.ID` stays empty in this PR. The `pipeline.turbostats` config block that supplies it is PR 2.
+
+At the bottom of `NewCommand`, after the `--with-http-debug` flag, add:
+
+```go
+	cmd.Flags().BoolVar(&serveTurbostats, "turbostats", false,
+		"Serve GET /turbostats/v1 on "+metricsPort+": the process's own state as one document")
+```
+
+- [ ] **Step 8: Build, vet, and run the affected packages**
+
+Run: `go build ./... && go vet ./internal/cli/... ./internal/turbostats/`
+Expected: clean.
+
+Run: `go test -short ./internal/cli/... ./internal/turbostats/ ./internal/core/`
+Expected: PASS, including `TestExportedSeriesNames`, which proves the Prometheus series list did not change.
+
+Run: `make sqlflow && ./bin/sqlflow run --help | grep turbostats`
+Expected: the flag and its help text.
+
+- [ ] **Step 9: Prove it end to end against a live process**
+
+The Bluesky raw config needs only the network. From the repo root:
+
+```bash
+./bin/sqlflow run dev/config/examples/bluesky/bluesky.raw.stdout.yml --turbostats > /dev/null 2>&1 &
+PID=$!
+sleep 5
+curl -s -D - http://localhost:8000/turbostats/v1
+kill $PID
+```
+
+Expected: `Content-Type: application/vnd.turbolytics.turbostats.v1+json`, a body with `"v":1`, `"version"` matching `./bin/sqlflow version`, a `started_at` a few seconds ago, `message_count` above zero, and no `state_db_size_bytes` since that config has no state path. If the machine has no network, use any Kafka example against `make start-backing-services` instead; the assertion is the same.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/turbostats/handler.go internal/turbostats/handler_test.go internal/cli/run/metrics.go internal/cli/run/metrics_test.go internal/cli/run/root.go
+git commit -m "turbostats: GET /turbostats/v1, behind --turbostats
+
+The meter provider existed only for --metrics=prometheus, so without it
+every counter recorded into nothing and there was nothing for a bundle
+to read. The manual reader is now attached always, and the Prometheus
+exporter is a second reader on request. A test holds the exported
+series list unchanged, so attaching the reader cost no dashboard.
+
+--turbostats starts the HTTP server without Prometheus and mounts the
+bundle at /turbostats/v1 with its media type. Default stays off: a
+device should not listen on a port unless told to."
+```
+
+---
+
+### Task 6: The feature registry, and the release test
+
+**Files:**
+- Modify: `docs/coverage/features.yml` after the `observability.debug_api` entry
+- Modify: `docs/coverage/status/features.yml`
+- Modify: `docs/coverage/matrix.md` (regenerated)
+- Modify: `tests/release/test_image.py`
+
+- [ ] **Step 1: Declare the feature**
+
+In `docs/coverage/features.yml`, after the `observability.debug_api` entry, add:
+
+```yaml
+  - id: observability.turbostats
+    description: Reports the process's own state as one versioned document, served at /turbostats/v1.
+    requires: [unit, release]
+```
+
+- [ ] **Step 2: Write the failing release test**
+
+Append to `tests/release/test_image.py`:
+
+```python
+@pytest.mark.covers("observability.turbostats")
+def test_turbostats_endpoint_serves_the_bundle(image, stack):
+    """The shipped image answers /turbostats/v1 with a bundle whose version
+    is the one stamped into the image.
+
+    Driven against the real binary rather than the handler, because what
+    ships is the flag, the mux and the link-time stamp together, and a unit
+    test proves none of those.
+    """
+    topic = f"turbostats-{int(time.time())}"
+
+    container = DockerContainer(image) \
+        .with_volume_mapping(settings.DEV_DIR, "/tmp/conf") \
+        .with_env("SQLFLOW_KAFKA_BROKERS", "kafka:9092") \
+        .with_env("SQLFLOW_TOPIC", topic) \
+        .with_env("SQLFLOW_GROUP_ID", topic) \
+        .with_exposed_ports(8000) \
+        .with_network(stack.network) \
+        .with_command("run /tmp/conf/config/examples/kafka.stateful.window.yml --turbostats")
+    container.start()
+    try:
+        wait_for_logs(container, "consumer loop starting", timeout=60)
+        port = container.get_exposed_port(8000)
+        resp = requests.get(f"http://localhost:{port}/turbostats/v1", timeout=10)
+    finally:
+        container.stop()
+
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/vnd.turbolytics.turbostats.v1+json"
+    bundle = resp.json()
+    assert bundle["v"] == 1
+
+    stdout, _ = run_docker_container(image, "version")
+    stamped = stdout.splitlines()[0].split()[1]
+    assert bundle["instance"]["version"] == stamped
+    assert bundle["process"]["rss_bytes"] > 0
+    assert bundle["process"]["goroutines"] > 0
+```
+
+`requests` is already imported at the top of `tests/release/test_image.py` and pinned in `pyproject.toml`, so nothing is added.
+
+- [ ] **Step 3: Run the release test**
+
+Run: `make sqlflow-image && SQLFLOW_IMAGE=turbolytics/sql-flow:$(git describe --tags --always --dirty) SQLFLOW_PYTEST_JSON=$(pwd)/.coverage/pytest.json TC_KAFKA_LIMIT_BROKER_TO_FIRST_HOST=true uv run --locked pytest tests/release -q -k turbostats`
+Expected: PASS. If it fails on the version assertion, print `stdout` from `run_docker_container(image, "version")`; the Dockerfile stamp from Task 1 is the likely cause.
+
+- [ ] **Step 4: Regenerate the coverage page and add the status row**
+
+The status directory is regenerated from test reports in CI. Locally, add the row by hand where it will land, sorted by id, in `docs/coverage/status/features.yml` after `observability.metrics`:
+
+```yaml
+observability.turbostats: {unit: covered, integration: not_required, release: covered}
+```
+
+Then:
+
+```bash
+make coverage-page
+git status --short docs/coverage
+```
+
+Expected: `matrix.md` modified with one new feature row and nothing else. If CI's coverage job later reports the status file stale, the diff it prints is the correction.
+
+- [ ] **Step 5: Run the tooling suite**
+
+Run: `uv run --locked pytest tests/tooling -q`
+Expected: PASS. `test_the_committed_page_is_current` proves the page matches the status files and registries.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/coverage/features.yml docs/coverage/status/features.yml docs/coverage/matrix.md tests/release/test_image.py
+git commit -m "coverage: observability.turbostats, proven at unit and release
+
+The feature is declared, so the gate can hold it to a unit pass and a
+release pass. The release test starts the shipped image with
+--turbostats and checks the bundle's version against what the image
+prints, which is what proves the flag, the mux and the link-time stamp
+shipped together."
+```
+
+---
+
+### Task 7: The spec refinement, final verification, push
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-09-10-turbostats-v1-design.md`, the `pipeline` paragraph under "Fields"
+
+- [ ] **Step 1: Record two refinements in the spec**
+
+In the spec's "The package" section, the `Static` type gains the start time, since it is a fact the run command knows once and the package cannot learn. Replace
+
+```go
+type Static struct {
+    ID, Pipeline, Version, Commit, ConfigHash string
+}
+```
+
+with
+
+```go
+type Static struct {
+    ID, Pipeline, Version, Commit, ConfigHash string
+    StartedAt                                 time.Time
+}
+```
+
+Then, in the paragraph beginning "`pipeline` holds one field per instrument", replace the sentence
+
+```
+An instrument that carries attributes is summed across them, so
+`consumer_lag` is the sum over partitions.
+```
+
+with
+
+```
+An instrument that carries attributes is summed across them, so
+`consumer_lag` is the sum over partitions, with one exception: a data point
+whose `role` attribute is not `pipeline` is skipped. The DLQ sink records
+`sink_rows_accepted` and `sink_rows_written` with `role=dlq` so its rows
+never sum into the pipeline's delivered series, and the bundle keeps them
+out the same way.
+```
+
+- [ ] **Step 2: Run everything**
+
+```bash
+gofmt -l internal/ cmd/
+go build ./... && go vet ./...
+go test -short -race ./...
+uv run --locked pytest tests/tooling -q
+make coverage-page && git status --short
+```
+
+Expected: gofmt prints nothing; build and vet clean; every Go package `ok`; the tooling suite passes; the tree is clean after `coverage-page`.
+
+- [ ] **Step 3: Confirm the spec's PR 1 done-when**
+
+Run: `curl -s http://localhost:8000/turbostats/v1 | wc -c` against the process from Task 5 Step 9.
+Expected: under 1024.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add docs/superpowers/specs/2026-09-10-turbostats-v1-design.md
+git commit -m "spec: the bundle counts the pipeline role only
+
+Summing sink rows across every attribute would fold the DLQ's rows into
+the delivered series, which role=dlq exists to prevent. Found by the
+test that holds Collect to it."
+git push -u origin HEAD
+```
+
+Then open the PR. The body should say what the Bluesky host operator does next: deploy the image, start it with `--turbostats`, and switch the cron from `ps` to `curl http://localhost:8000/turbostats/v1`.

--- a/docs/superpowers/specs/2026-09-10-turbostats-v1-design.md
+++ b/docs/superpowers/specs/2026-09-10-turbostats-v1-design.md
@@ -1,0 +1,296 @@
+# TurboStats v1: design
+
+A sqlflow process reports its own state as one small, versioned document:
+what it is, when it started, how much memory it holds, and the totals every
+instrument has counted since it started. The document is TurboStats. The
+process serves it at `GET /turbostats/v1` for anything that can reach the
+process, and posts it outbound to a control plane on an interval, because
+most instances cannot be reached.
+
+This is the contract the control plane, its first demo page, and every later
+fleet feature depend on. It is written down before any of them exist so that
+each is built against the document rather than against the others.
+
+## Why now
+
+The control plane's first deliverable is a read-only demo at
+control-demo.turbolytics.io showing a live fleet: instance, uptime, restarts
+with causes, and resident memory over time. Two facts about that fleet fix the
+shape of this design:
+
+- Instances cannot be dialed. The Raspberry Pi is behind home NAT with no
+  resolvable address, and industrial deployments look the same. Status has to
+  leave the instance as a push it initiates. Nothing can be pulled from it.
+- The targets are constrained. A sidecar that scrapes the Prometheus text
+  format and re-encodes it is two processes and a text parser on a device
+  that may have 512 MiB. Prometheus stays as the exporter for cloud
+  deployments. The instance itself reports, and it reports the instrument
+  values directly, not a rendering of them.
+
+Two facts about the code fix the rest:
+
+- The Prometheus exporter builds a bare `prom.NewRegistry()`. `/metrics`
+  carries the pipeline's instruments and nothing about the process: no start
+  time, no resident memory, no goroutines. The demo needs exactly those.
+- The meter provider is built only for `--metrics=prometheus`. With metrics
+  off there is no provider and the instruments record into nothing, so there
+  is nothing for a reporter to read. The provider has to exist always.
+
+The Bluesky firehose instance has been running for days and nothing is
+recording its uptime. History does not backfill, so the sequence below starts
+with a cron line, not a package.
+
+## Decisions
+
+Made in the design conversation. Each one closes a fork.
+
+| Decision | Choice | Rejected |
+|---|---|---|
+| Who builds the document | The sqlflow process, from its own meter. | A sidecar scraping `/metrics`: a second process and a text parser on constrained hardware, and no access to the process's own memory. |
+| Direction | The instance initiates every connection. Status is pushed. | The control plane scraping instances: nothing can resolve or dial one. |
+| One document, two transports | `Collect()` builds a `Bundle`; the HTTP handler serves it and the reporter posts it. Neither computes anything. | A different shape per transport. |
+| Field names | The OTel instrument names: `message_count`, `error_count`. | The Prometheus series names, `message_count_messages_total`: those suffixes belong to one exporter's rendering. |
+| Counters | Totals since `started_at`. The receiver derives rates. | Rates computed on the instance: they need the previous sample remembered, and remembered state is what goes wrong on a device that reboots. |
+| Restarts | Derived by the receiver from `started_at` changing. | Reported by the instance: the process that died cannot say so, and its replacement should not guess. |
+| Restart causes | A final bundle on a clean drain carries `exit`. A crash sends nothing. `config_hash` differing across a gap is a config change. | Supervisor integration. |
+| Histograms | Excluded from v1. | Included: buckets are most of a scrape by bytes, and the demo reads none of them. |
+| Per-table gauges | Excluded from v1. `state_db_size_bytes` alone. | `state_table_rows` and `reference_table_rows`: a table dimension makes the size unbounded. |
+| Identity | `instance.id` is an explicit config field, required when reporting is on. | Derived from machine-id plus pipeline name: silently collides when a device is imaged from another. |
+| Buffering while unreachable | None. A missed interval is a gap, and the gap is the signal. | A queue on the instance: state, memory, and replayed samples that hide the outage the page exists to show. |
+| Versioning | `/turbostats/v1` in the path and `"v": 1` in the body. Additive changes stay v1. A removed or renamed field is v2 at a new path. | Content negotiation: more machinery than a path segment. |
+| Media type | `application/vnd.turbolytics.turbostats.v1+json` | `application/json`: says nothing about which version this is. |
+| Encoding | JSON. | CBOR: smaller, but the debug path on a device is `curl`, and 550 bytes is already small. |
+| Where it lives | `internal/turbostats` in this repository. | The private control-plane repository: the builder ships in the binary the control plane observes. |
+
+## The document
+
+```jsonc
+{
+  "v": 1,
+  "sent_at": "2026-09-10T21:14:03Z",
+
+  "instance": {
+    "id": "pi-basement-01",
+    "pipeline": "bluesky-firehose",
+    "version": "v1.1.0",
+    "commit": "723f823",
+    "arch": "linux/arm64",
+    "config_hash": "sha256:9f3c…"
+  },
+
+  "process": {
+    "started_at": "2026-09-01T08:12:44Z",
+    "rss_bytes": 26214400,
+    "goroutines": 19
+  },
+
+  "pipeline": {
+    "message_count": 184203311,
+    "handler_rows_read": 184203311,
+    "error_count": 12,
+    "sink_flush_count": 1842033,
+    "sink_rows_accepted": 184203311,
+    "sink_rows_written": 184203311,
+    "state_commit_count": 1842033,
+    "consumer_lag": 0,
+    "state_db_size_bytes": 4194304
+  },
+
+  "exit": {
+    "reason": "SIGTERM",
+    "code": 0
+  }
+}
+```
+
+### Fields
+
+`v` is the document version. A receiver rejects a `v` it does not know.
+
+`sent_at` is when the bundle was built, RFC 3339, UTC.
+
+`instance`:
+
+- `id`: the operator's name for this instance. From `pipeline.turbostats.id`
+  in the config. Required when reporting is enabled; a config that enables
+  reporting without it fails validation.
+- `pipeline`: `pipeline.name` from the config. Required when reporting is
+  enabled, for the same reason.
+- `version`, `commit`: the values the Makefile stamps into `internal/cli`.
+  The package cannot import `internal/cli` without a cycle, so the run command
+  hands them to the package once at startup.
+- `arch`: `runtime.GOOS + "/" + runtime.GOARCH`.
+- `config_hash`: `sha256:` plus the hex digest of the rendered config text,
+  after templating and before parsing. Two instances running the same file
+  under different environments hash differently, which is correct: they are
+  running different configs.
+
+`process`:
+
+- `started_at`: taken once, when the run command starts. RFC 3339, UTC.
+- `rss_bytes`: anonymous resident memory. On Linux, `RssAnon` from
+  `/proc/self/status`, which excludes file-backed pages and is exact. On other
+  platforms, `getrusage` peak resident size, which only rises; it is a weaker
+  signal there and the field is still populated. This is the reading
+  `internal/handlers/leak_test.go` already makes, moved into a package the
+  test then imports.
+- `goroutines`: `runtime.NumGoroutine()`.
+
+`pipeline` holds one field per instrument in `internal/core/metrics.go` and
+`internal/core/counting.go` that is a counter or a dimensionless gauge, named
+for the instrument. Counters are the total since `started_at`. Gauges are the
+value now. An instrument that carries attributes is summed across them, so
+`consumer_lag` is the sum over partitions. `state_db_size_bytes` comes from
+the same stats function `/stats` uses, and is omitted, not zero, when the
+pipeline has no state path: absent state and empty state are different facts.
+
+`exit` is present only in the last bundle a clean shutdown sends, after the
+drain completes. `reason` is the signal name or `max-msgs` when the run ended
+by count. `code` is the process exit code. A bundle without `exit` is an
+instance that is still running, or one that died without saying so.
+
+### Size
+
+A bundle is under 1 KiB. A test holds the example above under that bound,
+and the bound is the reason histograms and per-table gauges are out.
+
+## The package
+
+`internal/turbostats` exports:
+
+```go
+// Static is what the run command knows once and the package cannot learn.
+type Static struct {
+    ID, Pipeline, Version, Commit, ConfigHash string
+}
+
+// Collect builds one bundle. It is the only function that does.
+func Collect(ctx context.Context, s Static, r *sdkmetric.ManualReader,
+             stats func() (*core.StateStats, error)) (Bundle, error)
+```
+
+`Collect` calls `r.Collect` on the manual reader, walks the resource metrics,
+and picks each instrument by name. It reads `/proc/self/status` and the
+runtime. It calls `stats` when it is non-nil. It allocates one bundle and
+touches nothing shared, so the handler and the reporter can call it at once.
+
+The manual reader is attached to the meter provider at startup, always. The
+Prometheus exporter is a second reader attached only for
+`--metrics=prometheus`. Both read the same instruments, which is the property
+the design exists for.
+
+## The endpoint
+
+`GET /turbostats/v1` on the existing mux at `:8000`, beside `/metrics` and
+`/stats`. It responds `200` with the media type above and one bundle. It
+serves whenever the HTTP server is up.
+
+The server is up for `--metrics=prometheus`, as today, or for a new
+`--turbostats` flag, which starts the server without the Prometheus exporter.
+The default stays off. A device should not listen on a port unless told to.
+
+`/stats` stays as it is. It is the detailed per-table view of durable state,
+and renaming it breaks whoever reads it. The bundle's `state_db_size_bytes`
+reads through the same function so the two cannot disagree.
+
+## The reporter
+
+Configured in the pipeline file:
+
+```yaml
+pipeline:
+  name: bluesky-firehose
+  turbostats:
+    id: pi-basement-01
+    report_to: https://control-demo.turbolytics.io/v1/turbostats
+    token: {{ SQLFLOW_TURBOSTATS_TOKEN }}
+    interval_seconds: 60
+```
+
+`report_to` enables it. `token` is a bearer token, supplied through the
+template as every secret in a config is, so `sqlflow validate` reports it
+missing before the pipeline starts. `interval_seconds` defaults to 60.
+
+The reporter does not need the HTTP server. It reads the same manual reader
+the handler reads and opens its own outbound connection, so a device can
+report without listening on any port. `--turbostats` and `report_to` are
+independent, and a fleet instance will usually set only the second.
+
+The reporter posts one bundle at start, one every interval, and one on a
+clean drain. Each post is `POST report_to` with `Authorization: Bearer`,
+the media type above, and a 10-second timeout. The interval carries ten
+percent jitter, so a fleet that loses power together does not report
+together.
+
+Three rules about failure:
+
+- **A failed post never touches the pipeline.** The reporter runs on its own
+  goroutine, every post is bounded by its timeout, and nothing it does can
+  block the consume loop or delay a shutdown by more than that timeout.
+- **A failed post is logged and forgotten.** Debug level per failure, one
+  warning when a run of failures begins, one info when it ends. No retry
+  within an interval, no queue.
+- **Plaintext to a non-loopback address is refused** at config load. TLS is
+  not optional on a public network, and a device is on one.
+
+The final bundle is sent from the run command after `ConsumeLoop` returns and
+the drain completes, before the process exits, on a context bounded by the
+same timeout. A crash never reaches that line, which is the point.
+
+## Testing
+
+Unit, all in-process, all under `go test -short`:
+
+- `Collect` reads a counter's total from a manual reader, sums it across
+  attribute sets, reads a gauge's current value, and omits every histogram.
+- `Collect` omits `state_db_size_bytes` when `stats` is nil and populates it
+  when it is not.
+- The example bundle marshals under 1 KiB.
+- The handler responds with the media type and a bundle whose `v` is 1.
+- The reporter posts at start, at each interval, and on drain with `exit`
+  set; a receiver that hangs does not delay the caller past the timeout;
+  a plaintext non-loopback `report_to` fails config validation.
+- The feature registry gains `observability.turbostats`, and every test
+  above carries its marker, so the coverage gate holds the package to the
+  same standard as the rest of the engine.
+
+Release, in `tests/release`: the shipped image with `--turbostats` answers
+`GET /turbostats/v1` with a bundle whose `version` matches the image tag.
+
+## Rollout
+
+### First, today: start the record
+
+On the Bluesky host, one cron line every minute appending the time, the
+process start time, and RSS from `ps` to a file. No code. The demo's uptime
+graph starts from today rather than from the day the endpoint ships, and the
+file is backfilled into the control plane's store later.
+
+### PR 1: the document and the endpoint
+
+`internal/turbostats`, `Collect`, the always-present manual reader, the
+`--turbostats` flag, `GET /turbostats/v1`, the feature entry, and the tests
+above except the reporter's. Deploy to the Bluesky instance. Its first
+recorded restart; record the cause. Switch the cron from `ps` to `curl`.
+
+### PR 2: the reporter
+
+The `turbostats` config block, its validation, the reporter, and the final
+bundle on drain. Lands when the control plane has an endpoint to post to.
+
+### After
+
+The private control-plane repository: an ingest endpoint validating the
+media type and the token, a store of bundles and the uptime segments derived
+from them, a read-only query API, the three-panel page, and the deployment.
+Each is its own design.
+
+## Out of scope
+
+- Any command path. v1 has no verb the control plane can send an instance.
+- The three latency histograms, per-table gauges, and `duckdb_memory()`.
+  Each is additive if a later panel needs it.
+- Buffering or replay of bundles across an outage.
+- CBOR or any second encoding.
+- Issue #178's Kubernetes operator. It assumes provider-hosted pipelines in a
+  cluster you control, where none of this design's constraints apply.

--- a/docs/superpowers/specs/2026-09-10-turbostats-v1-design.md
+++ b/docs/superpowers/specs/2026-09-10-turbostats-v1-design.md
@@ -140,7 +140,11 @@ Made in the design conversation. Each one closes a fork.
 `internal/core/counting.go` that is a counter or a dimensionless gauge, named
 for the instrument. Counters are the total since `started_at`. Gauges are the
 value now. An instrument that carries attributes is summed across them, so
-`consumer_lag` is the sum over partitions. `state_db_size_bytes` comes from
+`consumer_lag` is the sum over partitions, with one exception: a data point
+whose `role` attribute is not `pipeline` is skipped. The DLQ sink records
+`sink_rows_accepted` and `sink_rows_written` with `role=dlq` so its rows
+never sum into the pipeline's delivered series, and the bundle keeps them
+out the same way. `state_db_size_bytes` comes from
 the same stats function `/stats` uses, and is omitted, not zero, when the
 pipeline has no state path: absent state and empty state are different facts.
 
@@ -162,6 +166,7 @@ and the bound is the reason histograms and per-table gauges are out.
 // Static is what the run command knows once and the package cannot learn.
 type Static struct {
     ID, Pipeline, Version, Commit, ConfigHash string
+    StartedAt                                 time.Time
 }
 
 // Collect builds one bundle. It is the only function that does.

--- a/docs/superpowers/specs/2026-09-10-turbostats-v1-design.md
+++ b/docs/superpowers/specs/2026-09-10-turbostats-v1-design.md
@@ -54,6 +54,8 @@ Made in the design conversation. Each one closes a fork.
 | Restarts | Derived by the receiver from `started_at` changing. | Reported by the instance: the process that died cannot say so, and its replacement should not guess. |
 | Restart causes | A final bundle on a clean drain carries `exit`. A crash sends nothing. `config_hash` differing across a gap is a config change. | Supervisor integration. |
 | Histograms | Excluded from v1. | Included: buckets are most of a scrape by bytes, and the demo reads none of them. |
+| Attributes | Every number the bundle reports has a dimensionless series recorded for it, so `Collect` is a lookup. | `Collect` summing an instrument's attribute sets: arithmetic that silently encodes a policy. Adding `sink_flush_count`'s `result=ok` to `result=error` reports a number of flushes true of nothing. |
+| Staleness | `last_message_at`, one timestamp. | `consumer_lag`: per-partition, so it cannot be one number without summing, and a websocket or webhook source has no offsets at all. It stays a Prometheus series where PromQL can aggregate it. |
 | Per-table gauges | Excluded from v1. `state_db_size_bytes` alone. | `state_table_rows` and `reference_table_rows`: a table dimension makes the size unbounded. |
 | Identity | `instance.id` is an explicit config field, required when reporting is on. | Derived from machine-id plus pipeline name: silently collides when a device is imaged from another. |
 | Buffering while unreachable | None. A missed interval is a gap, and the gap is the signal. | A queue on the instance: state, memory, and replayed samples that hide the outage the page exists to show. |
@@ -92,9 +94,10 @@ Made in the design conversation. Each one closes a fork.
     "sink_rows_accepted": 184203311,
     "sink_rows_written": 184203311,
     "state_commit_count": 1842033,
-    "consumer_lag": 0,
     "state_db_size_bytes": 4194304
   },
+
+  "last_message_at": "2026-09-10T21:14:01Z",
 
   "exit": {
     "reason": "SIGTERM",
@@ -116,9 +119,12 @@ Made in the design conversation. Each one closes a fork.
   reporting without it fails validation.
 - `pipeline`: `pipeline.name` from the config. Required when reporting is
   enabled, for the same reason.
-- `version`, `commit`: the values the Makefile stamps into `internal/cli`.
-  The package cannot import `internal/cli` without a cycle, so the run command
-  hands them to the package once at startup.
+- `version`, `commit`: the values the build stamps into `internal/buildinfo`.
+  They live in a leaf package because `internal/cli/run` reports them and
+  cannot import `internal/cli` without a cycle. Stamped at link time rather
+  than read from the environment: the version is a fact about the artifact,
+  and an operator who upgrades a binary and forgets an environment variable
+  would report the old one forever.
 - `arch`: `runtime.GOOS + "/" + runtime.GOARCH`.
 - `config_hash`: `sha256:` plus the hex digest of the rendered config text,
   after templating and before parsing. Two instances running the same file
@@ -136,17 +142,42 @@ Made in the design conversation. Each one closes a fork.
   test then imports.
 - `goroutines`: `runtime.NumGoroutine()`.
 
-`pipeline` holds one field per instrument in `internal/core/metrics.go` and
-`internal/core/counting.go` that is a counter or a dimensionless gauge, named
-for the instrument. Counters are the total since `started_at`. Gauges are the
-value now. An instrument that carries attributes is summed across them, so
-`consumer_lag` is the sum over partitions, with one exception: a data point
-whose `role` attribute is not `pipeline` is skipped. The DLQ sink records
-`sink_rows_accepted` and `sink_rows_written` with `role=dlq` so its rows
-never sum into the pipeline's delivered series, and the bundle keeps them
-out the same way. `state_db_size_bytes` comes from
-the same stats function `/stats` uses, and is omitted, not zero, when the
-pipeline has no state path: absent state and empty state are different facts.
+`pipeline` holds the engine's top-line totals since `started_at`. Every one is
+read from a **dimensionless** series, so building it is a lookup: `Collect`
+sums nothing and filters nothing, and a point carrying any attribute is a
+different series and not the bundle's.
+
+That is the rule the design turns on. Several instruments carry an attribute
+whose values mean different things, and folding them together produces a
+number that is true of nothing: `sink_flush_count` carries `result=ok` and
+`result=error`, `state_commit_count` the same, and the sink row counters carry
+`role=dlq` for the DLQ so its rows never reach the pipeline's delivered
+series. So the engine records a flat twin beside each, and the choice of which
+measurements count is made where they are recorded:
+
+| Bundle field | Series read | Recorded |
+|---|---|---|
+| `message_count` | `message_count` | already dimensionless |
+| `handler_rows_read` | `handler_rows_read` | already dimensionless |
+| `error_count` | `pipeline_errors` | every error |
+| `sink_flush_count` | `pipeline_flushes` | successes only |
+| `state_commit_count` | `pipeline_commits` | successes only |
+| `sink_rows_accepted` | `pipeline_rows_accepted` | pipeline role only |
+| `sink_rows_written` | `pipeline_rows_written` | pipeline role only |
+| `last_message_at` | `pipeline_last_message_timestamp` | once per received batch |
+
+The flat twins export through Prometheus too, which is the cost of one
+instrument feeding both readers, and a global total is useful there anyway.
+
+`state_db_size_bytes` comes from the same stats function `/stats` uses, and is
+omitted, not zero, when the pipeline has no state path: absent state and empty
+state are different facts.
+
+`last_message_at` is absent until the pipeline receives anything, because zero
+is not a time. Staleness is `sent_at` minus it, and since both come from the
+instance's own clock the difference carries no skew. It answers "is it still
+doing anything", which offset lag cannot: `consumer_lag` is per partition, and
+a websocket or webhook source has no offsets at all.
 
 `exit` is present only in the last bundle a clean shutdown sends, after the
 drain completes. `reason` is the signal name or `max-msgs` when the run ended

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,24 @@
+// Package buildinfo carries what the build stamped into the binary.
+//
+// A leaf package on purpose: internal/cli prints these and internal/cli/run
+// reports them in the TurboStats bundle, and run cannot import cli without a
+// cycle. Both import this.
+//
+// Stamped at link time rather than read from the environment, because the
+// version is a fact about the artifact, not a claim about the environment it
+// was started in. An operator who upgrades a binary and forgets to update an
+// environment variable would otherwise report the old version forever, and
+// that is the number a fleet page can least afford to have wrong.
+package buildinfo
+
+// Version and Commit are stamped at link time by the Makefile, the Dockerfile
+// and the release script:
+//
+//	go build -ldflags "-X github.com/turbolytics/sql-flow/internal/buildinfo.Version=v1.0.0"
+//
+// A plain `go build ./cmd/sqlflow/` leaves the defaults below, which is how an
+// unreleased local binary identifies itself.
+var (
+	Version = "dev"
+	Commit  = "unknown"
+)

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,16 @@
+package buildinfo
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// An unstamped build must still identify itself, because a bundle from a
+// developer's binary should say "dev" rather than an empty string.
+func TestBuildInfo_UnstampedDefaults(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	assert.Equal(t, "dev", Version)
+	assert.Equal(t, "unknown", Commit)
+}

--- a/internal/cli/run/metrics.go
+++ b/internal/cli/run/metrics.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/turbostats"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -23,15 +25,19 @@ const metricsPort = ":8000"
 // nil snapshot, and no error, for a pipeline that has no state database.
 type statsFunc func() (*core.StateStats, error)
 
-// newHTTPMux builds the server the pipeline exposes: Prometheus scraping, and
-// a JSON view of durable state.
+// newHTTPMux builds the server the pipeline exposes: Prometheus scraping, a
+// JSON view of durable state, and the TurboStats bundle.
 //
-// The two are on one mux deliberately. DuckDB takes an exclusive lock on the
-// state file, so no other process can read it while the pipeline runs -- not
-// even read-only. A running pipeline is the only thing that can report its own
-// state, which makes this endpoint the live half of observability rather than
-// a convenience.
-func newHTTPMux(registry *prom.Registry, stats statsFunc) *http.ServeMux {
+// All on one mux deliberately. DuckDB takes an exclusive lock on the state
+// file, so no other process can read it while the pipeline runs -- not even
+// read-only. A running pipeline is the only thing that can report its own
+// state, which makes these the live half of observability rather than a
+// convenience.
+//
+// Each route is registered only when its provider is non-nil, so a route that
+// would answer with nothing is absent rather than half-working.
+func newHTTPMux(registry *prom.Registry, stats statsFunc,
+	collect func(context.Context) (turbostats.Bundle, error)) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	if registry != nil {
@@ -59,35 +65,71 @@ func newHTTPMux(registry *prom.Registry, stats statsFunc) *http.ServeMux {
 		})
 	}
 
+	if collect != nil {
+		mux.Handle("/turbostats/v1", turbostats.Handler(collect))
+	}
+
 	return mux
 }
 
-// newMeterProvider starts the exporter named by --metrics. An empty name
-// disables metrics entirely.
-func newMeterProvider(name string, l *zap.Logger, stats statsFunc) (metric.MeterProvider, error) {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "":
-		return nil, nil
+// newMeterProvider builds the provider every instrument records into, and
+// starts the HTTP server when anything needs it.
+//
+// The manual reader is attached always: it is what /turbostats/v1 reads, and
+// the outbound reporter after it. The Prometheus exporter is a second reader,
+// attached only for --metrics=prometheus. Both read the same instruments,
+// which is the property the design exists for. Before this, the provider
+// existed only for Prometheus, and without it every counter recorded into
+// nothing -- so there was nothing for a bundle to read.
+func newMeterProvider(exporter string, serveTurbostats bool,
+	static turbostats.Static, l *zap.Logger, stats statsFunc) (metric.MeterProvider, error) {
 
+	reader := sdkmetric.NewManualReader()
+	opts := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+
+	var registry *prom.Registry
+	switch strings.ToLower(strings.TrimSpace(exporter)) {
+	case "":
 	case "prometheus":
-		registry := prom.NewRegistry()
-		exporter, err := prometheus.New(prometheus.WithRegisterer(registry))
+		registry = prom.NewRegistry()
+		exp, err := prometheus.New(prometheus.WithRegisterer(registry))
 		if err != nil {
 			return nil, fmt.Errorf("prometheus exporter: %w", err)
 		}
-
-		mux := newHTTPMux(registry, stats)
-
-		go func() {
-			l.Info("serving prometheus metrics", zap.String("addr", metricsPort+"/metrics"))
-			if err := http.ListenAndServe(metricsPort, mux); err != nil {
-				l.Error("metrics server stopped", zap.Error(err))
-			}
-		}()
-
-		return sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter)), nil
-
+		opts = append(opts, sdkmetric.WithReader(exp))
 	default:
-		return nil, fmt.Errorf("unsupported --metrics exporter: %q (supported: prometheus)", name)
+		return nil, fmt.Errorf("unsupported --metrics exporter: %q (supported: prometheus)", exporter)
 	}
+
+	mp := sdkmetric.NewMeterProvider(opts...)
+
+	// Nothing to serve: the provider still exists, so the instruments record
+	// and a later reporter can read them without an HTTP server.
+	if registry == nil && !serveTurbostats {
+		return mp, nil
+	}
+
+	var collect func(context.Context) (turbostats.Bundle, error)
+	if serveTurbostats {
+		collect = func(ctx context.Context) (turbostats.Bundle, error) {
+			return turbostats.Collect(ctx, static, reader, stats)
+		}
+	}
+	mux := newHTTPMux(registry, stats, collect)
+
+	go func() {
+		routes := []string{}
+		if registry != nil {
+			routes = append(routes, "/metrics")
+		}
+		if serveTurbostats {
+			routes = append(routes, "/turbostats/v1")
+		}
+		l.Info("serving http", zap.String("addr", metricsPort), zap.Strings("routes", routes))
+		if err := http.ListenAndServe(metricsPort, mux); err != nil {
+			l.Error("http server stopped", zap.Error(err))
+		}
+	}()
+
+	return mp, nil
 }

--- a/internal/cli/run/metrics_test.go
+++ b/internal/cli/run/metrics_test.go
@@ -133,6 +133,14 @@ func exportedNames(t *testing.T) []string {
 	m.StateSizeBytes.Record(ctx, 1)
 	m.StateTableRows.Record(ctx, 1)
 	m.ReferenceTableRows.Record(ctx, 1)
+	// The flat twins the TurboStats bundle reads. They export too, which is
+	// the cost of one instrument feeding both readers.
+	m.PipelineErrors.Add(ctx, 1)
+	m.PipelineFlushes.Add(ctx, 1)
+	m.PipelineCommits.Add(ctx, 1)
+	m.PipelineRowsAccepted.Add(ctx, 1)
+	m.PipelineRowsWritten.Add(ctx, 1)
+	m.PipelineLastMessage.Record(ctx, 1)
 
 	wm, err := webhook.NewMetrics(mp)
 	assert.NoError(t, err)
@@ -187,6 +195,12 @@ func TestExportedSeriesNames(t *testing.T) {
 		"error_count_total",
 		"handler_rows_read_total",
 		"message_count_messages_total",
+		"pipeline_commits_total",
+		"pipeline_errors_total",
+		"pipeline_flushes_total",
+		"pipeline_last_message_timestamp_seconds",
+		"pipeline_rows_accepted_total",
+		"pipeline_rows_written_total",
 		"reference_table_rows",
 		"sink_flush_count_flushes_total",
 		"sink_flush_latency_seconds",

--- a/internal/cli/run/metrics_test.go
+++ b/internal/cli/run/metrics_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/turbolytics/sql-flow/internal/core"
 	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/sinks"
+	"github.com/turbolytics/sql-flow/internal/turbostats"
 	"github.com/turbolytics/sql-flow/internal/webhook"
 	"github.com/zeebo/assert"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.uber.org/zap"
 )
 
 // DuckDB takes an exclusive lock on the state file, so a second process
@@ -35,7 +37,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsState(t *testing.T) {
 		Offsets:   []core.OffsetStat{{Topic: "events", Partition: 0, Offset: 999, LeaderEpoch: 7}},
 	}
 
-	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return want, nil })
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return want, nil }, nil)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
@@ -62,7 +64,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsState(t *testing.T) {
 // endpoint stays useful for the counters even when nothing is durable.
 func TestObservabilityMetrics_StatsHandler_NullStateWithoutAStateDatabase(t *testing.T) {
 	coverage.Covers(t, "observability.metrics")
-	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return nil, nil })
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return nil, nil }, nil)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
@@ -80,7 +82,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsCollectionFailure(t *testing.T
 	coverage.Covers(t, "observability.metrics")
 	mux := newHTTPMux(nil, func() (*core.StateStats, error) {
 		return nil, errors.New("state database unreadable")
-	})
+	}, nil)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
@@ -91,7 +93,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsCollectionFailure(t *testing.T
 // endpoint must not be registered as a half-working route.
 func TestObservabilityMetrics_StatsHandler_AbsentWithoutAProvider(t *testing.T) {
 	coverage.Covers(t, "observability.metrics")
-	mux := newHTTPMux(nil, nil)
+	mux := newHTTPMux(nil, nil, nil)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
@@ -216,4 +218,75 @@ func TestStateCommitLatencyUnitIsNameNeutral(t *testing.T) {
 		}
 	}
 	assert.That(t, found)
+}
+
+// --- TurboStats ------------------------------------------------------------
+
+// /turbostats/v1 is present only when asked for, like /stats: a route that
+// answers with nothing is worse than none.
+func TestObservabilityTurbostats_RouteAbsentWithoutACollector(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	mux := newHTTPMux(nil, nil, nil)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestObservabilityTurbostats_RouteServesTheBundle(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	mux := newHTTPMux(nil, nil, func(context.Context) (turbostats.Bundle, error) {
+		return turbostats.Bundle{V: turbostats.Version}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, turbostats.MediaType, rec.Header().Get("Content-Type"))
+}
+
+// Attaching the manual reader must not change what Prometheus exports. The
+// series list is what the README documents and dashboards depend on.
+func TestObservabilityTurbostats_ManualReaderLeavesExportedNamesAlone(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	coverage.Covers(t, "observability.metrics")
+	reg := prom.NewRegistry()
+	exp, err := prometheus.New(prometheus.WithRegisterer(reg))
+	assert.NoError(t, err)
+	manual := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(manual), sdkmetric.WithReader(exp))
+
+	m, err := core.NewMetrics(mp)
+	assert.NoError(t, err)
+	m.MessageCount.Add(context.Background(), 1)
+
+	families, err := reg.Gather()
+	assert.NoError(t, err)
+	found := false
+	for _, f := range families {
+		if f.GetName() == "message_count_messages_total" {
+			found = true
+		}
+	}
+	assert.That(t, found)
+}
+
+// The provider exists even with no exporter, so the instruments record and a
+// reporter can read them. It used to be nil, and every counter recorded into
+// nothing unless Prometheus was on.
+func TestObservabilityTurbostats_ProviderExistsWithoutAnExporter(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	mp, err := newMeterProvider("", false, turbostats.Static{}, zap.NewNop(), nil)
+	assert.NoError(t, err)
+	assert.That(t, mp != nil)
+
+	m, err := core.NewMetrics(mp)
+	assert.NoError(t, err)
+	m.MessageCount.Add(context.Background(), 1)
+}
+
+func TestObservabilityTurbostats_RejectsAnUnknownExporter(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	_, err := newMeterProvider("statsd", false, turbostats.Static{}, zap.NewNop(), nil)
+	assert.Error(t, err)
 }

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -23,9 +23,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/turbolytics/sql-flow/internal/buildinfo"
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/core"
 	"github.com/turbolytics/sql-flow/internal/errs"
+	"github.com/turbolytics/sql-flow/internal/turbostats"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -76,6 +78,7 @@ func NewCommand() *cobra.Command {
 	var statsJSONPath string
 	var metricsExporter string
 	var withHTTPDebug bool
+	var serveTurbostats bool
 
 	var maxMsgsToProcess int
 
@@ -92,6 +95,10 @@ func NewCommand() *cobra.Command {
 			if levelErr != nil {
 				return levelErr
 			}
+
+			// Taken here, once. It is the TurboStats bundle's started_at, and
+			// a restart is the control plane seeing that value change.
+			startedAt := time.Now().UTC()
 
 			configPath, err := resolveConfigPath(configPath, args)
 			if err != nil {
@@ -126,7 +133,7 @@ func NewCommand() *cobra.Command {
 				context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stopSignals()
 
-			conf, err := config.Load(configPath, map[string]string{})
+			conf, rendered, err := config.LoadRendered(configPath, map[string]string{})
 			if err != nil {
 				// Returned as-is: the error already names the file, the stage and the
 				// code, so another prefix adds a word and no information.
@@ -267,7 +274,17 @@ func NewCommand() *cobra.Command {
 				startDebugServer(conn, lock, l)
 			}
 
-			meterProvider, err := newMeterProvider(metricsExporter, l, statsFn)
+			// What the bundle says this process is. ID stays empty until the
+			// pipeline.turbostats config block lands with the reporter.
+			static := turbostats.Static{
+				Pipeline:   conf.Pipeline.Name,
+				Version:    buildinfo.Version,
+				Commit:     buildinfo.Commit,
+				ConfigHash: turbostats.HashConfig(rendered),
+				StartedAt:  startedAt,
+			}
+
+			meterProvider, err := newMeterProvider(metricsExporter, serveTurbostats, static, l, statsFn)
 			if err != nil {
 				return err
 			}
@@ -454,6 +471,8 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&statsJSONPath, "stats-json", "", "Write final run stats as JSON to this path")
 	cmd.Flags().StringVar(&metricsExporter, "metrics", "", "Metrics exporter to enable (prometheus); serves /metrics on :8000")
 	cmd.Flags().BoolVar(&withHTTPDebug, "with-http-debug", false, "Serve GET /debug?sql=... against the live DuckDB connection on "+debugAddr)
+	cmd.Flags().BoolVar(&serveTurbostats, "turbostats", false,
+		"Serve GET /turbostats/v1 on "+metricsPort+": the process's own state as one document")
 
 	return cmd
 }

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -331,7 +331,7 @@ func NewCommand() *cobra.Command {
 			// its destination stops the start instead of waiting it out.
 			sink, err := sinks.New(ctx, conf.Pipeline.Sink, conn,
 				sinks.WithMeterProvider(meterProvider),
-				sinks.WithSinkRole("pipeline"))
+				sinks.WithSinkRole(core.SinkRolePipeline))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -5,25 +5,27 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+	"github.com/turbolytics/sql-flow/internal/buildinfo"
 )
 
-// Version and Commit are stamped at link time by the Makefile and the container
-// build:
-//
-//	go build -ldflags "-X github.com/turbolytics/sql-flow/internal/cli.Version=v1.0.0"
-//
-// A plain `go build ./cmd/sqlflow/` leaves the defaults below, which is how an
-// unreleased local binary identifies itself.
+// Version and Commit live in internal/buildinfo, so the run command can
+// report them in the TurboStats bundle without importing this package, which
+// would be a cycle. These names stay here because root.go sets cmd.Version
+// from one of them.
 var (
-	Version = "dev"
-	Commit  = "unknown"
+	Version = buildinfo.Version
+	Commit  = buildinfo.Commit
 )
 
 // versionString is what both `sqlflow version` and `sqlflow --version` print.
+//
+// It reads buildinfo rather than the copies above. -X sets buildinfo.Version
+// at link time and the copies are initialized from it, so the two agree; one
+// source is still one fewer thing to reason about.
 func versionString() string {
 	return fmt.Sprintf(
 		"sqlflow %s\ncommit: %s\ngo:     %s\n",
-		Version, Commit, runtime.Version(),
+		buildinfo.Version, buildinfo.Commit, runtime.Version(),
 	)
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -110,13 +110,17 @@ func TemplateVars(overrides map[string]string) map[string]string {
 	return out
 }
 
-func Load(path string, overrides map[string]string) (*Conf, error) {
+// LoadRendered renders the file and parses it, returning both. The rendered
+// text is what the TurboStats bundle hashes: two instances running the same
+// file under different environments are running different configs, and the
+// hash should say so.
+func LoadRendered(path string, overrides map[string]string) (*Conf, []byte, error) {
 	rendered, err := RenderTemplate(path, overrides)
 	if err != nil {
 		// Returned as-is. The inner error already names the file and the
 		// stage that failed, so another "rendering config failed" prefix adds
 		// a word and no information.
-		return nil, err
+		return nil, nil, err
 	}
 
 	var conf Conf
@@ -126,7 +130,13 @@ func Load(path string, overrides map[string]string) (*Conf, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(rendered))
 	dec.KnownFields(true)
 	if err := dec.Decode(&conf); err != nil {
-		return nil, errs.Wrap(errs.CodeConfigParseFailed, err, "parsing YAML failed")
+		return nil, nil, errs.Wrap(errs.CodeConfigParseFailed, err, "parsing YAML failed")
 	}
-	return &conf, nil
+	return &conf, rendered, nil
+}
+
+// Load is LoadRendered for callers that do not need the text.
+func Load(path string, overrides map[string]string) (*Conf, error) {
+	conf, _, err := LoadRendered(path, overrides)
+	return conf, err
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -253,3 +253,19 @@ pipeline:
 `)
 	assert.That(t, conf.Pipeline.State == nil)
 }
+
+// The rendered text is what the TurboStats bundle hashes, so a config that
+// renders differently under two environments hashes differently. Load used
+// to discard it.
+func TestLoadRendered_ReturnsTheTextTheConfWasParsedFrom(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	path := filepath.Join(t.TempDir(), "p.yml")
+	src := "pipeline:\n  name: {{ SQLFLOW_NAME|default('demo') }}\n  source:\n    type: kafka\n  handler:\n    type: handlers.InferredMemBatch\n    sql: SELECT 1\n  sink:\n    type: noop\n"
+	assert.NoError(t, os.WriteFile(path, []byte(src), 0o644))
+
+	conf, rendered, err := LoadRendered(path, map[string]string{"SQLFLOW_NAME": "x"})
+	assert.NoError(t, err)
+	assert.Equal(t, "x", conf.Pipeline.Name)
+	assert.That(t, strings.Contains(string(rendered), "name: x"))
+	assert.That(t, !strings.Contains(string(rendered), "{{"))
+}

--- a/internal/core/counting.go
+++ b/internal/core/counting.go
@@ -27,6 +27,12 @@ type counting struct {
 	written  metric.Int64Counter
 	attrs    metric.AddOption
 
+	// Flat twins, recorded only for the pipeline role. The DLQ's rows must
+	// not reach them: a pipeline would look healthier the more records it
+	// rejected. Nil for any other role, which is the switch.
+	flatAccepted metric.Int64Counter
+	flatWritten  metric.Int64Counter
+
 	mu      sync.Mutex
 	pending int64
 }
@@ -44,6 +50,14 @@ type countingBuffered struct {
 }
 
 func (c *countingBuffered) BufferedRows() int { return c.reporter.BufferedRows() }
+
+// SinkRolePipeline is the role of the sink a pipeline delivers through, as
+// opposed to its DLQ or a table manager's.
+//
+// Exported and shared with internal/sinks, which sets it, because the flat
+// row counters are recorded for this role alone. A second spelling of the
+// string would silently stop them recording.
+const SinkRolePipeline = "pipeline"
 
 // NewCountingSink wraps a sink so its rows are counted.
 //
@@ -87,6 +101,27 @@ func NewCountingSink(inner Sink, mp metric.MeterProvider, sinkType, role string)
 		),
 	}
 
+	// The flat twins exist for the pipeline role alone. The DLQ's rows must
+	// not reach them, or a pipeline looks healthier the more records it
+	// rejects. An error leaves them nil, which the record path already
+	// tolerates, for the same reason the two above return unwrapped.
+	if role == SinkRolePipeline {
+		if flat, err := meter.Int64Counter(
+			"pipeline_rows_accepted",
+			metric.WithDescription("Rows the pipeline sink buffered, excluding the DLQ's"),
+			metric.WithUnit("rows"),
+		); err == nil {
+			c.flatAccepted = flat
+		}
+		if flat, err := meter.Int64Counter(
+			"pipeline_rows_written",
+			metric.WithDescription("Rows the pipeline sink delivered, excluding the DLQ's"),
+			metric.WithUnit("rows"),
+		); err == nil {
+			c.flatWritten = flat
+		}
+	}
+
 	if reporter, ok := inner.(BufferedRowReporter); ok {
 		return &countingBuffered{counting: c, reporter: reporter}
 	}
@@ -107,6 +142,9 @@ func (c *counting) WriteTable(ctx context.Context, batch arrow.Table) error {
 	c.mu.Unlock()
 
 	c.accepted.Add(ctx, n, c.attrs)
+	if c.flatAccepted != nil {
+		c.flatAccepted.Add(ctx, n)
+	}
 	return nil
 }
 
@@ -129,6 +167,9 @@ func (c *counting) Flush(ctx context.Context) error {
 
 	if n > 0 {
 		c.written.Add(ctx, n, c.attrs)
+		if c.flatWritten != nil {
+			c.flatWritten.Add(ctx, n)
+		}
 	}
 	return nil
 }

--- a/internal/core/flat_test.go
+++ b/internal/core/flat_test.go
@@ -1,0 +1,143 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// The flat instruments exist so a reader that cannot filter attributes has an
+// honest number. Which measurements reach them is decided here, at the
+// recording site, rather than re-derived by whoever reads the series.
+
+// flatValue reads the dimensionless point of one instrument, which is what
+// turbostats.Collect does. A point carrying attributes is a different series.
+func flatValue(t *testing.T, r *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, r.Collect(context.Background(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			switch data := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range data.DataPoints {
+					if dp.Attributes.Len() == 0 {
+						return dp.Value
+					}
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range data.DataPoints {
+					if dp.Attributes.Len() == 0 {
+						return dp.Value
+					}
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// meteredTurbine builds a pipeline whose instruments record into a reader the
+// test can read back.
+func meteredTurbine(t *testing.T, src Source, sink Sink, batchSize int) (*Turbine, *sdkmetric.ManualReader) {
+	t.Helper()
+	r := sdkmetric.NewManualReader()
+	m, err := NewMetrics(sdkmetric.NewMeterProvider(sdkmetric.WithReader(r)))
+	assert.NoError(t, err)
+
+	tb := NewTurbine(src, &fakeHandler{}, sink, batchSize, time.Second,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithMetrics(m))
+	return tb, r
+}
+
+// flushFailingSink accepts rows and fails every flush, the way a sink whose
+// destination has stopped answering does.
+type flushFailingSink struct {
+	mu sync.Mutex
+}
+
+func (s *flushFailingSink) WriteTable(ctx context.Context, batch arrow.Table) error { return nil }
+func (s *flushFailingSink) Flush(ctx context.Context) error {
+	return errors.New("destination unreachable")
+}
+
+// A failed flush delivered nothing, so it must not count. The dimensioned
+// series carries result=error for a dashboard to filter; a reader that adds
+// ok and error together reports a number true of nothing, which is why the
+// bundle reads this series instead.
+func TestCoreConsumeLoop_FlushesCountSuccessesOnly(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	src := &fakeSource{batches: [][]Message{messages(10)}}
+	tb, reader := meteredTurbine(t, src, &flushFailingSink{}, 10)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.Error(t, err)
+
+	assert.Equal(t, int64(0), flatValue(t, reader, "pipeline_flushes"))
+	// The error did reach the flat error counter.
+	assert.That(t, flatValue(t, reader, "pipeline_errors") > 0)
+}
+
+func TestCoreConsumeLoop_ASuccessfulFlushCounts(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	src := &fakeSource{batches: [][]Message{messages(10)}}
+	tb, reader := meteredTurbine(t, src, &fakeSink{}, 10)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, int64(1), flatValue(t, reader, "pipeline_flushes"))
+	assert.Equal(t, int64(0), flatValue(t, reader, "pipeline_errors"))
+}
+
+// Receiving messages stamps the time, so a reader can tell a pipeline that is
+// idle from one that is wedged. A pipeline that has received nothing reports
+// nothing, because zero is not a time.
+func TestCoreConsumeLoop_StampsWhenMessagesLastArrived(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	src := &fakeSource{batches: [][]Message{messages(10)}}
+	tb, reader := meteredTurbine(t, src, &fakeSink{}, 10)
+
+	before := time.Now().Unix()
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	got := flatValue(t, reader, "pipeline_last_message_timestamp")
+	assert.That(t, got >= before)
+}
+
+// The DLQ's rows must not reach the flat counters, or a pipeline looks
+// healthier the more records it rejects.
+func TestToolingCoverage_TheDLQsRowsStayOutOfTheFlatCounters(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	r := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(r))
+
+	pipeline := NewCountingSink(&fakeSink{}, mp, "console", SinkRolePipeline)
+	dlq := NewCountingSink(&fakeSink{}, mp, "console", "dlq")
+
+	ctx := context.Background()
+	tbl := countIDTable(1)
+	defer tbl.Release()
+
+	assert.NoError(t, pipeline.WriteTable(ctx, tbl))
+	assert.NoError(t, pipeline.Flush(ctx))
+	assert.NoError(t, dlq.WriteTable(ctx, tbl))
+	assert.NoError(t, dlq.Flush(ctx))
+
+	// Two sinks wrote one row each; only the pipeline's counts.
+	assert.Equal(t, int64(1), flatValue(t, r, "pipeline_rows_written"))
+	assert.Equal(t, int64(1), flatValue(t, r, "pipeline_rows_accepted"))
+}

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -24,6 +24,27 @@ type Metrics struct {
 	StateTableRows         metric.Int64Gauge
 	ReferenceTableRows     metric.Int64Gauge
 	ConsumerLag            metric.Int64Gauge
+
+	// Flat twins of the instruments above that carry attributes.
+	//
+	// The TurboStats bundle reads one series by name and cannot filter or
+	// sum, so the choice of which measurements count is made at the recording
+	// site rather than re-derived by whoever reads it. That matters most for
+	// the two whose attribute is an outcome: adding result=ok to result=error
+	// reports a number of commits that is true of nothing.
+	//
+	// They are dimensionless on purpose. A reader looks for the point with no
+	// attributes, so an attribute added here would hide the series from it.
+	PipelineErrors       metric.Int64Counter
+	PipelineFlushes      metric.Int64Counter
+	PipelineCommits      metric.Int64Counter
+	PipelineRowsAccepted metric.Int64Counter
+	PipelineRowsWritten  metric.Int64Counter
+	// PipelineLastMessage is when the pipeline last received messages, as
+	// unix seconds. It answers "is it still doing anything", which offset lag
+	// cannot: a websocket or webhook source has no offsets at all, and a
+	// per-partition lag is not one number.
+	PipelineLastMessage metric.Int64Gauge
 }
 
 // NewMetrics builds the instruments from a meter provider. Passing a noop
@@ -172,6 +193,46 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		metric.WithUnit("rows"),
 	); err != nil {
 		return nil, fmt.Errorf("reference_table_rows: %w", err)
+	}
+
+	// The flat twins.
+	//
+	// Each unit repeats the plural already in the name, because the exporter
+	// appends the unit unless the name contains it. "count" here would export
+	// pipeline_errors_count_total; "errors" exports pipeline_errors_total.
+	// Measured against the exporter in TestExportedSeriesNames, not inferred.
+	for _, f := range []struct {
+		into *metric.Int64Counter
+		name string
+		unit string
+		desc string
+	}{
+		{&m.PipelineErrors, "pipeline_errors", "errors",
+			"Errors, every class and phase together"},
+		{&m.PipelineFlushes, "pipeline_flushes", "flushes",
+			"Flushes that succeeded; a failed flush delivered nothing"},
+		{&m.PipelineCommits, "pipeline_commits", "commits",
+			"State transactions that committed; a failed commit is not a commit"},
+		{&m.PipelineRowsAccepted, "pipeline_rows_accepted", "rows",
+			"Rows the pipeline sink buffered, excluding the DLQ's"},
+		{&m.PipelineRowsWritten, "pipeline_rows_written", "rows",
+			"Rows the pipeline sink delivered, excluding the DLQ's"},
+	} {
+		if *f.into, err = meter.Int64Counter(
+			f.name,
+			metric.WithDescription(f.desc),
+			metric.WithUnit(f.unit),
+		); err != nil {
+			return nil, fmt.Errorf("%s: %w", f.name, err)
+		}
+	}
+
+	if m.PipelineLastMessage, err = meter.Int64Gauge(
+		"pipeline_last_message_timestamp",
+		metric.WithDescription("When the pipeline last received messages, as unix seconds"),
+		metric.WithUnit("s"),
+	); err != nil {
+		return nil, fmt.Errorf("pipeline_last_message_timestamp: %w", err)
 	}
 
 	return &m, nil

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -473,6 +473,10 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 		}
 		t.metrics.SourceReadLatency.Record(ctx, readLatency.Seconds())
 		t.metrics.MessageCount.Add(ctx, int64(len(msgBatch)))
+		// Once per batch, not per message: the cost is one gauge record
+		// against a whole batch, and a reader asking "is it still doing
+		// anything" cannot tell the two apart.
+		t.metrics.PipelineLastMessage.Record(ctx, time.Now().Unix())
 
 		for _, raw := range msgBatch {
 			if err := t.writeMessage(raw); err != nil {
@@ -590,6 +594,7 @@ func (t *Turbine) recordError(ctx context.Context, err error, phase, message str
 		attribute.String("code", string(code)),
 		attribute.String("phase", phase),
 	))
+	t.metrics.PipelineErrors.Add(ctx, 1)
 
 	t.logger.Error(message,
 		zap.Error(err),
@@ -761,6 +766,9 @@ func (t *Turbine) commitState(ctx context.Context) error {
 
 	t.metrics.StateCommitLatency.Record(ctx, time.Since(c0).Seconds())
 	t.metrics.StateCommitCount.Add(ctx, 1, t.resultAttrs(resultOK)...)
+	// Success only. The error path below records the dimensioned series and
+	// not this one, because a failed commit is not a commit.
+	t.metrics.PipelineCommits.Add(ctx, 1)
 	return nil
 }
 
@@ -860,6 +868,9 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 
 	t.metrics.SinkFlushLatency.Record(ctx, b2.Sub(b1).Seconds())
 	t.metrics.SinkFlushCount.Add(ctx, 1, t.resultAttrs(resultOK)...)
+	// Success only, for the same reason as PipelineCommits: the two error
+	// paths above record the dimensioned series and not this one.
+	t.metrics.PipelineFlushes.Add(ctx, 1)
 	if batch != nil {
 		t.metrics.SinkFlushNumRows.Record(ctx, batch.NumRows())
 	}

--- a/internal/handlers/leak_test.go
+++ b/internal/handlers/leak_test.go
@@ -1,61 +1,26 @@
 package handlers
 
 import (
-	"bufio"
 	"context"
-	"os"
 	"runtime"
 	"runtime/debug"
-	"strconv"
-	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/turbolytics/sql-flow/internal/turbostats"
 )
 
-// residentAnonBytes is the process's anonymous resident memory. That is the
-// figure a native leak moves: Go's heap profiler cannot see a buffer that
-// DuckDB allocated across the ADBC boundary, and duckdb_memory() does not
-// track it either, so the only honest instrument is the process itself.
-//
-// Linux reads RssAnon, which excludes file-backed pages and is exact. Other
-// platforms fall back to peak resident size from getrusage, which only ever
-// rises, so it is a weaker signal there; a leak still shows as growth between
-// two measurements, since a steady process has a steady peak.
+// residentAnonBytes is turbostats.ResidentAnonBytes, which moved there so the
+// TurboStats bundle and this test read the same number, with the test's
+// failure semantics.
 func residentAnonBytes(t *testing.T) int64 {
 	t.Helper()
-	if runtime.GOOS == "linux" {
-		f, err := os.Open("/proc/self/status")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer f.Close()
-		sc := bufio.NewScanner(f)
-		for sc.Scan() {
-			line := sc.Text()
-			if !strings.HasPrefix(line, "RssAnon:") {
-				continue
-			}
-			fields := strings.Fields(line)
-			kb, err := strconv.ParseInt(fields[1], 10, 64)
-			if err != nil {
-				t.Fatal(err)
-			}
-			return kb << 10
-		}
-		t.Fatal("RssAnon not found in /proc/self/status")
-	}
-	var ru syscall.Rusage
-	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+	n, err := turbostats.ResidentAnonBytes()
+	if err != nil {
 		t.Fatal(err)
 	}
-	maxrss := int64(ru.Maxrss)
-	if runtime.GOOS != "darwin" {
-		maxrss <<= 10 // kilobytes everywhere but darwin, which reports bytes
-	}
-	return maxrss
+	return n
 }
 
 func settle() {

--- a/internal/sinks/init.go
+++ b/internal/sinks/init.go
@@ -82,7 +82,7 @@ func New(ctx context.Context, sink config.Sink, conn adbc.Connection, opts ...Op
 
 	role := o.role
 	if role == "" {
-		role = "pipeline"
+		role = core.SinkRolePipeline
 	}
 
 	policy := RetryPolicyFrom(sink.Retry)

--- a/internal/turbostats/bundle.go
+++ b/internal/turbostats/bundle.go
@@ -1,0 +1,86 @@
+// Package turbostats is the document a sqlflow process reports about itself.
+//
+// One bundle, built by one function, carried by two transports: the HTTP
+// handler in this package serves it to whatever can reach the process, and
+// the reporter posts it outbound to a control plane that cannot. Neither
+// transport computes anything.
+//
+// Field names are the OTel instrument names in internal/core, not the
+// Prometheus series names those instruments render as. The bundle reads the
+// instrument; the suffixes belong to one exporter.
+package turbostats
+
+import "time"
+
+// MediaType names the version on the wire, so v1 and v2 are distinguishable
+// without parsing.
+const MediaType = "application/vnd.turbolytics.turbostats.v1+json"
+
+// Version is the document version, carried in the body so a bundle stored or
+// forwarded without its URL still says what it is.
+const Version = 1
+
+// Bundle is one report. The spec at
+// docs/superpowers/specs/2026-09-10-turbostats-v1-design.md defines every
+// field; the comments here say only what is not obvious from the name.
+type Bundle struct {
+	V        int       `json:"v"`
+	SentAt   time.Time `json:"sent_at"`
+	Instance Instance  `json:"instance"`
+	Process  Process   `json:"process"`
+	Pipeline Pipeline  `json:"pipeline"`
+	// Exit is present only in the last bundle a clean shutdown sends. A
+	// bundle without it is an instance still running, or one that died
+	// without saying so.
+	Exit *Exit `json:"exit,omitempty"`
+}
+
+// Instance is what the operator and the build said this process is.
+type Instance struct {
+	// ID is the operator's name for the instance. Empty until the reporter
+	// config exists, which is why it is omitempty here and required there.
+	ID         string `json:"id,omitempty"`
+	Pipeline   string `json:"pipeline,omitempty"`
+	Version    string `json:"version"`
+	Commit     string `json:"commit"`
+	Arch       string `json:"arch"`
+	ConfigHash string `json:"config_hash"`
+}
+
+// Process is what the runtime and the kernel say about this process.
+type Process struct {
+	StartedAt  time.Time `json:"started_at"`
+	RSSBytes   int64     `json:"rss_bytes"`
+	Goroutines int       `json:"goroutines"`
+}
+
+// Pipeline carries one field per counter or dimensionless gauge the engine
+// declares. Counters are totals since Process.StartedAt; gauges are the value
+// now. Histograms are deliberately absent: they are most of a scrape by bytes
+// and nothing on the first page reads them.
+type Pipeline struct {
+	MessageCount     int64 `json:"message_count"`
+	HandlerRowsRead  int64 `json:"handler_rows_read"`
+	ErrorCount       int64 `json:"error_count"`
+	SinkFlushCount   int64 `json:"sink_flush_count"`
+	SinkRowsAccepted int64 `json:"sink_rows_accepted"`
+	SinkRowsWritten  int64 `json:"sink_rows_written"`
+	StateCommitCount int64 `json:"state_commit_count"`
+	ConsumerLag      int64 `json:"consumer_lag"`
+	// A pointer so a pipeline with no state path omits the field: absent
+	// state and empty state are different facts.
+	StateDBSizeBytes *int64 `json:"state_db_size_bytes,omitempty"`
+}
+
+// Exit is how a clean shutdown ended.
+type Exit struct {
+	Reason string `json:"reason"`
+	Code   int    `json:"code"`
+}
+
+// Static is what the run command knows once, at startup, and the package
+// cannot learn on its own.
+type Static struct {
+	ID, Pipeline, Version, Commit, ConfigHash string
+	StartedAt                                 time.Time
+}

--- a/internal/turbostats/bundle.go
+++ b/internal/turbostats/bundle.go
@@ -29,6 +29,10 @@ type Bundle struct {
 	Instance Instance  `json:"instance"`
 	Process  Process   `json:"process"`
 	Pipeline Pipeline  `json:"pipeline"`
+	// LastMessageAt is when the pipeline last received messages. Absent until
+	// it receives any. Staleness is sent_at minus this, and because both come
+	// from the instance's own clock the difference carries no skew.
+	LastMessageAt *time.Time `json:"last_message_at,omitempty"`
 	// Exit is present only in the last bundle a clean shutdown sends. A
 	// bundle without it is an instance still running, or one that died
 	// without saying so.
@@ -54,10 +58,13 @@ type Process struct {
 	Goroutines int       `json:"goroutines"`
 }
 
-// Pipeline carries one field per counter or dimensionless gauge the engine
-// declares. Counters are totals since Process.StartedAt; gauges are the value
-// now. Histograms are deliberately absent: they are most of a scrape by bytes
-// and nothing on the first page reads them.
+// Pipeline carries the engine's top-line totals since Process.StartedAt.
+//
+// Every one is read from a dimensionless series, so building this is a
+// lookup. Flushes and commits count successes only, and the row counts
+// exclude the DLQ's, because those choices are made where the measurements
+// are recorded rather than here. Histograms are deliberately absent: they are
+// most of a scrape by bytes and nothing on the first page reads them.
 type Pipeline struct {
 	MessageCount     int64 `json:"message_count"`
 	HandlerRowsRead  int64 `json:"handler_rows_read"`
@@ -66,7 +73,6 @@ type Pipeline struct {
 	SinkRowsAccepted int64 `json:"sink_rows_accepted"`
 	SinkRowsWritten  int64 `json:"sink_rows_written"`
 	StateCommitCount int64 `json:"state_commit_count"`
-	ConsumerLag      int64 `json:"consumer_lag"`
 	// A pointer so a pipeline with no state path omits the field: absent
 	// state and empty state are different facts.
 	StateDBSizeBytes *int64 `json:"state_db_size_bytes,omitempty"`

--- a/internal/turbostats/collect.go
+++ b/internal/turbostats/collect.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/turbolytics/sql-flow/internal/core"
-	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -25,7 +24,7 @@ func Collect(ctx context.Context, s Static, r *sdkmetric.ManualReader,
 	if err := r.Collect(ctx, &rm); err != nil {
 		return Bundle{}, fmt.Errorf("turbostats: collecting instruments: %w", err)
 	}
-	totals := sumByName(rm)
+	flat := scalars(rm)
 
 	rss, err := ResidentAnonBytes()
 	if err != nil {
@@ -49,15 +48,22 @@ func Collect(ctx context.Context, s Static, r *sdkmetric.ManualReader,
 			Goroutines: runtime.NumGoroutine(),
 		},
 		Pipeline: Pipeline{
-			MessageCount:     totals["message_count"],
-			HandlerRowsRead:  totals["handler_rows_read"],
-			ErrorCount:       totals["error_count"],
-			SinkFlushCount:   totals["sink_flush_count"],
-			SinkRowsAccepted: totals["sink_rows_accepted"],
-			SinkRowsWritten:  totals["sink_rows_written"],
-			StateCommitCount: totals["state_commit_count"],
-			ConsumerLag:      totals["consumer_lag"],
+			MessageCount:     flat["message_count"],
+			HandlerRowsRead:  flat["handler_rows_read"],
+			ErrorCount:       flat["pipeline_errors"],
+			SinkFlushCount:   flat["pipeline_flushes"],
+			SinkRowsAccepted: flat["pipeline_rows_accepted"],
+			SinkRowsWritten:  flat["pipeline_rows_written"],
+			StateCommitCount: flat["pipeline_commits"],
 		},
+	}
+
+	// Zero means no messages yet, which is not a time. The control plane
+	// derives staleness as sent_at minus this, both from the instance's own
+	// clock, so the difference carries no skew.
+	if ts := flat["pipeline_last_message_timestamp"]; ts > 0 {
+		at := time.Unix(ts, 0).UTC()
+		b.LastMessageAt = &at
 	}
 
 	if stats != nil {
@@ -73,38 +79,36 @@ func Collect(ctx context.Context, s Static, r *sdkmetric.ManualReader,
 	return b, nil
 }
 
-// roleKey is the attribute the sink counters carry to keep the DLQ's rows out
-// of the pipeline's delivered series. The bundle keeps them out too.
-var roleKey = attribute.Key("role")
-
-// sumByName folds every int64 counter and gauge into one total per name,
-// summed across attribute sets, except that a point with a role other than
-// "pipeline" is skipped. Histograms and float instruments are ignored: the
-// bundle carries none.
-func sumByName(rm metricdata.ResourceMetrics) map[string]int64 {
+// scalars reads the dimensionless point of every int64 instrument, by name.
+//
+// It sums nothing and filters nothing. Every number the bundle reports has a
+// dimensionless series recorded for it, so this is a lookup, and which
+// measurements count was decided where they were recorded.
+//
+// That is the whole point. Adding a counter's attribute sets together is
+// arithmetic that silently encodes a policy: sink_flush_count carries
+// result=ok and result=error, and summing them reports a number of flushes
+// that is true of nothing. A point carrying any attribute is not the flat
+// series and is skipped.
+func scalars(rm metricdata.ResourceMetrics) map[string]int64 {
 	out := map[string]int64{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			switch data := m.Data.(type) {
 			case metricdata.Sum[int64]:
 				for _, dp := range data.DataPoints {
-					if pipelineRole(dp.Attributes) {
-						out[m.Name] += dp.Value
+					if dp.Attributes.Len() == 0 {
+						out[m.Name] = dp.Value
 					}
 				}
 			case metricdata.Gauge[int64]:
 				for _, dp := range data.DataPoints {
-					if pipelineRole(dp.Attributes) {
-						out[m.Name] += dp.Value
+					if dp.Attributes.Len() == 0 {
+						out[m.Name] = dp.Value
 					}
 				}
 			}
 		}
 	}
 	return out
-}
-
-func pipelineRole(set attribute.Set) bool {
-	v, ok := set.Value(roleKey)
-	return !ok || v.AsString() == "pipeline"
 }

--- a/internal/turbostats/collect.go
+++ b/internal/turbostats/collect.go
@@ -1,0 +1,110 @@
+package turbostats
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// Collect builds one bundle. It is the only function that does.
+//
+// It allocates one bundle and touches nothing shared, so the HTTP handler and
+// the reporter can call it at once. stats may be nil for a pipeline with no
+// state path; a stats error is the bundle's error, because a document with a
+// field quietly missing reads as healthy.
+func Collect(ctx context.Context, s Static, r *sdkmetric.ManualReader,
+	stats func() (*core.StateStats, error)) (Bundle, error) {
+
+	var rm metricdata.ResourceMetrics
+	if err := r.Collect(ctx, &rm); err != nil {
+		return Bundle{}, fmt.Errorf("turbostats: collecting instruments: %w", err)
+	}
+	totals := sumByName(rm)
+
+	rss, err := ResidentAnonBytes()
+	if err != nil {
+		return Bundle{}, fmt.Errorf("turbostats: reading resident memory: %w", err)
+	}
+
+	b := Bundle{
+		V:      Version,
+		SentAt: time.Now().UTC().Truncate(time.Second),
+		Instance: Instance{
+			ID:         s.ID,
+			Pipeline:   s.Pipeline,
+			Version:    s.Version,
+			Commit:     s.Commit,
+			Arch:       runtime.GOOS + "/" + runtime.GOARCH,
+			ConfigHash: s.ConfigHash,
+		},
+		Process: Process{
+			StartedAt:  s.StartedAt.UTC().Truncate(time.Second),
+			RSSBytes:   rss,
+			Goroutines: runtime.NumGoroutine(),
+		},
+		Pipeline: Pipeline{
+			MessageCount:     totals["message_count"],
+			HandlerRowsRead:  totals["handler_rows_read"],
+			ErrorCount:       totals["error_count"],
+			SinkFlushCount:   totals["sink_flush_count"],
+			SinkRowsAccepted: totals["sink_rows_accepted"],
+			SinkRowsWritten:  totals["sink_rows_written"],
+			StateCommitCount: totals["state_commit_count"],
+			ConsumerLag:      totals["consumer_lag"],
+		},
+	}
+
+	if stats != nil {
+		st, err := stats()
+		if err != nil {
+			return Bundle{}, fmt.Errorf("turbostats: reading state stats: %w", err)
+		}
+		if st != nil {
+			size := st.SizeBytes
+			b.Pipeline.StateDBSizeBytes = &size
+		}
+	}
+	return b, nil
+}
+
+// roleKey is the attribute the sink counters carry to keep the DLQ's rows out
+// of the pipeline's delivered series. The bundle keeps them out too.
+var roleKey = attribute.Key("role")
+
+// sumByName folds every int64 counter and gauge into one total per name,
+// summed across attribute sets, except that a point with a role other than
+// "pipeline" is skipped. Histograms and float instruments are ignored: the
+// bundle carries none.
+func sumByName(rm metricdata.ResourceMetrics) map[string]int64 {
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch data := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range data.DataPoints {
+					if pipelineRole(dp.Attributes) {
+						out[m.Name] += dp.Value
+					}
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range data.DataPoints {
+					if pipelineRole(dp.Attributes) {
+						out[m.Name] += dp.Value
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func pipelineRole(set attribute.Set) bool {
+	v, ok := set.Value(roleKey)
+	return !ok || v.AsString() == "pipeline"
+}

--- a/internal/turbostats/collect_test.go
+++ b/internal/turbostats/collect_test.go
@@ -1,0 +1,179 @@
+package turbostats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// A provider with the engine's real instruments, driven a known distance.
+func provider(t *testing.T) (*sdkmetric.ManualReader, *core.Metrics, metric.Meter) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m, err := core.NewMetrics(mp)
+	assert.NoError(t, err)
+	return reader, m, mp.Meter("sqlflow")
+}
+
+var static = Static{
+	ID:         "pi-01",
+	Pipeline:   "demo",
+	Version:    "v1.2.3",
+	Commit:     "abc1234",
+	ConfigHash: "sha256:00",
+	StartedAt:  time.Date(2026, 9, 1, 8, 12, 44, 0, time.UTC),
+}
+
+func TestCollect_CountersAreTotalsSinceStart(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.MessageCount.Add(ctx, 3)
+	m.MessageCount.Add(ctx, 4)
+	m.ErrorCount.Add(ctx, 1)
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(7), b.Pipeline.MessageCount)
+	assert.Equal(t, int64(1), b.Pipeline.ErrorCount)
+}
+
+// consumer_lag is recorded per partition. The bundle carries one number.
+func TestCollect_AGaugeIsSummedAcrossItsAttributes(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.ConsumerLag.Record(ctx, 5, metric.WithAttributes(attribute.Int("partition", 0)))
+	m.ConsumerLag.Record(ctx, 7, metric.WithAttributes(attribute.Int("partition", 1)))
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(12), b.Pipeline.ConsumerLag)
+}
+
+// The DLQ records its rows with role=dlq so they never sum into the
+// pipeline's delivered series. The bundle must not undo that.
+func TestCollect_SinkRowsCountThePipelineRoleOnly(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, meter := provider(t)
+	ctx := context.Background()
+	written, err := meter.Int64Counter("sink_rows_written")
+	assert.NoError(t, err)
+	written.Add(ctx, 10, metric.WithAttributes(
+		attribute.String("sink", "console"), attribute.String("role", "pipeline")))
+	written.Add(ctx, 4, metric.WithAttributes(
+		attribute.String("sink", "console"), attribute.String("role", "dlq")))
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(10), b.Pipeline.SinkRowsWritten)
+}
+
+func TestCollect_HistogramsAreNotInTheBundle(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.SinkFlushLatency.Record(ctx, 0.25)
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	raw, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.That(t, !strings.Contains(string(raw), "latency"))
+	assert.That(t, !strings.Contains(string(raw), "bucket"))
+}
+
+// Absent state and empty state are different facts, the same rule /stats
+// follows.
+func TestCollect_StateSizeIsOmittedWithoutAStateDatabase(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+
+	b, err := Collect(context.Background(), static, reader, nil)
+	assert.NoError(t, err)
+	raw, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.That(t, !strings.Contains(string(raw), "state_db_size_bytes"))
+}
+
+func TestCollect_StateSizeComesFromTheStatsFunction(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+	stats := func() (*core.StateStats, error) {
+		return &core.StateStats{SizeBytes: 4096}, nil
+	}
+
+	b, err := Collect(context.Background(), static, reader, stats)
+	assert.NoError(t, err)
+	assert.That(t, b.Pipeline.StateDBSizeBytes != nil)
+	assert.Equal(t, int64(4096), *b.Pipeline.StateDBSizeBytes)
+}
+
+// A stats failure is the bundle's failure. A monitoring system must see it
+// rather than a healthy-looking document with a field quietly missing.
+func TestCollect_AStatsFailureFailsTheBundle(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+	stats := func() (*core.StateStats, error) { return nil, errors.New("unreadable") }
+
+	_, err := Collect(context.Background(), static, reader, stats)
+	assert.Error(t, err)
+}
+
+func TestCollect_CarriesTheStaticFactsAndTheRuntime(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+
+	b, err := Collect(context.Background(), static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, b.V)
+	assert.Equal(t, "pi-01", b.Instance.ID)
+	assert.Equal(t, "demo", b.Instance.Pipeline)
+	assert.Equal(t, "v1.2.3", b.Instance.Version)
+	assert.Equal(t, "abc1234", b.Instance.Commit)
+	assert.Equal(t, "sha256:00", b.Instance.ConfigHash)
+	assert.That(t, strings.Contains(b.Instance.Arch, "/"))
+	assert.Equal(t, static.StartedAt, b.Process.StartedAt)
+	assert.That(t, b.Process.Goroutines > 0)
+	assert.That(t, b.Process.RSSBytes > 0)
+	assert.That(t, b.Exit == nil)
+	assert.That(t, !b.SentAt.IsZero())
+	assert.Equal(t, 0, b.SentAt.Nanosecond())
+}
+
+func TestCollect_TheBundleIsUnderOneKiB(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, meter := provider(t)
+	ctx := context.Background()
+	// Nine-digit totals, the size a year of the Bluesky firehose reaches.
+	m.MessageCount.Add(ctx, 184203311)
+	m.HandlerRowsRead.Add(ctx, 184203311)
+	m.SinkFlushCount.Add(ctx, 1842033)
+	m.StateCommitCount.Add(ctx, 1842033)
+	for _, name := range []string{"sink_rows_accepted", "sink_rows_written"} {
+		c, err := meter.Int64Counter(name)
+		assert.NoError(t, err)
+		c.Add(ctx, 184203311, metric.WithAttributes(
+			attribute.String("sink", "clickhouse"), attribute.String("role", "pipeline")))
+	}
+	size := int64(4194304)
+	stats := func() (*core.StateStats, error) { return &core.StateStats{SizeBytes: size}, nil }
+
+	b, err := Collect(ctx, static, reader, stats)
+	assert.NoError(t, err)
+	b.Exit = &Exit{Reason: "SIGTERM", Code: 0}
+	raw, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.That(t, len(raw) < 1024)
+}

--- a/internal/turbostats/collect_test.go
+++ b/internal/turbostats/collect_test.go
@@ -41,7 +41,7 @@ func TestCollect_CountersAreTotalsSinceStart(t *testing.T) {
 	ctx := context.Background()
 	m.MessageCount.Add(ctx, 3)
 	m.MessageCount.Add(ctx, 4)
-	m.ErrorCount.Add(ctx, 1)
+	m.PipelineErrors.Add(ctx, 1)
 
 	b, err := Collect(ctx, static, reader, nil)
 	assert.NoError(t, err)
@@ -49,35 +49,74 @@ func TestCollect_CountersAreTotalsSinceStart(t *testing.T) {
 	assert.Equal(t, int64(1), b.Pipeline.ErrorCount)
 }
 
-// consumer_lag is recorded per partition. The bundle carries one number.
-func TestCollect_AGaugeIsSummedAcrossItsAttributes(t *testing.T) {
-	coverage.Covers(t, "observability.turbostats")
-	reader, m, _ := provider(t)
-	ctx := context.Background()
-	m.ConsumerLag.Record(ctx, 5, metric.WithAttributes(attribute.Int("partition", 0)))
-	m.ConsumerLag.Record(ctx, 7, metric.WithAttributes(attribute.Int("partition", 1)))
-
-	b, err := Collect(ctx, static, reader, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(12), b.Pipeline.ConsumerLag)
-}
-
-// The DLQ records its rows with role=dlq so they never sum into the
-// pipeline's delivered series. The bundle must not undo that.
-func TestCollect_SinkRowsCountThePipelineRoleOnly(t *testing.T) {
+// Collect never sums and never filters. A series carrying attributes is not
+// the flat one, so it is not the bundle's, whatever its name.
+//
+// This is what keeps policy out of the reader. sink_flush_count carries
+// result=ok and result=error; adding them reports a number of flushes that is
+// true of nothing, and the engine records pipeline_flushes instead.
+func TestCollect_ADimensionedSeriesIsNotTheBundles(t *testing.T) {
 	coverage.Covers(t, "observability.turbostats")
 	reader, _, meter := provider(t)
 	ctx := context.Background()
-	written, err := meter.Int64Counter("sink_rows_written")
+	flushes, err := meter.Int64Counter("pipeline_flushes")
 	assert.NoError(t, err)
-	written.Add(ctx, 10, metric.WithAttributes(
-		attribute.String("sink", "console"), attribute.String("role", "pipeline")))
-	written.Add(ctx, 4, metric.WithAttributes(
-		attribute.String("sink", "console"), attribute.String("role", "dlq")))
+	flushes.Add(ctx, 3)
+	// The same name with an attribute: a different series, and not ours.
+	flushes.Add(ctx, 99, metric.WithAttributes(attribute.String("result", "error")))
 
 	b, err := Collect(ctx, static, reader, nil)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(10), b.Pipeline.SinkRowsWritten)
+	assert.Equal(t, int64(3), b.Pipeline.SinkFlushCount)
+}
+
+// The bundle reads the flat twins, not the instruments they shadow.
+func TestCollect_ReadsTheFlatSeries(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.PipelineErrors.Add(ctx, 2)
+	m.PipelineFlushes.Add(ctx, 3)
+	m.PipelineCommits.Add(ctx, 4)
+	m.PipelineRowsAccepted.Add(ctx, 5)
+	m.PipelineRowsWritten.Add(ctx, 6)
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), b.Pipeline.ErrorCount)
+	assert.Equal(t, int64(3), b.Pipeline.SinkFlushCount)
+	assert.Equal(t, int64(4), b.Pipeline.StateCommitCount)
+	assert.Equal(t, int64(5), b.Pipeline.SinkRowsAccepted)
+	assert.Equal(t, int64(6), b.Pipeline.SinkRowsWritten)
+}
+
+// Staleness is the question the page asks, and the control plane derives it
+// from sent_at minus this. Offset lag could not answer it: a websocket source
+// has no offsets at all.
+func TestCollect_CarriesWhenMessagesLastArrived(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, m, _ := provider(t)
+	ctx := context.Background()
+	m.PipelineLastMessage.Record(ctx, 1757570000)
+
+	b, err := Collect(ctx, static, reader, nil)
+	assert.NoError(t, err)
+	assert.That(t, b.LastMessageAt != nil)
+	assert.Equal(t, int64(1757570000), b.LastMessageAt.Unix())
+}
+
+// A pipeline that has received nothing has no last message, and zero is not a
+// time. The field is absent rather than 1970.
+func TestCollect_OmitsTheLastMessageBeforeAnyArrive(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	reader, _, _ := provider(t)
+
+	b, err := Collect(context.Background(), static, reader, nil)
+	assert.NoError(t, err)
+	assert.That(t, b.LastMessageAt == nil)
+	raw, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.That(t, !strings.Contains(string(raw), "last_message_at"))
 }
 
 func TestCollect_HistogramsAreNotInTheBundle(t *testing.T) {
@@ -161,12 +200,10 @@ func TestCollect_TheBundleIsUnderOneKiB(t *testing.T) {
 	m.HandlerRowsRead.Add(ctx, 184203311)
 	m.SinkFlushCount.Add(ctx, 1842033)
 	m.StateCommitCount.Add(ctx, 1842033)
-	for _, name := range []string{"sink_rows_accepted", "sink_rows_written"} {
-		c, err := meter.Int64Counter(name)
-		assert.NoError(t, err)
-		c.Add(ctx, 184203311, metric.WithAttributes(
-			attribute.String("sink", "clickhouse"), attribute.String("role", "pipeline")))
-	}
+	m.PipelineRowsAccepted.Add(ctx, 184203311)
+	m.PipelineRowsWritten.Add(ctx, 184203311)
+	m.PipelineLastMessage.Record(ctx, 1757570000)
+	_ = meter
 	size := int64(4194304)
 	stats := func() (*core.StateStats, error) { return &core.StateStats{SizeBytes: size}, nil }
 

--- a/internal/turbostats/handler.go
+++ b/internal/turbostats/handler.go
@@ -1,0 +1,32 @@
+package turbostats
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Handler serves one bundle per GET. The run command mounts it at
+// /turbostats/v1; the path is the caller's, the media type is this package's.
+func Handler(collect func(context.Context) (Bundle, error)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		b, err := collect(r.Context())
+		if err != nil {
+			// A monitoring system must see the failure, not a healthy-looking
+			// blank, which is the rule /stats already follows.
+			http.Error(w, fmt.Sprintf("building bundle: %v", err),
+				http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", MediaType)
+		if err := json.NewEncoder(w).Encode(b); err != nil {
+			return
+		}
+	})
+}

--- a/internal/turbostats/handler_test.go
+++ b/internal/turbostats/handler_test.go
@@ -1,0 +1,52 @@
+package turbostats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+func TestHandler_ServesOneBundleWithTheMediaType(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	h := Handler(func(context.Context) (Bundle, error) {
+		return Bundle{V: Version, Instance: Instance{Version: "v9"}}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, MediaType, rec.Header().Get("Content-Type"))
+	var got Bundle
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, 1, got.V)
+	assert.Equal(t, "v9", got.Instance.Version)
+}
+
+// A collection failure is a server error, not an empty success: a monitoring
+// system must see it rather than a healthy-looking blank.
+func TestHandler_ReportsACollectionFailure(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	h := Handler(func(context.Context) (Bundle, error) {
+		return Bundle{}, errors.New("reader closed")
+	})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandler_RejectsAnythingButGET(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	h := Handler(func(context.Context) (Bundle, error) { return Bundle{V: Version}, nil })
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/turbostats/v1", nil))
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}

--- a/internal/turbostats/hash.go
+++ b/internal/turbostats/hash.go
@@ -1,0 +1,16 @@
+package turbostats
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// HashConfig identifies a rendered config by content.
+//
+// Hashed after templating and before parsing, so the same file under two
+// environments hashes differently: those are two configs. The prefix names
+// the algorithm so a stored hash stays readable when the algorithm changes.
+func HashConfig(rendered []byte) string {
+	sum := sha256.Sum256(rendered)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/turbostats/hash_test.go
+++ b/internal/turbostats/hash_test.go
@@ -1,0 +1,22 @@
+package turbostats
+
+import (
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+func TestHashConfig_IsSHA256OfTheRenderedText(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	got := HashConfig([]byte("pipeline:\n  name: x\n"))
+	// sha256 of that exact text, computed once with
+	// printf 'pipeline:\n  name: x\n' | shasum -a 256
+	assert.Equal(t, "sha256:2d1b7510db148fa0dfa4e13e50f1bd30c4ccceeae5dc5f5f20cce0c8034c6fcd", got)
+}
+
+func TestHashConfig_DiffersWhenTheTextDoes(t *testing.T) {
+	coverage.Covers(t, "observability.turbostats")
+	assert.That(t, HashConfig([]byte("a")) != HashConfig([]byte("b")))
+	assert.Equal(t, 7+64, len(HashConfig([]byte("a"))))
+}

--- a/internal/turbostats/rss.go
+++ b/internal/turbostats/rss.go
@@ -1,0 +1,54 @@
+package turbostats
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ResidentAnonBytes is the process's anonymous resident memory.
+//
+// That is the figure a native leak moves: Go's heap profiler cannot see a
+// buffer DuckDB allocated across the ADBC boundary, and duckdb_memory() does
+// not track it either, so the only honest instrument is the process itself.
+//
+// Linux reads RssAnon, which excludes file-backed pages and is exact. Other
+// platforms fall back to peak resident size from getrusage, which only ever
+// rises, so it is a weaker signal there; a leak still shows as growth between
+// two readings, since a steady process has a steady peak.
+func ResidentAnonBytes() (int64, error) {
+	if runtime.GOOS == "linux" {
+		f, err := os.Open("/proc/self/status")
+		if err != nil {
+			return 0, err
+		}
+		defer f.Close()
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := sc.Text()
+			if !strings.HasPrefix(line, "RssAnon:") {
+				continue
+			}
+			fields := strings.Fields(line)
+			kb, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return 0, err
+			}
+			return kb << 10, nil
+		}
+		return 0, fmt.Errorf("RssAnon not found in /proc/self/status")
+	}
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		return 0, err
+	}
+	maxrss := int64(ru.Maxrss)
+	if runtime.GOOS != "darwin" {
+		maxrss <<= 10 // kilobytes everywhere but darwin, which reports bytes
+	}
+	return maxrss, nil
+}

--- a/scripts/release-binaries.sh
+++ b/scripts/release-binaries.sh
@@ -45,7 +45,7 @@ GO_IMAGE="${GO_IMAGE:-golang:1.25-bookworm}"
 GO_MODULE="github.com/turbolytics/sql-flow"
 VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 COMMIT="${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
-LDFLAGS="-X ${GO_MODULE}/internal/cli.Version=${VERSION} -X ${GO_MODULE}/internal/cli.Commit=${COMMIT}"
+LDFLAGS="-X ${GO_MODULE}/internal/buildinfo.Version=${VERSION} -X ${GO_MODULE}/internal/buildinfo.Commit=${COMMIT}"
 
 mkdir -p "$DEST_DIR"
 

--- a/scripts/soak-verdict.py
+++ b/scripts/soak-verdict.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Pass or fail a memory soak, and say why.
+
+    scripts/soak-verdict.py soak-pr/decomp.csv [--max-bytes-per-msg 1.0]
+                            [--warmup 3]
+
+The number that decides it is bytes retained per message, not megabytes per
+minute. A leak is linear in messages, so per-message growth is comparable
+between a saturated run and a trickle, and between a fast machine and a slow
+one. Minutes per megabyte is none of those things.
+
+Native is what is judged: Go retained is reported beside it, because a Go-side
+leak should also fail, but the leak this gate exists to catch was a DuckDB
+buffer that Go's heap profiler could not see.
+
+Warm-up is discarded. Allocator arenas are bought once and reused, so the
+first minutes grow and then stop; judging from minute zero reads that as a
+slow leak.
+"""
+import argparse
+import csv
+import sys
+
+
+def load(path):
+    rows = []
+    with open(path) as fh:
+        for raw in csv.DictReader(fh):
+            row = {}
+            for k, v in raw.items():
+                try:
+                    row[k] = float(v)
+                except (TypeError, ValueError):
+                    row[k] = None
+            if row.get("min") is not None:
+                rows.append(row)
+    return rows
+
+
+def slope(points):
+    """MiB per minute, least squares. None when there is too little to fit."""
+    n = len(points)
+    if n < 3:
+        return None
+    sx = sum(x for x, _ in points)
+    sy = sum(y for _, y in points)
+    sxx = sum(x * x for x, _ in points)
+    sxy = sum(x * y for x, y in points)
+    d = n * sxx - sx * sx
+    return (n * sxy - sx * sy) / d if d else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("csv")
+    ap.add_argument("--max-bytes-per-msg", type=float, default=1.0)
+    ap.add_argument("--warmup", type=int, default=3,
+                    help="minutes discarded before judging")
+    args = ap.parse_args()
+
+    allrows = load(args.csv)
+
+    # Minutes must ascend. Two samplers writing one file interleave their rows
+    # and the arithmetic below would run happily over the mixture, reporting a
+    # window and a message count that belong to neither run.
+    minutes_seen = [r["min"] for r in allrows]
+    if minutes_seen != sorted(minutes_seen) or len(set(minutes_seen)) != len(minutes_seen):
+        print(f"FAIL  {args.csv}: samples are not in ascending minute order, "
+              "so more than one sampler wrote this file. Rerun it alone.")
+        return 1
+
+    rows = [r for r in allrows if r["min"] >= args.warmup]
+    if len(rows) < 3:
+        print(f"FAIL  {args.csv}: {len(rows)} samples after warm-up, need 3")
+        return 1
+
+    first, last = rows[0], rows[-1]
+    minutes = last["min"] - first["min"]
+    messages = (last.get("msgs") or 0) - (first.get("msgs") or 0)
+
+    native = [(r["min"], r["native_mib"]) for r in rows
+              if r.get("native_mib") is not None]
+    go = [(r["min"], r["go_retained_mib"]) for r in rows
+          if r.get("go_retained_mib") is not None]
+
+    native_slope = slope(native)
+    go_slope = slope(go)
+    growth_mib = last["native_mib"] - first["native_mib"]
+
+    print(f"window        minutes {args.warmup}-{int(last['min'])}, "
+          f"{int(messages):,} messages")
+    print(f"native        {first['native_mib']:.1f} -> {last['native_mib']:.1f} MiB")
+    print(f"go retained   {first['go_retained_mib']:.1f} -> "
+          f"{last['go_retained_mib']:.1f} MiB")
+    if native_slope is not None:
+        print(f"native slope  {native_slope:+.3f} MiB/min")
+    if go_slope is not None:
+        print(f"go slope      {go_slope:+.3f} MiB/min")
+
+    failures = []
+
+    # The volume gate. Without enough messages the per-message number is
+    # noise, and a pass would mean nothing. A saturated ten minutes clears
+    # this by two orders of magnitude; 500 msg/s for ten minutes does not.
+    if messages < 1_000_000:
+        failures.append(
+            f"only {int(messages):,} messages in the window; a per-message "
+            "leak needs volume to clear the noise, so this run proves nothing")
+
+    if messages > 0:
+        per_msg = growth_mib * 1024 * 1024 / messages
+        print(f"per message   {per_msg:+.3f} B/msg "
+              f"(threshold {args.max_bytes_per_msg})")
+        if per_msg > args.max_bytes_per_msg:
+            failures.append(
+                f"native grew {per_msg:.3f} B/msg, over the "
+                f"{args.max_bytes_per_msg} threshold")
+
+    # Go's side is judged more loosely: it is bounded by GC rather than by
+    # arithmetic, so a slow upward drift there is usually the heap settling.
+    if go_slope is not None and go_slope > 1.0:
+        failures.append(f"Go retained grew {go_slope:+.3f} MiB/min")
+
+    print()
+    if failures:
+        print("FAIL")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print(f"PASS  memory is flat over {int(messages):,} messages")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/soak.sh
+++ b/scripts/soak.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# The memory gate a pull request has to pass.
+#
+#   scripts/soak.sh [minutes] [label]
+#
+# Runs the shipped image against a saturated Kafka topic, polls
+# /turbostats/v1 once a second for the whole run, samples the memory
+# decomposition once a minute, and prints a verdict.
+#
+# Why a soak and not a unit test. Go's heap profiler cannot see a buffer
+# DuckDB allocated across the ADBC boundary, and duckdb_memory() does not
+# track it either. Only the process can, and only over enough messages for a
+# per-message leak to clear the noise. The leak this gate exists to catch was
+# 44 bytes a message: invisible in a benchmark that finishes in a second, and
+# 90 MiB over a day in production.
+#
+# Why high volume. A leak is linear in messages, not in wall clock. Ten
+# minutes at 500 messages a second is 300k messages and proves little; the
+# same ten minutes saturated is tens of millions.
+#
+# Why it polls the endpoint. /turbostats/v1 builds a bundle per request and
+# walks the metric data to do it. A handler that allocates per request leaks
+# in proportion to requests, which the once-a-minute sampler would take hours
+# to show.
+#
+# Environment:
+#   SQLFLOW_IMAGE   image under test        (default: git describe tag)
+#   SOAK_NETWORK    docker network          (default dev_default)
+#   SOAK_KAFKA      broker container name   (default kafka1)
+#   SOAK_BROKER     broker from inside it   (default kafka1:19092)
+#   SOAK_BYTES_PER_MSG  failing threshold   (default 1.0)
+set -euo pipefail
+
+minutes=${1:-10}
+label=${2:-pr}
+here=$(cd "$(dirname "$0")/.." && pwd)
+skill="$here/.claude/skills/memory-soak"
+
+image=${SQLFLOW_IMAGE:-turbolytics/sql-flow:$(git -C "$here" describe --tags --always --dirty)}
+net=${SOAK_NETWORK:-dev_default}
+kafka=${SOAK_KAFKA:-kafka1}
+broker=${SOAK_BROKER:-kafka1:19092}
+topic="soak-gate-$(date +%s)"
+
+if ! docker image inspect "$image" >/dev/null 2>&1; then
+  echo "image $image not present; run 'make sqlflow-image' first" >&2
+  exit 1
+fi
+
+# Two samplers writing one decomp.csv interleave their rows, and the verdict
+# then reads a file whose minutes do not ascend. Refuse rather than produce a
+# result that looks real. Seen once, by running the gate twice with the same
+# label after the first run's sampler survived its shell.
+if [ -e "soak-$label/decomp.csv" ]; then
+  echo "soak-$label/decomp.csv exists. Remove it, or pass another label." >&2
+  exit 1
+fi
+if docker ps --format '{{.Names}}' | grep -qx "sqlflow-soak-$label"; then
+  echo "sqlflow-soak-$label is already running. Stop it first." >&2
+  exit 1
+fi
+
+echo "image:   $image"
+echo "topic:   $topic"
+echo "minutes: $minutes"
+echo
+
+# A saturated producer, restarted for the length of the run. --throughput -1
+# means as fast as the broker will take it, so the pipeline is never waiting
+# for input and the message count is the largest the hardware allows.
+docker exec "$kafka" kafka-topics --bootstrap-server "$broker" \
+  --create --topic "$topic" --partitions 1 --replication-factor 1 >/dev/null 2>&1 || true
+
+# A payload file, not --record-size: the perf producer's own records are
+# random bytes, and the pipeline rejects them as malformed JSON, which is
+# correct of it. One line per record, cycled.
+docker exec "$kafka" sh -c "
+  awk 'BEGIN{
+    srand(7);
+    for (i = 0; i < 1000; i++)
+      printf \"{\\\"sensor_id\\\":%d,\\\"ts\\\":\\\"2026-09-11T00:00:00\\\",\\\"value\\\":%.2f}\n\",
+             int(rand()*5)+1, rand()*50-10
+  }' > /tmp/soak-payload.json"
+
+docker exec -d "$kafka" sh -c "
+  for i in \$(seq 1 $((minutes + 2))); do
+    kafka-producer-perf-test --topic $topic \
+      --num-records 4000000 --throughput -1 \
+      --payload-file /tmp/soak-payload.json --payload-delimiter '\n' \
+      --producer-props bootstrap.servers=$broker acks=1 >/dev/null 2>&1
+  done"
+echo "producing to $topic at line rate"
+
+config="$here/dev/config/soak/inferred.noop.yml"
+if [ ! -f "$config" ]; then
+  echo "missing $config" >&2
+  exit 1
+fi
+
+# noop sink on purpose: this gate is about the engine. A sink's own buffers
+# are its conformance suite's business, and a destination that falls behind
+# would be indistinguishable from a leak here.
+SQLFLOW_TOPIC="$topic" \
+SQLFLOW_GROUP_ID="$topic" \
+SQLFLOW_KAFKA_BROKERS="$broker" \
+SQLFLOW_BATCH_SIZE=5000 \
+SOAK_ENV="SQLFLOW_TOPIC SQLFLOW_GROUP_ID SQLFLOW_KAFKA_BROKERS SQLFLOW_BATCH_SIZE" \
+SOAK_NETWORK="$net" \
+SOAK_FLAGS="--turbostats" \
+SOAK_POLL="/turbostats/v1" \
+  bash "$skill/soak.sh" "$image" "$config" "$minutes" "$label"
+
+echo
+"$here/scripts/soak-verdict.py" "soak-$label/decomp.csv" \
+  --max-bytes-per-msg "${SOAK_BYTES_PER_MSG:-1.0}"

--- a/scripts/soak.sh
+++ b/scripts/soak.sh
@@ -68,8 +68,15 @@ echo
 # A saturated producer, restarted for the length of the run. --throughput -1
 # means as fast as the broker will take it, so the pipeline is never waiting
 # for input and the message count is the largest the hardware allows.
+# retention.bytes caps the topic on disk. Ten minutes at this rate is tens of
+# gigabytes of messages, and a gate that fills the disk is worse than no gate.
+# A small segment makes the broker actually roll and delete; without it
+# everything stays in one active segment that retention never touches.
 docker exec "$kafka" kafka-topics --bootstrap-server "$broker" \
-  --create --topic "$topic" --partitions 1 --replication-factor 1 >/dev/null 2>&1 || true
+  --create --topic "$topic" --partitions 1 --replication-factor 1 \
+  --config retention.bytes=2147483648 \
+  --config retention.ms=60000 \
+  --config segment.bytes=134217728 >/dev/null 2>&1 || true
 
 # A payload file, not --record-size: the perf producer's own records are
 # random bytes, and the pipeline rejects them as malformed JSON, which is
@@ -82,14 +89,25 @@ docker exec "$kafka" sh -c "
              int(rand()*5)+1, rand()*50-10
   }' > /tmp/soak-payload.json"
 
+# Driven by a deadline, not a record count. A fixed count finishes early and
+# leaves the pipeline idle for the rest of the run, and an idle process holds
+# memory beautifully flat while proving nothing -- which is what the verdict's
+# volume check exists to catch, and did.
+#
+# Throttled just under what the engine consumes, so the consumer stays caught
+# up and retention only ever deletes messages it has already read. Unthrottled,
+# the producer outruns it and retention deletes unread data, which resets the
+# consumer to earliest and makes the message count meaningless.
+rate=${SOAK_RATE:-250000}
+deadline=$(( $(date +%s) + (minutes + 2) * 60 ))
 docker exec -d "$kafka" sh -c "
-  for i in \$(seq 1 $((minutes + 2))); do
+  while [ \$(date +%s) -lt $deadline ]; do
     kafka-producer-perf-test --topic $topic \
-      --num-records 4000000 --throughput -1 \
+      --num-records 20000000 --throughput $rate \
       --payload-file /tmp/soak-payload.json --payload-delimiter '\n' \
       --producer-props bootstrap.servers=$broker acks=1 >/dev/null 2>&1
   done"
-echo "producing to $topic at line rate"
+echo "producing to $topic at $rate msg/s until the run ends"
 
 config="$here/dev/config/soak/inferred.noop.yml"
 if [ ! -f "$config" ]; then
@@ -110,6 +128,24 @@ SOAK_FLAGS="--turbostats" \
 SOAK_POLL="/turbostats/v1" \
   bash "$skill/soak.sh" "$image" "$config" "$minutes" "$label"
 
+# The sampler leaves the container up so a failure can be inspected. A gate
+# should not: left alone it consumes at line rate until someone notices, and
+# the topic keeps its segments. Both go, unless the verdict fails, in which
+# case the container stays for the heap profiles beside it.
 echo
+set +e
 "$here/scripts/soak-verdict.py" "soak-$label/decomp.csv" \
   --max-bytes-per-msg "${SOAK_BYTES_PER_MSG:-1.0}"
+verdict=$?
+set -e
+
+if [ "$verdict" -eq 0 ]; then
+  docker rm -f "sqlflow-soak-$label" >/dev/null 2>&1 || true
+else
+  echo
+  echo "sqlflow-soak-$label left running; heap profiles are in soak-$label/"
+fi
+docker exec "$kafka" kafka-topics --bootstrap-server "$broker" \
+  --delete --topic "$topic" >/dev/null 2>&1 || true
+
+exit "$verdict"

--- a/tests/release/test_image.py
+++ b/tests/release/test_image.py
@@ -944,3 +944,57 @@ def test_error_dlq_diverts_a_batch_the_handler_cannot_query(image, stack):
     assert 'Binder Error: Referenced column "broken" not found' in record["error"]
     assert record["message"] == "Handler invocation failed"
     assert record["phase"] == "handler.invoke"
+
+
+@pytest.mark.covers("observability.turbostats")
+def test_turbostats_endpoint_serves_the_bundle(image, stack):
+    """The shipped image answers /turbostats/v1 with a bundle whose version
+    is the one stamped into the image.
+
+    Driven against the real binary rather than the handler, because what
+    ships is the flag, the mux and the link-time stamp together, and a unit
+    test proves none of those. The stamp in particular: it moved packages,
+    and a build script that missed the move reports "dev" here.
+    """
+    topic = f"turbostats-{int(time.time())}"
+
+    with container_writable_dir() as state_dir:
+        container = DockerContainer(image) \
+            .with_volume_mapping(settings.DEV_DIR, "/tmp/conf") \
+            .with_volume_mapping(state_dir, "/state", "rw") \
+            .with_env("SQLFLOW_KAFKA_BROKERS", "kafka:9092") \
+            .with_env("SQLFLOW_STATE_PATH", "/state/state.db") \
+            .with_env("SQLFLOW_TOPIC", topic) \
+            .with_env("SQLFLOW_GROUP_ID", topic) \
+            .with_exposed_ports(8000) \
+            .with_network(stack.network) \
+            .with_command(
+                "run /tmp/conf/config/examples/kafka.stateful.window.yml --turbostats")
+        container.start()
+        try:
+            wait_for_logs(container, "consumer loop starting", timeout=90)
+            port = container.get_exposed_port(8000)
+            resp = requests.get(
+                f"http://localhost:{port}/turbostats/v1", timeout=10)
+        finally:
+            container.stop()
+
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == \
+        "application/vnd.turbolytics.turbostats.v1+json"
+
+    bundle = resp.json()
+    assert bundle["v"] == 1
+
+    stdout, _ = run_docker_container(image, "version")
+    stamped = stdout.splitlines()[0].split()[1]
+    assert bundle["instance"]["version"] == stamped, (
+        f"bundle says {bundle['instance']['version']}, image says {stamped}")
+
+    assert bundle["process"]["rss_bytes"] > 0
+    assert bundle["process"]["goroutines"] > 0
+    assert bundle["instance"]["config_hash"].startswith("sha256:")
+    # This config declares a state path, so the field is present.
+    assert bundle["pipeline"]["state_db_size_bytes"] > 0
+    # Histograms never reach the bundle.
+    assert "latency" not in json.dumps(bundle)

--- a/tests/release/test_image.py
+++ b/tests/release/test_image.py
@@ -998,3 +998,9 @@ def test_turbostats_endpoint_serves_the_bundle(image, stack):
     assert bundle["pipeline"]["state_db_size_bytes"] > 0
     # Histograms never reach the bundle.
     assert "latency" not in json.dumps(bundle)
+
+    # Nothing has been produced to the topic, so the pipeline has received no
+    # messages and has no last message. Zero is not a time, so the field is
+    # absent rather than 1970.
+    assert "last_message_at" not in bundle
+    assert bundle["pipeline"]["message_count"] == 0


### PR DESCRIPTION
A sqlflow process now reports its own state as one versioned document, built from the same instruments Prometheus reads, and serves it at `GET /turbostats/v1`.

This is the contract the control plane depends on, so the spec and the plan are committed alongside the code. PR 2 adds the outbound reporter that posts the same bundle to a control plane that cannot reach the instance.

Implements PR 1 of `docs/superpowers/specs/2026-09-10-turbostats-v1-design.md`.

## Why not Prometheus

The first control-plane page needs uptime, restarts and resident memory from a fleet that cannot be dialed, on hardware where a scraper sidecar is two processes too many. Prometheus stays as the exporter for cloud deployments. For constrained industrial and IoT targets the process reports for itself, and it reports the instrument values rather than a rendering of them.

Two facts about the code made this more than a serialization job:

- The Prometheus exporter builds a bare `prom.NewRegistry()`, so `/metrics` carries the pipeline's instruments and nothing about the process. No start time, no resident memory, no goroutines. Those are exactly the three the page needs.
- The meter provider was built **only** for `--metrics=prometheus`. Without that flag there was no provider, every counter recorded into a noop, and there was nothing for a bundle to read. The manual reader is now attached always and the Prometheus exporter is a second reader on request.

## The document

```json
{
  "v": 1,
  "sent_at": "2026-09-11T09:51:45Z",
  "instance": {
    "pipeline": "bluesky-firehose",
    "version": "v1.1.0",
    "commit": "723f823",
    "arch": "linux/arm64",
    "config_hash": "sha256:9f3c…"
  },
  "process": { "started_at": "2026-09-01T08:12:44Z", "rss_bytes": 26214400, "goroutines": 19 },
  "pipeline": {
    "message_count": 184203311,
    "handler_rows_read": 184203311,
    "error_count": 12,
    "sink_flush_count": 1842033,
    "sink_rows_accepted": 184203311,
    "sink_rows_written": 184203311,
    "state_commit_count": 1842033,
    "state_db_size_bytes": 4194304
  },
  "last_message_at": "2026-09-11T09:51:43Z"
}
```

Under 1 KiB, and a test holds it there. Field names are the OTel instrument names, not the Prometheus series names: `message_count`, not `message_count_messages_total`. Those suffixes belong to one exporter's rendering, and the bundle reads the instrument.

Four rules make it a protocol rather than a payload:

1. **Counters are totals since `started_at`.** The receiver derives rates. An instance that computes its own rate must remember the previous sample, and remembered state is what goes wrong on a device that reboots.
2. **Restarts are derived, not reported.** A new `started_at` is a restart. The process that died cannot say so.
3. **Histograms are excluded.** Buckets are most of a scrape by bytes and the first page reads none of them.
4. **`state_db_size_bytes` is omitted, not zero,** when there is no state path. Absent state and empty state are different facts, which is the rule `/stats` already follows.

## Two numbers that were wrong, and the rule that fixes them

The first draft had `Collect` sum each instrument's attribute sets. That is arithmetic which silently encodes a policy, and it produced two wrong numbers: `sink_flush_count` and `state_commit_count` both carry `result=ok` and `result=error`, so the bundle reported **failed commits as commits and failed flushes as flushes**. A Prometheus user filters on `result` and never sees this. A bundle reader has no such option, and the sum made the call for them.

The rule now: **every number the bundle reports has its own dimensionless series, and `Collect` looks it up.** No summing, no filtering, no policy in the reader. Which measurements count is decided where they are recorded.

| Bundle field | Series read | Recorded |
|---|---|---|
| `message_count` | `message_count` | already dimensionless |
| `handler_rows_read` | `handler_rows_read` | already dimensionless |
| `error_count` | `pipeline_errors` | every error |
| `sink_flush_count` | `pipeline_flushes` | successes only |
| `state_commit_count` | `pipeline_commits` | successes only |
| `sink_rows_accepted` | `pipeline_rows_accepted` | pipeline role only |
| `sink_rows_written` | `pipeline_rows_written` | pipeline role only |
| `last_message_at` | `pipeline_last_message_timestamp` | once per received batch |

The row counters live in the counting sink, which already knows its role, so the DLQ's rows cannot reach them: a pipeline must not look healthier the more records it rejects. `SinkRolePipeline` is exported and shared with `internal/sinks` because a second spelling of the string would silently stop them recording.

These six export through Prometheus too. That is the cost of one instrument feeding both readers, and a global total is useful there anyway.

## consumer_lag leaves the bundle

It cannot be one number without summing partitions, and a websocket or webhook source has no offsets at all, so the Bluesky instance this demo is built on would have reported zero forever.

`last_message_at` replaces it: one timestamp, stamped once per received batch, meaningful for every source. Staleness is `sent_at` minus it, and since both come from the instance's own clock the difference carries no skew. It answers the question the fleet page actually asks, which is whether a process that is up is still doing anything.

Per-partition `consumer_lag` stays a Prometheus series, where PromQL can aggregate it.

## Version and commit moved packages

The bundle reports the stamped version, and `internal/cli/run` cannot import `internal/cli` without a cycle. Both now import `internal/buildinfo`. The Makefile, the Dockerfile and the release script stamp the new path.

Link-time rather than an environment variable on purpose: the version is a fact about the artifact, not a claim about the environment it started in. An operator who upgrades a binary and forgets to update an env var would report the old version forever, and on a fleet page that is the number you can least afford to be wrong. The release test compares the bundle's version against what the image prints, which is what catches a stamping site that missed the move.

## Flags

`--turbostats` starts the HTTP server on `:8000` and mounts the endpoint. It is independent of `--metrics=prometheus`; either starts the server, neither is on by default. A device should not listen on a port unless told to. `/stats` is untouched, and the bundle's state size reads through the same function so the two cannot disagree.

## Verification conventions

This PR adds them too, since it is the change that needed them. `CONTRIBUTING.md` names five checks and the command for each, `.github/PULL_REQUEST_TEMPLATE.md` asks for pasted output rather than adjectives, and `make soak` is the new memory gate.

- `go test -short -race ./...`: 20 packages, no failures, no races.
- 22 new unit tests. Four drive a real consume loop against a sink whose flush fails and prove `pipeline_flushes` stays at zero while `pipeline_errors` moves.
- `uv run --locked pytest tests/tooling -q`: 205 passing.
- `make coverage-page && git status --short docs/coverage`: clean.
- The release test starts the shipped image with `--turbostats`, reads the bundle, checks its version against what the image prints, and asserts `last_message_at` is absent on a pipeline that has received nothing.

### Soak verdict

Ten minutes against a saturated topic, polling `/turbostats/v1` once a second, against `v1.1.0-15-g2d05962`:

```
window        minutes 3-10, 105,286,937 messages
native        21.5 -> 22.1 MiB
go retained   24.9 -> 25.1 MiB
native slope  +0.168 MiB/min
go slope      +0.008 MiB/min
per message   +0.006 B/msg (threshold 1.0)

PASS  memory is flat over 105,286,937 messages
```

0.006 B/msg over 105 million messages, against the 44 B/msg leak this gate exists to catch. The endpoint is polled for the whole run because `Collect` builds a bundle and walks the metric data per request, so it leaks in proportion to requests, which a once-a-minute sampler would take hours to surface.

The judgement is bytes per message, not megabytes per minute: a leak is linear in messages, so per-message growth compares across machines and rates while MiB/min compares across neither. Volume is part of the gate, and a run under a million messages fails as proving nothing.

### What the gate caught in itself

Three defects, before it judged any code, each producing a result that read as real:

- **Two samplers wrote one `decomp.csv`.** Their rows interleaved, so the window and message count belonged to neither run. Both scripts now refuse a second writer, and the verdict rejects any file whose minutes do not ascend.
- **The producer finished early.** A fixed record count drained in under two minutes and left the pipeline idle. Memory was textbook flat across that window and the verdict failed it anyway, on zero messages. It is deadline-driven and throttled now.
- **The topic had no retention bound.** Ten minutes at this rate is tens of gigabytes, against 62 GB free.

### Where the benchmark's ~250 MiB goes

Worth recording, since this soak reports 47 MiB resident and the README advertises about a quarter GiB. They measure different regimes, and native memory is identical in both:

| | Draining a backlog | Steady state |
|---|---|---|
| Resident anon | 286.7 MiB | 47.2 MiB |
| Go retained | 265.0 MiB | 25.1 MiB |
| Go heap in use | 232.1 MiB | 6.3 MiB |
| Native (cgo, DuckDB) | 21.7 MiB | 22.1 MiB |

All of the difference is Go heap holding fetched Kafka records. `fetch.max_bytes` defaults to 100 MiB with `prefetch: 2`, and `KafkaFetch`'s own comment gives the worst case as `(prefetch + 2) x brokers x max_bytes`. A consumer that is caught up never fills it.

## Not in this PR

PR 2: the `pipeline.turbostats` config block, the outbound reporter with its interval and jitter, and the final bundle a clean drain sends so a crash is the bundle that never came.
