### PR TITLE
Slow-moving data: liveness proven under trickle, surge, and silence

### DIFF
--- a/.claude/skills/slow-soak/SKILL.md
+++ b/.claude/skills/slow-soak/SKILL.md
@@ -42,12 +42,13 @@ Copy the directory first. A checkout under a running soak has bitten before.
     ./sample.sh sqlflow-slow soak 160 | tee soak/live.log
     python3 verdict.py soak/samples.csv 30
 
-`short` in place of `full` runs a ten minute profile for a dry run; give
-`sample.sh` 13 minutes for it. Do the dry run first: it takes ten minutes
-and it is how both harness defects so far were found, one in the sampler's
-cadence and one in a verdict rule that called a draining backlog a failure. The full profile is about two and a half
-hours: five minutes of surge, an hour of silence, an hour of trickle with
-gaps, then half an hour of silence.
+The full profile is about two and a half hours: five minutes of surge, an
+hour of silence, an hour of trickle with gaps, then half an hour of silence.
+
+`short` in place of `full` runs a ten minute profile; give `sample.sh` 13
+minutes for it. Do the dry run first. It is how both harness defects so far
+were found, one in the sampler's cadence and one in a verdict rule that
+called a draining backlog a failure.
 
 Do not map port 8000 or 6060 to the host unless you know they are free. The
 sampler reaches both through a sidecar on the container's network namespace,

--- a/.claude/skills/slow-soak/SKILL.md
+++ b/.claude/skills/slow-soak/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: slow-soak
+description: Use when a pipeline must be shown to stay live and correct under slow, bursty, or absent traffic for hours - latency on a trickle, the tail of a surge, idle commits, window closes on silence, and health reporting. Use before publishing a version floor that third parties will depend on.
+---
+
+# Slow soak
+
+Throughput proves nothing about a stream that trickles, stops, or never
+starts, and that is most streams most of the time. This runs a scripted
+profile against a real broker and judges seven rules once a minute. One line
+per sample; everything verbose stays in files.
+
+## The rule
+
+A slow stream breaks different things than a fast one. Every failure below
+has been real at least once:
+
+- A batch that never fills has to leave on a timer.
+- An offset has to commit after a batch of one.
+- An idle pipeline has to keep committing, and empty commits must cost
+  nothing on disk.
+- A window whose rows have stopped arriving has to close anyway. The stream
+  clock alone cannot close it, because a stopped stream never moves it.
+- A consumer has to stay joined to a broker it has not heard from in an hour.
+- Idle has to be distinguishable from stuck from outside the process.
+
+## Run it
+
+Copy the directory first. A checkout under a running soak has bitten before.
+
+    cp -r .claude/skills/slow-soak /tmp/slow-soak && cd /tmp/slow-soak
+    mkdir -p state soak
+    make -C <repo> start-backing-services
+
+    TOPIC=slow-$(date +%s)
+    docker run -d --name sqlflow-slow --network dev_default \
+      -v "$PWD":/conf -e SQLFLOW_TOPIC=$TOPIC \
+      turbolytics/sql-flow:<tag> \
+      run /conf/slow.yml --metrics=prometheus --with-http-debug
+
+    ./profile.sh kafka1 $TOPIC full > soak/profile.log 2>&1 &
+    ./sample.sh sqlflow-slow soak 160 | tee soak/live.log
+    python3 verdict.py soak/samples.csv 30
+
+`short` in place of `full` runs a ten minute profile for a dry run; give
+`sample.sh` 13 minutes for it. Do the dry run first: it takes ten minutes
+and it is how both harness defects so far were found, one in the sampler's
+cadence and one in a verdict rule that called a draining backlog a failure. The full profile is about two and a half
+hours: five minutes of surge, an hour of silence, an hour of trickle with
+gaps, then half an hour of silence.
+
+Do not map port 8000 or 6060 to the host unless you know they are free. The
+sampler reaches both through a sidecar on the container's network namespace,
+so no mapping is needed.
+
+## What each failure means
+
+| Verdict line | Where to look |
+| --- | --- |
+| worst latency above the interval | The flush ticker is not firing, or a flush is slow. `state_commit_latency_seconds` in /metrics. |
+| offset lag after the surge | Offsets are not committing per flush. `state_commit_count_commits_total` against the sample count. |
+| working set ended above the start | Something was held from the surge. Switch to the memory-soak skill, which decomposes it. |
+| state file grew through a silence | Empty commits are not empty. Check what the idle tick writes. |
+| windows still unpublished after the silence | The idleness branch of the window predicate did not fire. Read `sqlflow_progress` through /debug: a frozen `last_arrival` is the engine, a moving one is the predicate. |
+| healthz not 200 | The commit clock stopped. That is a real stall, not a quiet stream. |
+| landed below produced | Messages were lost, which no other rule here would catch on its own. |
+
+## What it does not cover
+
+Ordering, exactly-once, and late-arriving data. The engine is at-least-once
+and the window predicate closes on silence, so a row that arrives after its
+bucket closed publishes as a second part. That is by design and the docs say
+so; this soak does not judge it.

--- a/.claude/skills/slow-soak/SKILL.md
+++ b/.claude/skills/slow-soak/SKILL.md
@@ -38,17 +38,22 @@ Copy the directory first. A checkout under a running soak has bitten before.
       turbolytics/sql-flow:<tag> \
       run /conf/slow.yml --metrics=prometheus --with-http-debug
 
-    ./profile.sh kafka1 $TOPIC full > soak/profile.log 2>&1 &
-    ./sample.sh sqlflow-slow soak 160 | tee soak/live.log
+    ./profile.sh kafka1 $TOPIC medium > soak/profile.log 2>&1 &
+    ./sample.sh sqlflow-slow soak 22 | tee soak/live.log
     python3 verdict.py soak/samples.csv 30
 
-The full profile is about two and a half hours: five minutes of surge, an
-hour of silence, an hour of trickle with gaps, then half an hour of silence.
+`medium` is twenty minutes and is the one to run: two bursts, each followed
+by five minutes at zero, then a trickle and four more minutes at zero. What
+it proves is the shape that breaks things, traffic going to zero for longer
+than the window grace and then coming back.
 
-`short` in place of `full` runs a ten minute profile; give `sample.sh` 13
-minutes for it. Do the dry run first. It is how both harness defects so far
-were found, one in the sampler's cadence and one in a verdict rule that
-called a draining backlog a failure.
+`short` is ten minutes, for checking the harness itself; give `sample.sh`
+13 minutes. `full` is two and a half hours and exists only for something
+suspected of drifting slowly.
+
+Do a short run first when you change anything here. It is how both harness
+defects so far were found, one in the sampler's cadence and one in a
+verdict rule that called a draining backlog a failure.
 
 Do not map port 8000 or 6060 to the host unless you know they are free. The
 sampler reaches both through a sidecar on the container's network namespace,

--- a/.claude/skills/slow-soak/profile.sh
+++ b/.claude/skills/slow-soak/profile.sh
@@ -3,25 +3,38 @@
 # container so nothing crosses the host boundary and a dropped pipe cannot
 # end the run early.
 #
-#   profile.sh <kafka-container> <topic> [full|short]
+#   profile.sh <kafka-container> <topic> [medium|full|short]
 #
-# Phases:
-#   surge     1,000 messages a second      full 5m    short 2m
-#   silence   nothing                      full 60m   short 3m
-#   trickle   one message every 90s, with  full 60m   short 3m
-#             two gaps and one pair sent
-#             in the same second
-#   silence   nothing                      full 30m   short 2m
+# The shape that matters: traffic goes to zero, stays there longer than the
+# window grace, and comes back. A window that only closes when newer data
+# arrives would strand its last bucket in every one of those gaps, so each
+# silence is five times the 60 second grace and each return proves the
+# pipeline picks up where it left off.
+#
+#           medium (20m)          full (2h35m)        short (10m)
+#   burst   2m at 1,000/s         5m                  2m
+#   zero    5m                    60m                 3m
+#   burst   1m at 1,000/s         -                   -
+#   zero    5m                    -                   -
+#   trickle 3m, one every 90s     60m, every 90s      3m, every 20s
+#   zero    4m                    30m                 2m
+#
+# medium is the one to run. Every invariant here is observable within
+# minutes: the window grace is 60 seconds, the flush interval 30, and an
+# idle commit lands every interval. full exists only for something suspected
+# of drifting slowly.
 #
 # Every message carries sent_at, which is how the sampler measures latency.
 set -uo pipefail
 kafka=${1:?kafka container}; topic=${2:?topic}; mode=${3:-full}
 
-if [ "$mode" = short ]; then
-  surge=120; s1=180; trickle=180; s2=120; tick=20
-else
-  surge=300; s1=3600; trickle=3600; s2=1800; tick=90
-fi
+# Each phase is "kind:seconds"; kind is burst, zero or trickle.
+case "$mode" in
+  short)  phases="burst:120 zero:180 trickle:180 zero:120"; tick=20 ;;
+  medium) phases="burst:120 zero:300 burst:60 zero:300 trickle:180 zero:240"; tick=90 ;;
+  full)   phases="burst:300 zero:3600 trickle:3600 zero:1800"; tick=90 ;;
+  *) echo "unknown mode: $mode (short|medium|full)" >&2; exit 2 ;;
+esac
 
 id=0
 send() {
@@ -32,36 +45,36 @@ send() {
   echo "$(date -u +%H:%M:%SZ) phase=$phase sent=$n total=$id"
 }
 
-phase=surge
-echo "$(date -u +%H:%M:%SZ) phase=surge for ${surge}s"
-end=$((SECONDS + surge))
-while [ $SECONDS -lt $end ]; do send 1000; sleep 1; done
+n=0
+for spec in $phases; do
+  kind=${spec%%:*}
+  secs=${spec##*:}
+  n=$((n + 1))
+  phase="${kind}${n}"
+  echo "$(date -u +%H:%M:%SZ) phase=$phase for ${secs}s total=$id"
 
-phase=silence1
-echo "$(date -u +%H:%M:%SZ) phase=silence1 for ${s1}s total=$id"
-sleep "$s1"
-
-phase=trickle
-echo "$(date -u +%H:%M:%SZ) phase=trickle for ${trickle}s, one every ${tick}s"
-end=$((SECONDS + trickle))
-gap_at=$((SECONDS + trickle / 3))
-pair_at=$((SECONDS + trickle / 2))
-while [ $SECONDS -lt $end ]; do
-  # One deliberate long gap, several ticks wide, inside the trickle.
-  if [ $SECONDS -ge $gap_at ] && [ $SECONDS -lt $((gap_at + tick * 3)) ]; then
-    sleep 10; continue
-  fi
-  # One pair in the same second, so a batch holding two is exercised too.
-  if [ $SECONDS -ge $pair_at ] && [ $SECONDS -lt $((pair_at + tick)) ]; then
-    send 2; pair_at=$end
-  else
-    send 1
-  fi
-  sleep "$tick"
+  case "$kind" in
+    burst)
+      end=$((SECONDS + secs))
+      while [ $SECONDS -lt $end ]; do send 1000; sleep 1; done
+      ;;
+    zero)
+      sleep "$secs"
+      ;;
+    trickle)
+      end=$((SECONDS + secs))
+      pair_at=$((SECONDS + secs / 2))
+      while [ $SECONDS -lt $end ]; do
+        # One pair in the same second, so a batch holding two is exercised.
+        if [ $SECONDS -ge $pair_at ] && [ $SECONDS -lt $((pair_at + tick)) ]; then
+          send 2; pair_at=$end
+        else
+          send 1
+        fi
+        sleep "$tick"
+      done
+      ;;
+  esac
 done
-
-phase=silence2
-echo "$(date -u +%H:%M:%SZ) phase=silence2 for ${s2}s total=$id"
-sleep "$s2"
 
 echo "$(date -u +%H:%M:%SZ) PROFILE_DONE total=$id"

--- a/.claude/skills/slow-soak/profile.sh
+++ b/.claude/skills/slow-soak/profile.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Feed a topic with a scripted traffic profile, from inside the Kafka
+# container so nothing crosses the host boundary and a dropped pipe cannot
+# end the run early.
+#
+#   profile.sh <kafka-container> <topic> [full|short]
+#
+# Phases:
+#   surge     1,000 messages a second      full 5m    short 2m
+#   silence   nothing                      full 60m   short 3m
+#   trickle   one message every 90s, with  full 60m   short 3m
+#             two gaps and one pair sent
+#             in the same second
+#   silence   nothing                      full 30m   short 2m
+#
+# Every message carries sent_at, which is how the sampler measures latency.
+set -uo pipefail
+kafka=${1:?kafka container}; topic=${2:?topic}; mode=${3:-full}
+
+if [ "$mode" = short ]; then
+  surge=120; s1=180; trickle=180; s2=120; tick=20
+else
+  surge=300; s1=3600; trickle=3600; s2=1800; tick=90
+fi
+
+id=0
+send() {
+  local n=$1 ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%S)
+  docker exec -i "$kafka" bash -c "awk -v s=$id -v n=$n -v ts=$ts 'BEGIN{for(i=0;i<n;i++) printf \"{\\\"id\\\":%d,\\\"sent_at\\\":\\\"%s\\\"}\n\", s+i, ts}' | kafka-console-producer --bootstrap-server localhost:19092 --topic $topic >/dev/null 2>&1"
+  id=$((id + n))
+  echo "$(date -u +%H:%M:%SZ) phase=$phase sent=$n total=$id"
+}
+
+phase=surge
+echo "$(date -u +%H:%M:%SZ) phase=surge for ${surge}s"
+end=$((SECONDS + surge))
+while [ $SECONDS -lt $end ]; do send 1000; sleep 1; done
+
+phase=silence1
+echo "$(date -u +%H:%M:%SZ) phase=silence1 for ${s1}s total=$id"
+sleep "$s1"
+
+phase=trickle
+echo "$(date -u +%H:%M:%SZ) phase=trickle for ${trickle}s, one every ${tick}s"
+end=$((SECONDS + trickle))
+gap_at=$((SECONDS + trickle / 3))
+pair_at=$((SECONDS + trickle / 2))
+while [ $SECONDS -lt $end ]; do
+  # One deliberate long gap, several ticks wide, inside the trickle.
+  if [ $SECONDS -ge $gap_at ] && [ $SECONDS -lt $((gap_at + tick * 3)) ]; then
+    sleep 10; continue
+  fi
+  # One pair in the same second, so a batch holding two is exercised too.
+  if [ $SECONDS -ge $pair_at ] && [ $SECONDS -lt $((pair_at + tick)) ]; then
+    send 2; pair_at=$end
+  else
+    send 1
+  fi
+  sleep "$tick"
+done
+
+phase=silence2
+echo "$(date -u +%H:%M:%SZ) phase=silence2 for ${s2}s total=$id"
+sleep "$s2"
+
+echo "$(date -u +%H:%M:%SZ) PROFILE_DONE total=$id"

--- a/.claude/skills/slow-soak/sample.sh
+++ b/.claude/skills/slow-soak/sample.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Sample a running slow-soak pipeline once a minute.
+#
+#   sample.sh <container-name> <out-dir> <minutes>
+#
+# Columns: t, phase, produced, landed, max_latency_s, lag, anon_mib,
+# state_bytes, published_windows, healthz. One line per sample to stdout and
+# to samples.csv; everything verbose stays in the container's own log.
+set -uo pipefail
+name=${1:?container}; out=${2:?out dir}; minutes=${3:?minutes}
+mkdir -p "$out"
+csv="$out/samples.csv"
+echo "t,phase,produced,landed,max_latency_s,lag,anon_mib,state_bytes,published_windows,healthz" > "$csv"
+
+# One sidecar per sample, not one per query. Five `docker run` calls a
+# sample made an iteration take five minutes on a busy daemon, which
+# silently destroyed the per-minute granularity every rule below depends on.
+# This issues every query in one container and prints them tab separated.
+#
+# /debug answers [[v]] for a one-value query; /healthz answers a status code.
+probe() {
+  docker run --rm --network "container:$name" --entrypoint sh curlimages/curl:latest -c '
+    q() { curl -s --max-time 10 --get --data-urlencode "sql=$1" http://127.0.0.1:5000/debug; }
+    printf "%s\t" "$(q "SELECT coalesce((SELECT sum(count) FROM agg_slow),0) + coalesce((SELECT sum(count) FROM published),0)")"
+    printf "%s\t" "$(q "SELECT round(greatest(coalesce((SELECT max(max_latency_s) FROM agg_slow),0), coalesce((SELECT max(max_latency_s) FROM published),0)),1)")"
+    printf "%s\t" "$(q "SELECT coalesce(max(\"offset\"),-1) FROM sqlflow_offsets")"
+    printf "%s\t" "$(q "SELECT count(*) FROM published")"
+    printf "%s"   "$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://127.0.0.1:8000/healthz)"
+  ' 2>/dev/null
+}
+
+# scalar pulls the value out of [[v]], or empty when the query failed.
+scalar() {
+  python3 -c '
+import json,sys
+try:
+    r = json.loads(sys.argv[1])
+    print(r[0][0] if r and r[0] and r[0][0] is not None else "")
+except Exception:
+    print("")' "$1" 2>/dev/null
+}
+
+for ((i = 0; i < minutes; i++)); do
+  t=$(date -u +%H:%M:%SZ)
+  phase=$(grep -o 'phase=[a-z0-9]*' "$out/profile.log" 2>/dev/null | tail -1 | cut -d= -f2)
+  produced=$(grep -o 'total=[0-9]*' "$out/profile.log" 2>/dev/null | tail -1 | cut -d= -f2)
+
+  IFS=$'\t' read -r r_landed r_lat r_off r_pub r_hz <<< "$(probe)"
+  landed=$(scalar "$r_landed")
+  lat=$(scalar "$r_lat")
+  committed=$(scalar "$r_off")
+  pub=$(scalar "$r_pub")
+  hz=$r_hz
+
+  lag=$(( ${produced:-0} - 1 - ${committed:--1} ))
+  [ "${produced:-0}" -eq 0 ] && lag=0
+
+  anon=$(docker exec "$name" sh -c 'awk "/^anon /{print int(\$2/1048576)}" /sys/fs/cgroup/memory.stat 2>/dev/null' 2>/dev/null)
+  state=$(docker exec "$name" sh -c 'stat -c %s /conf/state/slow.db 2>/dev/null' 2>/dev/null)
+
+  echo "$t,${phase:-},${produced:-0},${landed:-},${lat:-},${lag},${anon:-},${state:-},${pub:-},${hz:-}" | tee -a "$csv"
+  sleep 60
+done
+echo "SAMPLING_DONE" | tee -a "$csv"

--- a/.claude/skills/slow-soak/slow.yml
+++ b/.claude/skills/slow-soak/slow.yml
@@ -1,0 +1,81 @@
+commands:
+  - name: publication log
+    sql: |
+      CREATE TABLE IF NOT EXISTS published (
+        bucket        TIMESTAMPTZ,
+        count         BIGINT,
+        max_latency_s DOUBLE,
+        published_at  TIMESTAMPTZ
+      );
+
+tables:
+  sql:
+    # One table carries both things the soak judges: how many messages landed
+    # in each minute, and the worst time any of them took to get from the
+    # producer to the handler. Keeping them together means a window that
+    # publishes carries its own latency evidence with it.
+    - name: agg_slow
+      sql: |
+        CREATE TABLE IF NOT EXISTS agg_slow (
+          bucket        TIMESTAMPTZ,
+          count         BIGINT,
+          max_latency_s DOUBLE
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS agg_slow_idx ON agg_slow (bucket);
+      manager:
+        tumbling_window:
+          poll_interval_seconds: 10
+          # Both branches, as the shipped examples carry them. The second one
+          # is what this soak exists to exercise: an hour of silence must
+          # still close the surge's last window.
+          collect_closed_windows_sql: |
+            SELECT bucket, count, max_latency_s
+            FROM agg_slow
+            WHERE bucket < (SELECT max(bucket) FROM agg_slow) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
+          delete_closed_windows_sql: |
+            DELETE FROM agg_slow
+            WHERE bucket < (SELECT max(bucket) FROM agg_slow) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
+        sink:
+          type: sqlcommand
+          sqlcommand:
+            sql: |
+              INSERT INTO published
+              SELECT bucket, count, max_latency_s, now()
+              FROM sqlflow_sink_batch
+
+pipeline:
+  name: slow-soak
+  description: "Liveness under trickle, surge and silence"
+  # Large enough that a trickle never fills it: every batch leaves on the
+  # interval, which is the property under test.
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default('5000') }}
+  flush_interval_seconds: {{ SQLFLOW_FLUSH_INTERVAL|default('30') }}
+  state:
+    path: {{ SQLFLOW_STATE_PATH|default('/conf/state/slow.db') }}
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('kafka1:19092') }}]
+      group_id: {{ SQLFLOW_GROUP_ID|default('slow-soak') }}
+      auto_offset_reset: earliest
+      topics:
+        - "{{ SQLFLOW_TOPIC|default('slow-soak') }}"
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: |
+      INSERT INTO agg_slow
+      BY NAME
+      SELECT
+        date_trunc('minute', CAST(sent_at AS TIMESTAMPTZ)) AS bucket,
+        count(*) AS count,
+        max(epoch(now() - CAST(sent_at AS TIMESTAMPTZ))) AS max_latency_s
+      FROM batch
+      GROUP BY bucket
+      ON CONFLICT (bucket)
+      DO UPDATE SET
+        count = count + EXCLUDED.count,
+        max_latency_s = greatest(max_latency_s, EXCLUDED.max_latency_s)
+  sink:
+    type: noop

--- a/.claude/skills/slow-soak/verdict.py
+++ b/.claude/skills/slow-soak/verdict.py
@@ -1,0 +1,92 @@
+"""Judge a slow-soak samples.csv. Exit 1 on any failed rule, printing each.
+
+Usage: verdict.py <samples.csv> [flush_interval_seconds]
+"""
+import csv
+import sys
+
+path = sys.argv[1]
+interval = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+
+rows = [r for r in csv.DictReader(open(path)) if r.get("t") and not r["t"].startswith("SAMPLING")]
+if not rows:
+    sys.exit("no samples")
+
+
+def f(x, d=0.0):
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return d
+
+
+fails = []
+
+# 1. Latency: a message must reach the handler within the flush interval,
+# plus slack for the sampler's own minute of granularity.
+worst = max(f(r["max_latency_s"]) for r in rows)
+if worst > interval + 60:
+    fails.append(f"worst latency {worst:.0f}s is above the interval plus a minute")
+
+# 2. Lag: the surge's backlog drains promptly once production stops, and
+# then stays drained. Being behind during the surge, and for the first
+# samples after it, is the consumer catching up and is not a defect. What
+# would be a defect is never catching up, or falling behind again on a
+# trickle where every message has a flush to itself.
+post = [r for r in rows if r["phase"] in ("silence1", "trickle", "silence2")]
+drained_at = next((i for i, r in enumerate(post) if f(r["lag"], 0) <= 2), None)
+if post and drained_at is None:
+    fails.append(f"the backlog never drained; lag was still {post[-1]['lag']} at the end")
+elif drained_at is not None and drained_at > 3:
+    fails.append(f"the backlog took {drained_at} samples after the surge to drain")
+else:
+    for r in post[(drained_at or 0) + 1:]:
+        if f(r["lag"], 0) > 2:
+            fails.append(f"fell behind again after draining: lag {r['lag']} at {r['t']} in {r['phase']}")
+            break
+
+# 3. Memory: the end of the run is not above where the run started.
+anon = [f(r["anon_mib"]) for r in rows if r["anon_mib"]]
+if anon and anon[-1] > anon[0] * 1.10 + 5:
+    fails.append(f"working set ended at {anon[-1]:.0f} MiB against {anon[0]:.0f} at the start")
+
+# 4. State file: it must not grow while nothing is arriving.
+for phase in ("silence1", "silence2"):
+    win = [r for r in rows if r["phase"] == phase and r["state_bytes"]]
+    if len(win) >= 3 and f(win[-1]["state_bytes"]) > f(win[0]["state_bytes"]) * 1.05:
+        fails.append(
+            f"state file grew through {phase}: "
+            f"{f(win[0]['state_bytes']):.0f} to {f(win[-1]['state_bytes']):.0f} bytes"
+        )
+
+# 5. Windows: the surge's buckets must publish during the silence that
+# follows it. This is the idleness branch, and the reason the soak exists.
+after_surge = [r for r in rows if r["phase"] in ("silence1", "trickle", "silence2")]
+if after_surge and f(after_surge[-1]["published_windows"]) == 0:
+    fails.append("no window was ever published, so the idleness branch never fired")
+sil1 = [r for r in rows if r["phase"] == "silence1"]
+if len(sil1) >= 3 and f(sil1[-1]["published_windows"]) == 0:
+    fails.append("the surge's windows were still unpublished at the end of the first silence")
+
+# 6. Health: idle is healthy, so a red sample is a real failure.
+red = [r["t"] for r in rows if r["healthz"] and r["healthz"] != "200"]
+if red:
+    fails.append(f"healthz was not 200 at {len(red)} samples, first {red[0]}")
+
+# 7. Everything produced eventually lands.
+last = rows[-1]
+if f(last["produced"]) and f(last["landed"]) < f(last["produced"]) * 0.999:
+    fails.append(f"landed {last['landed']} of {last['produced']} produced")
+
+if fails:
+    print("FAIL")
+    for x in fails:
+        print(" -", x)
+    sys.exit(1)
+
+print(
+    f"PASS over {len(rows)} samples: worst latency {worst:.0f}s, "
+    f"working set {anon[0]:.0f} to {anon[-1]:.0f} MiB, "
+    f"{f(last['landed']):.0f} of {f(last['produced']):.0f} messages landed, "
+    f"{f(last['published_windows']):.0f} windows published"
+)

--- a/.claude/skills/slow-soak/verdict.py
+++ b/.claude/skills/slow-soak/verdict.py
@@ -33,7 +33,9 @@ if worst > interval + 60:
 # samples after it, is the consumer catching up and is not a defect. What
 # would be a defect is never catching up, or falling behind again on a
 # trickle where every message has a flush to itself.
-post = [r for r in rows if r["phase"] in ("silence1", "trickle", "silence2")]
+# Everything after the first burst: the drain, the zeros, the trickle.
+first_burst_end = next((i for i, r in enumerate(rows) if not r["phase"].startswith("burst")), len(rows))
+post = rows[first_burst_end:]
 drained_at = next((i for i, r in enumerate(post) if f(r["lag"], 0) <= 2), None)
 if post and drained_at is None:
     fails.append(f"the backlog never drained; lag was still {post[-1]['lag']} at the end")
@@ -51,7 +53,7 @@ if anon and anon[-1] > anon[0] * 1.10 + 5:
     fails.append(f"working set ended at {anon[-1]:.0f} MiB against {anon[0]:.0f} at the start")
 
 # 4. State file: it must not grow while nothing is arriving.
-for phase in ("silence1", "silence2"):
+for phase in sorted({r["phase"] for r in rows if r["phase"].startswith("zero")}):
     win = [r for r in rows if r["phase"] == phase and r["state_bytes"]]
     if len(win) >= 3 and f(win[-1]["state_bytes"]) > f(win[0]["state_bytes"]) * 1.05:
         fails.append(
@@ -61,12 +63,15 @@ for phase in ("silence1", "silence2"):
 
 # 5. Windows: the surge's buckets must publish during the silence that
 # follows it. This is the idleness branch, and the reason the soak exists.
-after_surge = [r for r in rows if r["phase"] in ("silence1", "trickle", "silence2")]
-if after_surge and f(after_surge[-1]["published_windows"]) == 0:
+if post and f(post[-1]["published_windows"]) == 0:
     fails.append("no window was ever published, so the idleness branch never fired")
-sil1 = [r for r in rows if r["phase"] == "silence1"]
-if len(sil1) >= 3 and f(sil1[-1]["published_windows"]) == 0:
-    fails.append("the surge's windows were still unpublished at the end of the first silence")
+# Every zero phase longer than a couple of samples must end with more
+# windows published than it began with, unless there was nothing open. That
+# is the whole point: a stream at zero still closes what it was holding.
+for phase in sorted({r["phase"] for r in rows if r["phase"].startswith("zero")}):
+    win = [r for r in rows if r["phase"] == phase]
+    if len(win) >= 3 and f(win[-1]["published_windows"]) == f(win[0]["published_windows"]) == 0:
+        fails.append(f"{phase} published no window, so a bucket was stranded at zero traffic")
 
 # 6. Health: idle is healthy, so a red sample is a real failure.
 red = [r["t"] for r in rows if r["healthz"] and r["healthz"] != "200"]

--- a/.claude/skills/slow-soak/verdict.py
+++ b/.claude/skills/slow-soak/verdict.py
@@ -28,24 +28,22 @@ worst = max(f(r["max_latency_s"]) for r in rows)
 if worst > interval + 60:
     fails.append(f"worst latency {worst:.0f}s is above the interval plus a minute")
 
-# 2. Lag: the surge's backlog drains promptly once production stops, and
-# then stays drained. Being behind during the surge, and for the first
-# samples after it, is the consumer catching up and is not a defect. What
-# would be a defect is never catching up, or falling behind again on a
-# trickle where every message has a flush to itself.
-# Everything after the first burst: the drain, the zeros, the trickle.
-first_burst_end = next((i for i, r in enumerate(rows) if not r["phase"].startswith("burst")), len(rows))
-post = rows[first_burst_end:]
-drained_at = next((i for i, r in enumerate(post) if f(r["lag"], 0) <= 2), None)
-if post and drained_at is None:
-    fails.append(f"the backlog never drained; lag was still {post[-1]['lag']} at the end")
-elif drained_at is not None and drained_at > 3:
-    fails.append(f"the backlog took {drained_at} samples after the surge to drain")
-else:
-    for r in post[(drained_at or 0) + 1:]:
-        if f(r["lag"], 0) > 2:
-            fails.append(f"fell behind again after draining: lag {r['lag']} at {r['t']} in {r['phase']}")
-            break
+# 2. Lag: a burst is meant to run ahead of the consumer, so being behind
+# during one proves nothing. What matters is that every quiet phase ends
+# with the backlog gone, and that a trickle, where each message has a flush
+# to itself, never accumulates one.
+def phases_of(prefix):
+    return sorted({r["phase"] for r in rows if r["phase"].startswith(prefix)})
+
+
+for phase in phases_of("zero") + phases_of("trickle"):
+    win = [r for r in rows if r["phase"] == phase]
+    if not win:
+        continue
+    if f(win[-1]["lag"], 0) > 2:
+        fails.append(
+            f"{phase} ended with the backlog still {win[-1]['lag']} behind"
+        )
 
 # 3. Memory: the end of the run is not above where the run started.
 anon = [f(r["anon_mib"]) for r in rows if r["anon_mib"]]
@@ -63,7 +61,7 @@ for phase in sorted({r["phase"] for r in rows if r["phase"].startswith("zero")})
 
 # 5. Windows: the surge's buckets must publish during the silence that
 # follows it. This is the idleness branch, and the reason the soak exists.
-if post and f(post[-1]["published_windows"]) == 0:
+if rows and f(rows[-1]["published_windows"]) == 0:
     fails.append("no window was ever published, so the idleness branch never fired")
 # Every zero phase longer than a couple of samples must end with more
 # windows published than it began with, unless there was nothing open. That

--- a/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.kafka.windowed.yml
@@ -27,6 +27,15 @@ tables:
           #
           # The trade: the newest window waits for a later one, so a stream
           # that stops leaves its final window unpublished.
+          #
+          # The second branch is the idleness bound. A stream that goes quiet
+          # never moves its own clock, so the first branch alone would hold
+          # the newest window open until data a full grace newer arrived: a
+          # surge that stops leaves its last bucket unpublished forever.
+          # sqlflow_progress is the engine's one-row liveness table and
+          # last_arrival is when the newest batch was written, so after a
+          # grace of silence every open window closes. It is TIMESTAMPTZ, so
+          # the comparison holds whatever timezone the host runs in.
         tumbling_window:
           collect_closed_windows_sql: |
             SELECT 
@@ -35,10 +44,12 @@ tables:
               count
             FROM agg_post_kind_count_1_minute
             WHERE bucket < (SELECT max(bucket) FROM agg_post_kind_count_1_minute) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
 
           delete_closed_windows_sql: |
             DELETE FROM agg_post_kind_count_1_minute
             WHERE bucket < (SELECT max(bucket) FROM agg_post_kind_count_1_minute) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
 
         sink:
           type: kafka

--- a/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
+++ b/dev/config/examples/bluesky/bluesky.postgres.windowed.yml
@@ -50,15 +50,26 @@ tables:
           #
           # The trade: the newest window waits for a later one, so a stream
           # that stops leaves its final window unpublished.
+          #
+          # The second branch is the idleness bound. A stream that goes quiet
+          # never moves its own clock, so the first branch alone would hold
+          # the newest window open until data a full grace newer arrived: a
+          # surge that stops leaves its last bucket unpublished forever.
+          # sqlflow_progress is the engine's one-row liveness table and
+          # last_arrival is when the newest batch was written, so after a
+          # grace of silence every open window closes. It is TIMESTAMPTZ, so
+          # the comparison holds whatever timezone the host runs in.
         tumbling_window:
           poll_interval_seconds: 10
           collect_closed_windows_sql: |
             SELECT bucket, lang, posts
             FROM posts_per_minute_by_lang
             WHERE bucket + INTERVAL '1 minute' < (SELECT max(bucket) FROM posts_per_minute_by_lang) - INTERVAL '60 seconds'
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '1 minute'
           delete_closed_windows_sql: |
             DELETE FROM posts_per_minute_by_lang
             WHERE bucket + INTERVAL '1 minute' < (SELECT max(bucket) FROM posts_per_minute_by_lang) - INTERVAL '60 seconds'
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '1 minute'
 
         sink:
           type: sqlcommand

--- a/dev/config/examples/kafka.stateful.window.yml
+++ b/dev/config/examples/kafka.stateful.window.yml
@@ -34,6 +34,15 @@ tables:
           #
           # The trade: the newest window waits for a later one, so a stream
           # that stops leaves its final window unpublished.
+          #
+          # The second branch is the idleness bound. A stream that goes quiet
+          # never moves its own clock, so the first branch alone would hold
+          # the newest window open until data a full grace newer arrived: a
+          # surge that stops leaves its last bucket unpublished forever.
+          # sqlflow_progress is the engine's one-row liveness table and
+          # last_arrival is when the newest batch was written, so after a
+          # grace of silence every open window closes. It is TIMESTAMPTZ, so
+          # the comparison holds whatever timezone the host runs in.
         tumbling_window:
           poll_interval_seconds: 3600
           collect_closed_windows_sql: |
@@ -43,9 +52,11 @@ tables:
               count
             FROM agg_city_count
             WHERE bucket < (SELECT max(bucket) FROM agg_city_count) - INTERVAL '3600' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '3600' SECOND
           delete_closed_windows_sql: |
             DELETE FROM agg_city_count
             WHERE bucket < (SELECT max(bucket) FROM agg_city_count) - INTERVAL '3600' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '3600' SECOND
 
         sink:
           type: console

--- a/dev/config/examples/published/README.md
+++ b/dev/config/examples/published/README.md
@@ -14,6 +14,7 @@ generated JSON schema.
 | `clickhouse.taxi.yml` | ClickHouse docs, the NYC taxi walkthrough |
 | `clickhouse.bluesky.yml` | ClickHouse docs, the WebSocket example |
 | `motherduck.bluesky.websocket.yml` | MotherDuck cookbook, `sqlflow-streaming-websocket` |
+| `tigerdata.enrich.yml` | TigerData docs, `integrate/data-ingestion-streaming/sqlflow` |
 
 When a page changes, change the file here first and copy it out. When the
 engine changes, CI tells you which published page needs an edit before a

--- a/dev/config/examples/published/README.md
+++ b/dev/config/examples/published/README.md
@@ -1,0 +1,20 @@
+# Configs we publish
+
+Every config that appears in third-party documentation lives here. The pages
+copy from these files; these files are the source of truth.
+
+The reason is the version floor. A config that only exists in a vendor's docs
+is checked by nobody, so it drifts with the engine and the first person to
+notice is a reader following the page. Here, the three checks that already
+walk `dev/config/examples` cover them: the CLI validator, the loader, and the
+generated JSON schema.
+
+| File | Published in |
+| --- | --- |
+| `clickhouse.taxi.yml` | ClickHouse docs, the NYC taxi walkthrough |
+| `clickhouse.bluesky.yml` | ClickHouse docs, the WebSocket example |
+| `motherduck.bluesky.websocket.yml` | MotherDuck cookbook, `sqlflow-streaming-websocket` |
+
+When a page changes, change the file here first and copy it out. When the
+engine changes, CI tells you which published page needs an edit before a
+reader finds out.

--- a/dev/config/examples/published/clickhouse.bluesky.yml
+++ b/dev/config/examples/published/clickhouse.bluesky.yml
@@ -1,0 +1,20 @@
+pipeline:
+  batch_size: 200
+  source:
+    type: websocket
+    websocket:
+      uri: 'wss://jetstream2.us-east.bsky.network/subscribe?wantedCollections=app.bsky.feed.post'
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: |
+      SELECT
+        to_timestamp(time_us / 1000000)          AS ts,
+        did,
+        COALESCE(commit.record.langs, [])       AS langs,
+        COALESCE(commit.record.text, '')        AS text
+      FROM batch
+  sink:
+    type: clickhouse
+    clickhouse:
+      dsn: {{ SQLFLOW_CLICKHOUSE_DSN }}
+      table: bluesky_posts

--- a/dev/config/examples/published/clickhouse.taxi.yml
+++ b/dev/config/examples/published/clickhouse.taxi.yml
@@ -1,0 +1,41 @@
+pipeline:
+  name: nyc-taxi-clickhouse
+  batch_size: 20000
+
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('localhost:9092') }}]
+      group_id: nyc-taxi
+      auto_offset_reset: earliest
+      topics:
+        - nyc-taxi-trips
+
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: |
+      SELECT
+        CAST(trip_id AS UINTEGER)            AS trip_id,
+        CAST(pickup_datetime AS TIMESTAMP)   AS pickup_datetime,
+        CAST(dropoff_datetime AS TIMESTAMP)  AS dropoff_datetime,
+        pickup_longitude,
+        pickup_latitude,
+        dropoff_longitude,
+        dropoff_latitude,
+        CAST(passenger_count AS UTINYINT)    AS passenger_count,
+        CAST(trip_distance AS FLOAT)         AS trip_distance,
+        CAST(fare_amount AS FLOAT)           AS fare_amount,
+        CAST(extra AS FLOAT)                 AS extra,
+        CAST(tip_amount AS FLOAT)            AS tip_amount,
+        CAST(tolls_amount AS FLOAT)          AS tolls_amount,
+        CAST(total_amount AS FLOAT)          AS total_amount,
+        payment_type,
+        pickup_ntaname,
+        dropoff_ntaname
+      FROM batch
+
+  sink:
+    type: clickhouse
+    clickhouse:
+      dsn: {{ SQLFLOW_CLICKHOUSE_DSN }}
+      table: trips_small

--- a/dev/config/examples/published/motherduck.bluesky.websocket.yml
+++ b/dev/config/examples/published/motherduck.bluesky.websocket.yml
@@ -1,0 +1,47 @@
+commands:
+  - name: attach motherduck
+    sql: |
+      ATTACH 'md:{{ SQLFLOW_MD_DATABASE|default('my_db') }}'
+
+  - name: create the target table
+    sql: |
+      CREATE TABLE IF NOT EXISTS {{ SQLFLOW_MD_DATABASE|default('my_db') }}.{{ SQLFLOW_MD_TABLE|default('bluesky_posts') }} (
+        did VARCHAR,
+        event_time TIMESTAMP,
+        operation VARCHAR,
+        collection VARCHAR,
+        post_text VARCHAR,
+        lang VARCHAR
+      );
+
+pipeline:
+  name: bluesky-motherduck
+  description: "Streams the Bluesky firehose into MotherDuck"
+
+  # Rows per INSERT. Larger batches mean fewer round trips to MotherDuck and a
+  # longer wait before the first row lands.
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default(500) }}
+
+  source:
+    type: websocket
+    websocket:
+      uri: '{{ SQLFLOW_WEBSOCKET_URI|default("wss://jetstream2.us-east.bsky.network/subscribe?wantedCollections=app.bsky.feed.post") }}'
+
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: |
+      INSERT INTO {{ SQLFLOW_MD_DATABASE|default('my_db') }}.{{ SQLFLOW_MD_TABLE|default('bluesky_posts') }}
+      SELECT
+        did,
+        to_timestamp(time_us / 1000000)              AS event_time,
+        commit ->> 'operation'                       AS operation,
+        commit ->> 'collection'                      AS collection,
+        CAST(commit AS JSON) ->> '$.record.text'     AS post_text,
+        CAST(commit AS JSON) ->> '$.record.langs[0]' AS lang
+      FROM batch
+      WHERE kind = 'commit'
+
+  # The handler already wrote to MotherDuck through the attached database, so
+  # there is nothing left for a sink to do.
+  sink:
+    type: noop

--- a/dev/config/examples/published/tigerdata.enrich.yml
+++ b/dev/config/examples/published/tigerdata.enrich.yml
@@ -43,6 +43,9 @@ pipeline:
       LEFT JOIN tiger.{{ SQLFLOW_TIGERDATA_SCHEMA|default('public') }}.devices AS devices
         ON batch.device_id = devices.device_id
 
+  # Delivery is at-least-once: a crash between this insert and the offset
+  # commit replays the batch on restart. The unique index on (time,
+  # device_id) plus ON CONFLICT DO NOTHING makes the replay a no-op.
   sink:
     type: sqlcommand
     sqlcommand:
@@ -50,3 +53,4 @@ pipeline:
         INSERT INTO tiger.{{ SQLFLOW_TIGERDATA_SCHEMA|default('public') }}.readings
           (time, device_id, site, model, value)
         SELECT time, device_id, site, model, value FROM sqlflow_sink_batch
+        ON CONFLICT DO NOTHING

--- a/dev/config/examples/published/tigerdata.enrich.yml
+++ b/dev/config/examples/published/tigerdata.enrich.yml
@@ -1,0 +1,52 @@
+# Published in the TigerData docs: integrate/data-ingestion-streaming/sqlflow.
+# A stream of device readings from Kafka, enriched per batch by joining a
+# reference table that lives in the service, landed in a hypertable.
+commands:
+  - name: load the postgres extension
+    sql: |
+      INSTALL postgres;
+      LOAD postgres;
+
+  # One attach serves both directions: the join reads devices from it and
+  # the sink inserts readings into it. The DSN is a required input with no
+  # default on purpose; a production pipeline should not carry a bunk one.
+  - name: attach the service
+    sql: |
+      ATTACH '{{ SQLFLOW_TIGERDATA_DSN }}' AS tiger (TYPE POSTGRES);
+
+pipeline:
+  name: tigerdata-enrich
+  description: "Enrich a stream of readings with device metadata from the service, and land them in a hypertable"
+  batch_size: {{ SQLFLOW_BATCH_SIZE|default('500') }}
+
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('localhost:9092') }}]
+      group_id: {{ SQLFLOW_GROUP_ID|default('tigerdata-enrich') }}
+      auto_offset_reset: earliest
+      topics:
+        - "{{ SQLFLOW_TOPIC|default('readings') }}"
+
+  # LEFT JOIN, so a reading from a device the reference table does not know
+  # still lands, with site and model NULL, rather than being dropped.
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: |
+      SELECT
+        CAST(batch.ts AS TIMESTAMPTZ) AS time,
+        batch.device_id,
+        devices.site,
+        devices.model,
+        batch.value
+      FROM batch
+      LEFT JOIN tiger.{{ SQLFLOW_TIGERDATA_SCHEMA|default('public') }}.devices AS devices
+        ON batch.device_id = devices.device_id
+
+  sink:
+    type: sqlcommand
+    sqlcommand:
+      sql: |
+        INSERT INTO tiger.{{ SQLFLOW_TIGERDATA_SCHEMA|default('public') }}.readings
+          (time, device_id, site, model, value)
+        SELECT time, device_id, site, model, value FROM sqlflow_sink_batch

--- a/dev/config/examples/tumbling.window.yml
+++ b/dev/config/examples/tumbling.window.yml
@@ -22,6 +22,15 @@ tables:
           #
           # The trade: the newest window waits for a later one, so a stream
           # that stops leaves its final window unpublished.
+          #
+          # The second branch is the idleness bound. A stream that goes quiet
+          # never moves its own clock, so the first branch alone would hold
+          # the newest window open until data a full grace newer arrived: a
+          # surge that stops leaves its last bucket unpublished forever.
+          # sqlflow_progress is the engine's one-row liveness table and
+          # last_arrival is when the newest batch was written, so after a
+          # grace of silence every open window closes. It is TIMESTAMPTZ, so
+          # the comparison holds whatever timezone the host runs in.
         tumbling_window:
           collect_closed_windows_sql: |
             SELECT 
@@ -30,11 +39,13 @@ tables:
               count
             FROM agg_cities_count
             WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
             ORDER BY city
 
           delete_closed_windows_sql: |
             DELETE FROM agg_cities_count 
             WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
           
         sink:
           type: kafka

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -310,12 +310,16 @@ invariants:
     class: liveness
     applies_to: pipeline
     claim: >
-      A configuration that cannot make progress fails at startup rather than
-      running quietly. flush_interval_seconds of 0 removes the ticker
-      entirely, so a batch a low-traffic topic never fills waits forever.
-      Unenforced and untracked: the engine permits the configuration today.
+      A configuration cannot remove the flush ticker. flush_interval_seconds
+      absent, zero or negative all run with the thirty second default, so a
+      batch a low-traffic topic never fills still leaves on time. This entry
+      previously claimed the opposite, that zero removed the ticker and
+      stalled such a topic forever; the run command has always defaulted it,
+      and TestCliInvocation_FlushIntervalNeverZero now pins every value a
+      config can produce.
     verified_by: harness
     requires: []
+    enforced: true
 
   - id: lifecycle.drain.bounded
     family: lifecycle

--- a/docs/coverage/invariants.yml
+++ b/docs/coverage/invariants.yml
@@ -314,12 +314,18 @@ invariants:
       absent, zero or negative all run with the thirty second default, so a
       batch a low-traffic topic never fills still leaves on time. This entry
       previously claimed the opposite, that zero removed the ticker and
-      stalled such a topic forever; the run command has always defaulted it,
-      and TestCliInvocation_FlushIntervalNeverZero now pins every value a
-      config can produce.
+      stalled such a topic forever; the run command has always defaulted it.
+
+      Pinned by TestCliInvocation_FlushIntervalNeverZero, not by the harness,
+      and unenforced for that reason: the harness drives a pipeline that is
+      already constructed, and this is a property of resolving the config
+      before construction. There is nothing per-subject to observe, so
+      demanding a cell from every subject would buy a fake rather than a
+      proof. The liveness the harness can see is pipeline.flush.eventually,
+      which it proves.
     verified_by: harness
     requires: []
-    enforced: true
+    enforced: false
 
   - id: lifecycle.drain.bounded
     family: lifecycle

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -187,7 +187,7 @@ drains. An invariant holds only if it holds on all four.
 | Invariant | Claim | `pipeline.stateful` | `pipeline.stateless` |
 | --- | --- | --- | --- |
 | `pipeline.flush.eventually` | A batch that never reaches batchSize still reaches the sink, within the flush interval. | ✅ u | ✅ u |
-| `pipeline.progress.no_silent_stall` | A configuration that cannot make progress fails at startup rather than running quietly. flush_interval_seconds of 0 removes the ticker entirely, so a batch a low-traffic topic never fills waits forever. Unenforced and untracked: the engine permits the configuration today. | ❌ missing | ❌ missing |
+| `pipeline.progress.no_silent_stall` | A configuration cannot remove the flush ticker. flush_interval_seconds absent, zero or negative all run with the thirty second default, so a batch a low-traffic topic never fills still leaves on time. This entry previously claimed the opposite, that zero removed the ticker and stalled such a topic forever; the run command has always defaulted it. Pinned by TestCliInvocation_FlushIntervalNeverZero, not by the harness, and unenforced for that reason: the harness drives a pipeline that is already constructed, and this is a property of resolving the config before construction. There is nothing per-subject to observe, so demanding a cell from every subject would buy a fake rather than a proof. The liveness the harness can see is pipeline.flush.eventually, which it proves. | ❌ missing | ❌ missing |
 | `lifecycle.drain.bounded` | The drain finishes or fails inside its deadline. *(declared, tracked by #161)* | ❌ missing | ❌ missing |
 | `pipeline.batch.timeout` | A batch whose query exceeds the timeout fails the batch, not the process. *(declared, tracked by #163)* | ❌ missing | ❌ missing |
 

--- a/docs/coverage/matrix.md
+++ b/docs/coverage/matrix.md
@@ -52,6 +52,7 @@ added, and this page changes only when a status does.
 | `validate.template` | Reports referenced, provided, missing, and unused template variables. | ✅ | — | — |
 | `validate.schema` | Validates a rendered config against the config JSON Schema, naming the line. | ✅ | — | — |
 | `observability.metrics` | Exports pipeline counters and histograms over Prometheus. | ✅ | — | — |
+| `observability.turbostats` | Reports the process's own state as one versioned document, served at /turbostats/v1. | ✅ | — | ✅ |
 | `observability.debug_api` | Serves ad-hoc SQL against the live DuckDB connection. | ✅ | — | — |
 | `cli.invocation` | Resolves the config path and message limits from either flag form. | ✅ | — | — |
 | `cli.dev_invoke` | Runs a pipeline against a fixture file, without a source. | ✅ | — | ✅ |
@@ -59,7 +60,7 @@ added, and this page changes only when a status does.
 | `tooling.conformance` | The harness proves the declared invariants for any integration. | ✅ | — | — |
 | `tooling.coverage` | Tests attribute to features and invariants, and the registries match the code. | ✅ | — | — |
 
-**36 features declared. 36 have at least one passing test attributed at every level they require, so 0 gap(s).**
+**37 features declared. 37 have at least one passing test attributed at every level they require, so 0 gap(s).**
 
 That sentence counts attribution, not proof. A feature is green here when
 a test named for it ran and passed; it says nothing about whether the

--- a/docs/superpowers/plans/2026-09-10-slow-data-confidence.md
+++ b/docs/superpowers/plans/2026-09-10-slow-data-confidence.md
@@ -1,0 +1,1551 @@
+# Slow-Moving Data Confidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove, with tests that run in minutes and a soak that runs for hours, that a pipeline stays live and correct when its stream trickles, surges then stops, or never delivers at all.
+
+**Architecture:** A one-row engine table, `sqlflow_progress`, written where the state transaction already commits, plus an in-memory snapshot of the same facts. The window predicate reads the table so a quiet stream closes its open windows. `/stats` and a new `/healthz` read the snapshot. Seven test cells cover the invariants; a `slow-soak` skill runs a scripted traffic profile against a real broker.
+
+**Tech Stack:** Go 1.25, DuckDB via ADBC, franz-go `kgo`, `coder/websocket`, testcontainers Kafka for the one integration cell, bash and Python for the soak, the existing coverage registry.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-slow-data-confidence-design.md`
+
+## Global Constraints
+
+- Branch `feat/slow-data-confidence` in the main checkout at `/Users/danielmican/code/github.com/turbolytics/sql-flow`. Never `git checkout` elsewhere while a soak runs; run the soak from a scratchpad copy of its scripts.
+- Every Go test starts with `coverage.Covers(t, "<feature id>")`. Ids used here: `core.consume_loop`, `state.durability`, `manager.tumbling_window`, `source.kafka`, `source.websocket`, `observability.metrics`, `cli.invocation`. A skipped test covers nothing; integration tests skip only under `-short`.
+- The coverage matrix (`docs/coverage/matrix.*`) is regenerated from CI artifacts only. After any change under `internal/config` run `make schema`. No config struct changes are planned here.
+- Prose follows Google Technical Writing One. No em dashes. No attribution lines in commits or the PR.
+- `flush_interval_seconds` keeps its 30 second floor on the config path; tests set the Turbine's interval directly, which has no floor.
+- The engine table names follow `sqlflow_offsets`: `sqlflow_progress`, excluded from state stats the same way.
+- Timestamps in `sqlflow_progress` are wall clock in UTC, written by the engine, never by SQL.
+
+---
+
+### Task 1: The progress table and the in-memory snapshot
+
+**Files:**
+- Create: `internal/core/progress.go`
+- Modify: `internal/core/turbine.go` (struct at ~line 199, `WithStateStore` at ~254, `commitState` at ~735, `processBatch` at ~789)
+- Modify: `internal/core/stats.go:129` (the exclusion)
+- Test: `internal/core/progress_test.go` (new)
+
+**Interfaces:**
+- Produces: `core.Progress{LastArrival, LastCommit time.Time; Messages int64}`; `core.ProgressStore` with `NewProgressStore(conn adbc.Connection)`, `Init(ctx) error`, `Record(ctx, p Progress) error`; `core.WithProgressStore(s progressSaver) TurbineOption`; `(*Turbine).Progress() Progress`.
+- Consumed by: Task 3 (the predicate reads the table), Task 4 (`/stats` and `/healthz` read the snapshot), Task 6 (root.go wiring).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/core/progress_test.go`:
+
+```go
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/turbolytics/sql-flow/internal/duckdb"
+	"github.com/zeebo/assert"
+)
+
+// progressRecorder is the test double for the store: it keeps every record.
+type progressRecorder struct {
+	mu   sync.Mutex
+	recs []Progress
+}
+
+func (r *progressRecorder) Record(_ context.Context, p Progress) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recs = append(r.recs, p)
+	return nil
+}
+
+func (r *progressRecorder) last() (Progress, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.recs) == 0 {
+		return Progress{}, 0
+	}
+	return r.recs[len(r.recs)-1], len(r.recs)
+}
+
+// A batch moves both clocks and the count. An idle tick moves the commit
+// clock only. That distinction is what lets a predicate tell "quiet" from
+// "stuck", so it is the first thing pinned.
+func TestCoreConsumeLoop_ProgressRecordsArrivalOnBatchAndCommitOnIdle(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+	rec := &progressRecorder{}
+	src := newBlockingSource(messages(3))
+	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 1000, 30*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithProgressStore(rec))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
+
+	deadline := time.After(5 * time.Second)
+	var afterBatch Progress
+	for {
+		p, n := rec.last()
+		if n >= 1 && p.Messages == 3 {
+			afterBatch = p
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("no progress record with 3 messages; records=%d", n)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	assert.That(t, !afterBatch.LastArrival.IsZero())
+	assert.That(t, !afterBatch.LastCommit.Before(afterBatch.LastArrival))
+
+	// Now the source is silent. Idle ticks keep recording, and every one
+	// of them carries the arrival clock unchanged.
+	deadline = time.After(5 * time.Second)
+	for {
+		p, n := rec.last()
+		if n >= 4 {
+			assert.Equal(t, afterBatch.LastArrival, p.LastArrival)
+			assert.That(t, p.LastCommit.After(afterBatch.LastCommit))
+			assert.Equal(t, int64(3), p.Messages)
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("idle ticks did not record progress; records=%d", n)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	snap := tb.Progress()
+	assert.Equal(t, int64(3), snap.Messages)
+	close(src.release)
+	<-done
+}
+
+// The store writes one row and rewrites it; it never grows. Read back
+// through a second statement, the way the window manager will.
+func TestStateDurability_ProgressStoreKeepsOneRow(t *testing.T) {
+	coverage.Covers(t, "state.durability")
+	ctx := context.Background()
+	db, err := duckdb.OpenPath(ctx, "")
+	assert.NoError(t, err)
+	defer db.Close()
+	conn, err := db.Open(ctx)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	store := NewProgressStore(conn)
+	assert.NoError(t, store.Init(ctx))
+	assert.NoError(t, store.Init(ctx)) // idempotent, like the offsets table
+
+	t0 := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	assert.NoError(t, store.Record(ctx, Progress{LastArrival: t0, LastCommit: t0, Messages: 1}))
+	assert.NoError(t, store.Record(ctx, Progress{LastArrival: t0, LastCommit: t0.Add(time.Minute), Messages: 1}))
+
+	stmt, err := conn.NewStatement()
+	assert.NoError(t, err)
+	defer stmt.Close()
+	assert.NoError(t, stmt.SetSqlQuery(`SELECT count(*), max(messages), max(last_commit) - max(last_arrival) FROM sqlflow_progress`))
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	assert.NoError(t, err)
+	defer reader.Release()
+	assert.That(t, reader.Next())
+	rec := reader.Record()
+	assert.Equal(t, int64(1), rec.Column(0).(interface{ Value(int) int64 }).Value(0))
+	assert.Equal(t, int64(1), rec.Column(1).(interface{ Value(int) int64 }).Value(0))
+}
+```
+
+Note: `db.Open(ctx)` is the ADBC database's connection constructor; if `internal/duckdb.OpenPath` returns a wrapper with a different method, use the one `internal/core/stats_test.go` uses to get a connection and keep the rest.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `go test ./internal/core/ -run 'Progress' -v -count=1 2>&1 | head -20`
+Expected: compile errors, `undefined: Progress`, `undefined: WithProgressStore`, `undefined: NewProgressStore`.
+
+- [ ] **Step 3: Write the store**
+
+Create `internal/core/progress.go`:
+
+```go
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+)
+
+// progressTable is engine bookkeeping beside sqlflow_offsets: one row that
+// says when the newest batch arrived, when state last committed, and how many
+// messages have been consumed. The window predicate reads it to tell a quiet
+// stream from a replay; /stats and /healthz read the in-memory copy.
+const progressTable = "sqlflow_progress"
+
+// Progress is the pipeline's liveness in three facts. Wall clock, UTC.
+type Progress struct {
+	LastArrival time.Time
+	LastCommit  time.Time
+	Messages    int64
+}
+
+// progressSaver is what the Turbine needs; ProgressStore is the DuckDB one.
+type progressSaver interface {
+	Record(ctx context.Context, p Progress) error
+}
+
+// ProgressStore keeps the one-row table current. It is created on the state
+// connection when the pipeline has a state file, so its writes ride the same
+// transaction as the offsets, and on a connection to the in-memory database
+// otherwise.
+type ProgressStore struct {
+	conn adbc.Connection
+}
+
+func NewProgressStore(conn adbc.Connection) *ProgressStore {
+	return &ProgressStore{conn: conn}
+}
+
+// Init creates the table and its single row if they are absent.
+func (s *ProgressStore) Init(ctx context.Context) error {
+	for _, q := range []string{
+		`CREATE TABLE IF NOT EXISTS ` + progressTable + ` (
+		    last_arrival TIMESTAMP,
+		    last_commit  TIMESTAMP,
+		    messages     BIGINT NOT NULL
+		)`,
+		`INSERT INTO ` + progressTable + ` (last_arrival, last_commit, messages)
+		 SELECT NULL, NULL, 0 WHERE NOT EXISTS (SELECT 1 FROM ` + progressTable + `)`,
+	} {
+		if err := s.exec(ctx, q); err != nil {
+			return fmt.Errorf("initialising %s: %w", progressTable, err)
+		}
+	}
+	return nil
+}
+
+// Record rewrites the row. A zero LastArrival is left as it was, which is how
+// an idle tick moves the commit clock without touching the arrival clock.
+func (s *ProgressStore) Record(ctx context.Context, p Progress) error {
+	q := fmt.Sprintf(`UPDATE %s SET last_commit = TIMESTAMP '%s', messages = %d`,
+		progressTable, p.LastCommit.UTC().Format("2006-01-02 15:04:05.999999"), p.Messages)
+	if !p.LastArrival.IsZero() {
+		q += fmt.Sprintf(`, last_arrival = TIMESTAMP '%s'`,
+			p.LastArrival.UTC().Format("2006-01-02 15:04:05.999999"))
+	}
+	if err := s.exec(ctx, q); err != nil {
+		return fmt.Errorf("recording progress: %w", err)
+	}
+	return nil
+}
+
+func (s *ProgressStore) exec(ctx context.Context, q string) error {
+	stmt, err := s.conn.NewStatement()
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	if err := stmt.SetSqlQuery(q); err != nil {
+		return err
+	}
+	_, err = stmt.ExecuteUpdate(ctx)
+	return err
+}
+```
+
+- [ ] **Step 4: Wire the Turbine**
+
+In `internal/core/turbine.go`, add to the `Turbine` struct beside `offsets`:
+
+```go
+	// progress is the liveness record, see progress.go. Optional: a Turbine
+	// built without it records nothing and Progress() reports zeros.
+	progress progressSaver
+	// snapshot is the in-memory copy of what progress last recorded, read by
+	// /stats and /healthz without touching the database. Guarded by lock.
+	snapshot Progress
+	// batchSinceCommit is set by processBatch and cleared by commitState, so
+	// commitState knows whether this commit follows an arrival or an idle tick.
+	batchSinceCommit bool
+```
+
+Add the option after `WithStateStore`:
+
+```go
+// WithProgressStore records liveness into a store and into an in-memory
+// snapshot on every commit and every idle tick.
+func WithProgressStore(s progressSaver) TurbineOption {
+	return func(t *Turbine) { t.progress = s }
+}
+
+// Progress reports the last recorded liveness facts. Zero values mean
+// nothing has been recorded yet.
+func (t *Turbine) Progress() Progress {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.snapshot
+}
+```
+
+At the top of `commitState`, before the `if t.offsets == nil || t.stateTx == nil` guard, insert the recording, so a stateless pipeline records too:
+
+```go
+	if t.progress != nil {
+		now := time.Now().UTC()
+		t.lock.Lock()
+		p := Progress{LastCommit: now, Messages: t.stats.MessagesConsumed()}
+		if t.batchSinceCommit {
+			p.LastArrival = now
+			t.snapshot.LastArrival = now
+		}
+		t.snapshot.LastCommit = now
+		t.snapshot.Messages = p.Messages
+		t.batchSinceCommit = false
+		t.lock.Unlock()
+		if err := t.progress.Record(ctx, p); err != nil {
+			t.logger.Warn("recording progress", zap.Error(err))
+		}
+	}
+```
+
+Check that `commitState`'s existing `t.lock.Lock()` comes after this block, not around it; the block takes and releases the lock itself. In `processBatch`, immediately after the handler `Invoke` succeeds and before the sink write, set the flag under the lock the code already holds there:
+
+```go
+	t.batchSinceCommit = true
+```
+
+If `processBatch` releases the lock before that point, take it again for the assignment. A stateless pipeline reaches `commitState` from `processBatch` and from the idle tick already; both now record.
+
+In `internal/core/stats.go:129`, extend the exclusion:
+
+```go
+			if name == offsetsTable || name == batchTable || name == progressTable {
+```
+
+- [ ] **Step 5: Run the tests and the package**
+
+Run: `go test ./internal/core/ -run 'Progress' -v -count=1 2>&1 | grep -E '^(--- |ok|FAIL)'`
+Expected: both PASS.
+
+Run: `go test ./internal/core/ -count=1 2>&1 | tail -2`
+Expected: `ok`. The existing idle-tick tests still pass because the recorder is optional.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/core/progress.go internal/core/progress_test.go internal/core/turbine.go internal/core/stats.go
+git commit -m "core: a progress table, and a snapshot, so liveness is a fact the engine keeps
+
+sqlflow_progress holds one row: when the newest batch arrived, when state
+last committed, and how many messages have been consumed. A batch moves
+all three, an idle tick moves the commit clock only. The window predicate
+will read the table; /stats and /healthz will read the snapshot."
+```
+
+---
+
+### Task 2: Trickle and surge cells for the consume loop
+
+**Files:**
+- Test: `internal/core/slow_test.go` (new)
+
+**Interfaces:**
+- Consumes: `blockingSource` and `messages(n)` from `turbine_test.go:366-380`; `fakeHandler`, `fakeSink` (`turbine_test.go:72,134`); `offsetSaver`.
+- Produces: `pacedSource`, a source that emits one batch per tick on a schedule, reused by Task 7's docs of the cells.
+
+- [ ] **Step 1: Write the cells**
+
+Create `internal/core/slow_test.go`:
+
+```go
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// pacedSource delivers one message every `every`, n times, then stays open
+// and silent until released. It is the trickle.
+type pacedSource struct {
+	ch      chan []Message
+	release chan struct{}
+	every   time.Duration
+	n       int
+}
+
+func newPacedSource(n int, every time.Duration) *pacedSource {
+	return &pacedSource{ch: make(chan []Message), release: make(chan struct{}), every: every, n: n}
+}
+
+func (s *pacedSource) Start() error { return nil }
+func (s *pacedSource) Close() error { return nil }
+func (s *pacedSource) Commit() error { return nil }
+func (s *pacedSource) CommitMarks(*Marks) error { return nil }
+func (s *pacedSource) Stream() <-chan []Message {
+	go func() {
+		defer close(s.ch)
+		for i := 0; i < s.n; i++ {
+			select {
+			case <-time.After(s.every):
+				s.ch <- []Message{{Value: []byte(`{"i":1}`), Topic: "t", Partition: 0, Offset: int64(i)}}
+			case <-s.release:
+				return
+			}
+		}
+		<-s.release
+	}()
+	return s.ch
+}
+
+// markRecorder is an offsetSaver that keeps the newest saved mark.
+type markRecorder struct {
+	mu    sync.Mutex
+	saves int
+	last  *Marks
+}
+
+func (m *markRecorder) Save(_ context.Context, marks *Marks) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saves++
+	m.last = marks
+	return nil
+}
+
+func (m *markRecorder) count() int { m.mu.Lock(); defer m.mu.Unlock(); return m.saves }
+
+// noopTx satisfies stateTx for a pipeline that has offsets but no real
+// transaction; commitState needs both to be non-nil to save marks.
+type noopTx struct{}
+
+func (noopTx) Commit(context.Context) error   { return nil }
+func (noopTx) Rollback(context.Context) error { return nil }
+
+func waitFor(t *testing.T, what string, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for !cond() {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", what)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+// C1. A trickle: one message every 40 ms, a batch size it will never reach,
+// a 20 ms flush interval. Every message reaches the sink on the interval,
+// not when the batch fills, and every flush saves a mark.
+func TestCoreConsumeLoop_TrickleFlushesEveryMessageOnTheInterval(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+	src := newPacedSource(10, 40*time.Millisecond)
+	sink := &fakeSink{}
+	marks := &markRecorder{}
+	tb := NewTurbine(src, &fakeHandler{}, sink, 1000, 20*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithStateStore(marks, noopTx{}))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
+
+	// The first message lands within one interval plus scheduling slack,
+	// long before the 40 ms cadence could have produced a second one.
+	start := time.Now()
+	waitFor(t, "the first row at the sink", 2*time.Second, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return sink.rows >= 1
+	})
+	assert.That(t, time.Since(start) < 40*time.Millisecond+20*time.Millisecond+150*time.Millisecond)
+
+	waitFor(t, "all ten rows", 5*time.Second, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return sink.rows == 10
+	})
+	// Ten messages, at least ten flushes, since no batch ever held two.
+	assert.That(t, marks.count() >= 10)
+	close(src.release)
+	<-done
+}
+
+// C2. A surge then silence: 5,000 messages in one burst, then nothing. The
+// final partial batch reaches the sink within an interval of the last
+// arrival, the saved mark is the last offset, and the silence writes nothing.
+func TestCoreConsumeLoop_SurgeThenSilenceFlushesTheTailOnce(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+	burst := messages(5000)
+	for i := range burst {
+		burst[i].Offset = int64(i)
+	}
+	src := newBlockingSource(burst)
+	sink := &fakeSink{}
+	marks := &markRecorder{}
+	tb := NewTurbine(src, &fakeHandler{}, sink, 1000, 30*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithStateStore(marks, noopTx{}))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
+
+	waitFor(t, "5000 rows at the sink", 5*time.Second, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return sink.rows == 5000
+	})
+	marks.mu.Lock()
+	last := marks.last
+	marks.mu.Unlock()
+	assert.That(t, last != nil)
+	var newest int64 = -1
+	last.Each(func(_ string, _ int32, m Mark) { newest = m.Offset })
+	assert.Equal(t, int64(4999), newest)
+
+	// Five intervals of silence: the sink sees no further write.
+	sink.mu.Lock()
+	before := sink.writes
+	sink.mu.Unlock()
+	time.Sleep(150 * time.Millisecond)
+	sink.mu.Lock()
+	after := sink.writes
+	sink.mu.Unlock()
+	assert.Equal(t, before, after)
+	close(src.release)
+	<-done
+}
+```
+
+If `fakeSink` has no `writes` counter, add one beside `rows` in `turbine_test.go:134` and increment it in its `WriteTable`. If `Marks.Each`'s signature differs from `(topic string, partition int32, m Mark)`, mirror the one in `internal/core/marks.go`.
+
+- [ ] **Step 2: Run them**
+
+Run: `go test ./internal/core/ -run 'Trickle|SurgeThenSilence' -v -count=1 2>&1 | grep -E '^(--- |ok|FAIL)|slow_test'`
+Expected: both PASS on the current engine. These are not failing-first: they pin behaviour that exists so the soak and the docs can cite it. If either fails, that is a finding: stop, record the failure verbatim in the PR, and fix the engine before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/core/slow_test.go internal/core/turbine_test.go
+git commit -m "core: a trickle flushes every message on the interval, a surge flushes its tail once
+
+Two cells that pin liveness for slow data. A source that delivers one
+message every 40 ms into a batch of 1,000 with a 20 ms interval gets
+each row to the sink on the interval and saves a mark per flush. A burst
+of 5,000 followed by silence flushes its partial tail within an interval,
+saves the last offset, and writes nothing more."
+```
+
+---
+
+### Task 3: Idle commits keep the state file flat (C3)
+
+**Files:**
+- Test: `internal/core/progress_test.go` (append)
+
+**Interfaces:**
+- Consumes: `duckdb.OpenPath`, `NewOffsetStore`, `NewProgressStore`, `WithStateStore`, `WithProgressStore`, `newIdleSource` (`turbine_test.go:861`). Read `turbine_test.go:599-640` for how `txConn` obtains a real transaction on a connection, and `root.go:206-235` for how the run command builds the state store on the same connection.
+
+- [ ] **Step 1: Write the cell**
+
+Append to `internal/core/progress_test.go`:
+
+```go
+// C3. Twenty idle ticks against a real state file. The commit clock moves
+// on every tick, the arrival clock never does, and the file does not grow.
+func TestStateDurability_IdleTicksDoNotGrowTheStateFile(t *testing.T) {
+	coverage.Covers(t, "state.durability")
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := duckdb.OpenPath(ctx, path)
+	assert.NoError(t, err)
+	defer db.Close()
+	conn, err := db.Open(ctx)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	offsets := NewOffsetStore(conn)
+	assert.NoError(t, offsets.Init(ctx))
+	progress := NewProgressStore(conn)
+	assert.NoError(t, progress.Init(ctx))
+	tx := beginTx(t, conn) // the helper turbine_test.go uses to open the state transaction
+
+	src := newIdleSource()
+	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 1000, 20*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(offsets, tx), WithProgressStore(progress))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(ctx, 0); close(done) }()
+
+	sizeAfter := func(n int64) int64 {
+		waitFor(t, "idle ticks", 5*time.Second, func() bool { return tb.Progress().Messages == 0 && !tb.Progress().LastCommit.IsZero() && ticks(tb) >= n })
+		fi, err := os.Stat(path)
+		assert.NoError(t, err)
+		return fi.Size()
+	}
+	s1 := sizeAfter(1)
+	s20 := sizeAfter(20)
+	assert.That(t, tb.Progress().LastArrival.IsZero())
+	// One checkpoint of slack: DuckDB may write a WAL frame on the first
+	// commit. Twenty empty commits must not add another.
+	assert.That(t, s20 <= s1+256*1024)
+	close(src.release)
+	<-done
+}
+```
+
+`ticks(tb)` counts commits; add a `commits int64` counter to the Turbine under the lock, incremented in `commitState` after a successful commit, with an accessor `func (t *Turbine) commitCount() int64` in `turbine.go`. `beginTx` is whatever helper the state tests use to start the transaction on `conn`; if none exists, open it the way `root.go:228-235` does and wrap it in a `stateTx`. Add `"os"` and `"path/filepath"` to the imports.
+
+- [ ] **Step 2: Run it**
+
+Run: `go test ./internal/core/ -run 'IdleTicksDoNotGrow' -v -count=1 2>&1 | grep -E '^(--- |ok|FAIL)|size'`
+Expected: PASS. If the file grows by more than the slack, that is a finding about empty commits and belongs in the PR before the docs claim otherwise.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/core/progress_test.go internal/core/turbine.go
+git commit -m "core: twenty idle commits leave the state file where it was
+
+The commit clock moves on every tick, the arrival clock never does, and
+the file does not grow past one checkpoint of slack."
+```
+
+---
+
+### Task 4: The window predicate closes on silence (C4)
+
+**Files:**
+- Modify: `dev/config/examples/tumbling.window.yml`, `dev/config/examples/kafka.stateful.window.yml`, `dev/config/examples/bluesky/bluesky.kafka.windowed.yml`, `dev/config/examples/bluesky/bluesky.postgres.windowed.yml`
+- Test: `internal/managers/tumbling_test.go` (append)
+
+**Interfaces:**
+- Consumes: `newTestConn` (`tumbling_test.go:22`), `newTestTumbling` (`:133`), `recordingSink`, `core.NewProgressStore`.
+- Produces: the two-branch predicate, used verbatim by the docs in Task 8.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/managers/tumbling_test.go`:
+
+```go
+// The predicate the shipped examples use, with a five second grace so the
+// test runs in seconds. Branch one is the stream clock (#234); branch two is
+// the idleness bound, which reads the engine's progress row.
+const idlePredicate = `
+SELECT bucket, city, count FROM agg
+WHERE bucket < (SELECT max(bucket) FROM agg) - INTERVAL '5' SECOND
+   OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '5' SECOND`
+
+const idleDelete = `
+DELETE FROM agg
+WHERE bucket < (SELECT max(bucket) FROM agg) - INTERVAL '5' SECOND
+   OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '5' SECOND`
+
+func setupAggWithProgress(t *testing.T) (adbc.Connection, *core.ProgressStore, func()) {
+	t.Helper()
+	conn, cleanup := newTestConn(t)
+	exec(t, conn, `CREATE TABLE agg (bucket TIMESTAMP, city VARCHAR, count BIGINT)`)
+	progress := core.NewProgressStore(conn)
+	assert.NoError(t, progress.Init(context.Background()))
+	return conn, progress, cleanup
+}
+
+// C4, half one. Rows land in one bucket, the stream goes quiet. Nothing
+// newer ever arrives, so the stream clock alone would hold the window open
+// forever. The idleness branch publishes it once, a grace after the last row.
+func TestManagerTumblingWindow__QuietStreamClosesItsLastWindow(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
+	ctx := context.Background()
+	conn, progress, cleanup := setupAggWithProgress(t)
+	defer cleanup()
+	sink := &recordingSink{}
+	m := newTestTumblingWith(conn, sink, idlePredicate, idleDelete, 500*time.Millisecond)
+
+	exec(t, conn, `INSERT INTO agg VALUES (TIMESTAMP '2026-09-10 12:00:00', 'nyc', 3)`)
+	assert.NoError(t, progress.Record(ctx, core.Progress{LastArrival: time.Now().UTC(), LastCommit: time.Now().UTC(), Messages: 3}))
+
+	// Polls inside the grace publish nothing.
+	assert.NoError(t, m.Poll(ctx))
+	assert.Equal(t, 0, sink.rowCount())
+
+	// Only the commit clock moves while the stream is quiet.
+	time.Sleep(5500 * time.Millisecond)
+	assert.NoError(t, progress.Record(ctx, core.Progress{LastCommit: time.Now().UTC(), Messages: 3}))
+	assert.NoError(t, m.Poll(ctx))
+	assert.Equal(t, 1, sink.rowCount())
+	assert.NoError(t, m.Poll(ctx))
+	assert.Equal(t, 1, sink.rowCount()) // deleted after publish, not published twice
+}
+
+// C4, half two, the #234 property kept. Three buckets arrive in one burst
+// with arrivals continuous, so the idleness branch never fires; the stream
+// clock closes the two older buckets once each and leaves the newest open.
+func TestManagerTumblingWindow__ReplayStillClosesEachWindowOnce(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
+	ctx := context.Background()
+	conn, progress, cleanup := setupAggWithProgress(t)
+	defer cleanup()
+	sink := &recordingSink{}
+	m := newTestTumblingWith(conn, sink, idlePredicate, idleDelete, 500*time.Millisecond)
+
+	exec(t, conn, `INSERT INTO agg VALUES
+		(TIMESTAMP '2026-09-10 12:00:00', 'nyc', 1),
+		(TIMESTAMP '2026-09-10 12:00:10', 'nyc', 1),
+		(TIMESTAMP '2026-09-10 12:00:20', 'nyc', 1)`)
+	assert.NoError(t, progress.Record(ctx, core.Progress{LastArrival: time.Now().UTC(), LastCommit: time.Now().UTC(), Messages: 3}))
+
+	assert.NoError(t, m.Poll(ctx))
+	assert.Equal(t, 2, sink.rowCount())
+	assert.NoError(t, m.Poll(ctx))
+	assert.Equal(t, 2, sink.rowCount())
+}
+```
+
+`newTestTumblingWith(conn, sink, collect, delete, poll)` is `newTestTumbling` with the SQL and interval as parameters; add it beside the original at `tumbling_test.go:133` and have the original call it. `exec` and `rowCount` are whatever the file already uses to run SQL and count published rows; if the names differ, use those. `Poll` is the manager's one-iteration method; if the manager only exposes `Start`, use `Start` with a context cancelled after one poll interval and adjust the assertions to "within one poll".
+
+- [ ] **Step 2: Run them and watch half one fail**
+
+Run: `go test ./internal/managers/ -run 'QuietStream|ReplayStill' -v -count=1 2>&1 | grep -E '^(--- |ok|FAIL)|Error'`
+Expected: `QuietStreamClosesItsLastWindow` FAILS at the second `rowCount` assertion if the predicate is the stream clock alone; it PASSES with `idlePredicate` because the test carries the predicate itself. So the failing-first run is: temporarily use the shipped predicate (branch one only) and watch it hold the window open; then restore `idlePredicate` and watch it pass. Record both runs in the commit message.
+
+- [ ] **Step 3: Change the shipped examples**
+
+In each of the four example configs, the collect and delete predicates change from
+
+```sql
+WHERE bucket < (SELECT max(bucket) FROM <table>) - INTERVAL '60' SECOND
+```
+
+to
+
+```sql
+WHERE bucket < (SELECT max(bucket) FROM <table>) - INTERVAL '60' SECOND
+   OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
+```
+
+and the comment above them gains one paragraph:
+
+```yaml
+          # The second branch is the idleness bound. A stream that goes quiet
+          # never moves its own clock, so without it the last window would
+          # stay open until data a full grace newer arrived. sqlflow_progress
+          # is the engine's one-row liveness table; last_arrival is when the
+          # newest batch was written. After a grace of silence every open
+          # window closes, including the newest.
+```
+
+Run: `go run ./cmd/sqlflow config validate dev/config/examples/tumbling.window.yml` and the other three.
+Expected: `valid` for each.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/managers/tumbling_test.go dev/config/examples/
+git commit -m "tumbling window: a quiet stream closes its last window
+
+The stream-clock predicate from #234 holds a window open until data a
+full grace newer arrives, so a stream that stops never closes its last
+window. The predicate gains an idleness branch that reads the engine's
+progress row: after a grace of silence every open window closes. Two
+cells: a quiet stream publishes its bucket once, a replay still closes
+each bucket once."
+```
+
+---
+
+### Task 5: Progress on `/stats`, and `/healthz` (C7)
+
+**Files:**
+- Modify: `internal/cli/run/metrics.go` (`newHTTPMux`, ~line 30)
+- Test: `internal/cli/run/health_test.go` (new)
+
+**Interfaces:**
+- Consumes: `core.Progress`, `(*core.Turbine).Progress()`.
+- Produces: `progressFunc func() core.Progress`; `newHTTPMux(registry, stats, progress, interval, now)`; `/stats` gains `"progress"`; `/healthz`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/cli/run/health_test.go`:
+
+```go
+package run
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// C7. Idle is healthy: the commit clock keeps moving while nothing arrives.
+// Stuck is not: three intervals without a commit turns /healthz red, and the
+// body says how old the last commit is.
+func TestObservabilityMetrics_HealthzTellsIdleFromStuck(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	clock := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	now := func() time.Time { return clock }
+	p := core.Progress{LastArrival: clock.Add(-time.Hour), LastCommit: clock.Add(-20 * time.Second), Messages: 42}
+	mux := newHTTPMux(nil, nil, func() core.Progress { return p }, 30*time.Second, now)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	get := func(path string) (int, map[string]any) {
+		resp, err := http.Get(srv.URL + path)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp.StatusCode, body
+	}
+
+	// Idle for an hour, committed 20 s ago: healthy.
+	code, body := get("/healthz")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "ok", body["status"])
+
+	// /stats carries the ages.
+	_, stats := get("/stats")
+	prog := stats["progress"].(map[string]any)
+	assert.Equal(t, float64(42), prog["messages"])
+	assert.Equal(t, float64(3600), prog["arrival_age_seconds"])
+	assert.Equal(t, float64(20), prog["commit_age_seconds"])
+
+	// No commit for three intervals: stuck.
+	p.LastCommit = clock.Add(-91 * time.Second)
+	code, body = get("/healthz")
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, "stuck", body["status"])
+	assert.Equal(t, float64(91), body["commit_age_seconds"])
+
+	// Never committed at all, just started: healthy until three intervals pass.
+	p = core.Progress{}
+	code, _ = get("/healthz")
+	assert.Equal(t, http.StatusOK, code)
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `go test ./internal/cli/run/ -run Healthz -v -count=1 2>&1 | head -5`
+Expected: compile error, `newHTTPMux` has too many arguments.
+
+- [ ] **Step 3: Extend the mux**
+
+In `internal/cli/run/metrics.go`, change the signature and body:
+
+```go
+// progressFunc reports the pipeline's liveness snapshot.
+type progressFunc func() core.Progress
+
+// newHTTPMux builds the server the pipeline exposes: Prometheus scraping, a
+// JSON view of durable state and progress, and a health check.
+//
+// /healthz answers the one question a supervisor has: is this pipeline
+// making progress? Idle is progress: the commit clock moves on every tick
+// whether or not a message arrived. Three intervals without a commit is
+// stuck, and the body says how long it has been. `now` is injectable for
+// the test; `started` guards the window before the first commit.
+func newHTTPMux(registry *prom.Registry, stats statsFunc, progress progressFunc, interval time.Duration, now func() time.Time) *http.ServeMux {
+	mux := http.NewServeMux()
+	started := now()
+	if registry != nil {
+		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	}
+	ages := func() (core.Progress, float64, float64) {
+		p := progress()
+		arrival, commit := -1.0, -1.0
+		if !p.LastArrival.IsZero() {
+			arrival = now().Sub(p.LastArrival).Seconds()
+		}
+		if !p.LastCommit.IsZero() {
+			commit = now().Sub(p.LastCommit).Seconds()
+		} else {
+			commit = now().Sub(started).Seconds()
+		}
+		return p, arrival, commit
+	}
+	if stats != nil || progress != nil {
+		mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+			out := map[string]any{"state": nil}
+			if stats != nil {
+				state, err := stats()
+				if err != nil {
+					http.Error(w, fmt.Sprintf("collecting state stats: %v", err), http.StatusInternalServerError)
+					return
+				}
+				out["state"] = state
+			}
+			if progress != nil {
+				p, arrival, commit := ages()
+				out["progress"] = map[string]any{
+					"last_arrival": p.LastArrival, "last_commit": p.LastCommit, "messages": p.Messages,
+					"arrival_age_seconds": arrival, "commit_age_seconds": commit,
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(out)
+		})
+	}
+	if progress != nil {
+		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			_, _, commit := ages()
+			w.Header().Set("Content-Type", "application/json")
+			if commit > 3*interval.Seconds() {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "stuck", "commit_age_seconds": commit, "interval_seconds": interval.Seconds()})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "commit_age_seconds": commit})
+		})
+	}
+	return mux
+}
+```
+
+Keep the existing comment about the state file lock above the function. Add `"time"` to the imports. Update the one call site in `root.go` (find it with `grep -n newHTTPMux internal/cli/run/root.go`) to pass `turbine.Progress`, `flushInterval`, and `time.Now`; the turbine is constructed at `root.go:351`, so the mux must be built after it or take a closure that reads a variable assigned later. Task 6 does the wiring; for this task, make the call compile by passing `nil, flushInterval, time.Now` and note it.
+
+- [ ] **Step 4: Run the test**
+
+Run: `go test ./internal/cli/run/ -run Healthz -v -count=1 2>&1 | grep -E '^(--- |ok|FAIL)'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/run/metrics.go internal/cli/run/health_test.go internal/cli/run/root.go
+git commit -m "run: /stats reports progress, /healthz tells idle from stuck
+
+Idle is healthy: the commit clock moves on every tick whether or not a
+message arrived. Three intervals without a commit is stuck, 503, with
+the age in the body."
+```
+
+---
+
+### Task 6: Wire the run command, and pin the flush default (C6)
+
+**Files:**
+- Modify: `internal/cli/run/root.go` (state wiring ~lines 150-260, flush interval at 346, turbine at 351, mux call site)
+- Test: `internal/cli/run/flush_interval_test.go` (new)
+- Modify: `docs/coverage/invariants.yml` (`pipeline.progress.no_silent_stall`)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 and 5.
+- Produces: `flushIntervalFor(seconds int) time.Duration`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/cli/run/flush_interval_test.go`:
+
+```go
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// C6. The invariant registry said a zero interval removes the ticker and a
+// low-traffic topic waits forever. It does not: the run command defaults
+// zero to thirty seconds. This pins that, for absent, zero and negative.
+func TestCliInvocation_FlushIntervalNeverZero(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
+	assert.Equal(t, 30*time.Second, flushIntervalFor(0))
+	assert.Equal(t, 30*time.Second, flushIntervalFor(-5))
+	assert.Equal(t, 45*time.Second, flushIntervalFor(45))
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `go test ./internal/cli/run/ -run FlushIntervalNeverZero -count=1 2>&1 | head -3`
+Expected: `undefined: flushIntervalFor`.
+
+- [ ] **Step 3: Extract the helper and wire progress**
+
+In `root.go`, replace lines 346-349:
+
+```go
+			flushInterval := flushIntervalFor(conf.Pipeline.FlushIntervalSeconds)
+```
+
+and add, at package level:
+
+```go
+// flushIntervalFor is the one place the flush interval is decided. Absent,
+// zero and negative all mean the default: a ticker the pipeline cannot lose,
+// because without one a batch a low-traffic topic never fills waits forever.
+func flushIntervalFor(seconds int) time.Duration {
+	if seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	return 30 * time.Second
+}
+```
+
+Wire the progress store. Where the run command opens the database (`root.go:156` for the in-memory case and the state-file branch around `:206`), obtain a connection the same way the offsets store does, then:
+
+```go
+			progress := core.NewProgressStore(progressConn)
+			if err := progress.Init(context.Background()); err != nil {
+				return err
+			}
+			turbineOpts = append(turbineOpts, core.WithProgressStore(progress))
+```
+
+In the state-file branch, `progressConn` is the same `conn` the offsets store uses at `:206`, so its writes ride the state transaction. In the in-memory branch, open one connection on the in-memory `db` for it. Then change the mux construction to pass `turbine.Progress`, `flushInterval` and `time.Now`. If the mux is built before the turbine, declare `var progressFn func() core.Progress` before and assign `progressFn = turbine.Progress` after construction, passing a closure that calls it when non-nil and returns a zero `core.Progress` otherwise.
+
+- [ ] **Step 4: Correct the invariant**
+
+In `docs/coverage/invariants.yml`, replace the `pipeline.progress.no_silent_stall` entry's `claim` and mark it enforced:
+
+```yaml
+  - id: pipeline.progress.no_silent_stall
+    family: lifecycle
+    class: liveness
+    applies_to: pipeline
+    claim: >
+      A configuration cannot remove the flush ticker. flush_interval_seconds
+      absent, zero or negative all run with the thirty second default, so a
+      batch a low-traffic topic never fills still leaves on time. Pinned by
+      TestCliInvocation_FlushIntervalNeverZero.
+    verified_by: harness
+    requires: []
+    enforced: true
+```
+
+Check `enforced: true` is a value the registry accepts on this entry by running `make coverage-check` if the reports exist locally; if they do not, CI will say.
+
+- [ ] **Step 5: Run the unit pass, then a real pipeline**
+
+Run: `make test-go 2>&1 | tail -3`
+Expected: green.
+
+Run a shipped stateless example against the dev broker for thirty seconds and read the endpoints:
+
+```bash
+make start-backing-services >/dev/null 2>&1
+(go run ./cmd/sqlflow run dev/config/examples/kafka.structured.mem.yml --metrics=prometheus > /tmp/slow-run.log 2>&1 &)
+sleep 8
+curl -s localhost:8000/healthz; echo
+curl -s localhost:8000/stats | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['progress'])"
+pkill -f "sqlflow run dev/config/examples/kafka.structured.mem.yml"
+```
+
+Expected: `{"status":"ok","commit_age_seconds":<small>}` and a progress object whose `messages` is 0 and whose `arrival_age_seconds` is -1 with no traffic.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/run/root.go internal/cli/run/flush_interval_test.go docs/coverage/invariants.yml
+git commit -m "run: the progress store rides the state transaction, and the flush default is pinned
+
+The registry said a zero interval stalls a low-traffic topic forever.
+It does not, and now a test says so: absent, zero and negative all run
+with the thirty second default. The invariant is corrected and marked
+enforced."
+```
+
+---
+
+### Task 7: Consumers survive idle (C5)
+
+**Files:**
+- Test: `internal/kafka/source_test.go` (append)
+- Test: `internal/websocket/source_test.go` (append)
+
+**Interfaces:**
+- Consumes: `newTestClient(t, broker, topic, group, extra...)` (`source_test.go:17`), `brokerOrFail`, `produce`; `newServer` and `wsURL` (`websocket/source_test.go:20,53`), and the existing `TestSourceWebsocket_ReconnectsAfterDrop` at `:103`, which is the drop half of C5 and stays as is.
+
+- [ ] **Step 1: Kafka idle past the session timeout**
+
+Append to `internal/kafka/source_test.go`:
+
+```go
+// C5, Kafka. A trickle can leave a consumer silent for longer than its
+// session timeout. franz-go heartbeats in the background, so the group
+// membership survives and the next message is delivered without a rejoin
+// storm. Six second session, eight seconds of silence.
+func TestIntegrationSourceKafka_SurvivesIdleLongerThanTheSessionTimeout(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
+	broker := brokerOrFail(t)
+	topic := fmt.Sprintf("turbine-idle-%d", time.Now().UnixNano())
+
+	producer, err := kgo.NewClient(kgo.SeedBrokers(broker), kgo.AllowAutoTopicCreation())
+	assert.NoError(t, err)
+	defer producer.Close()
+	produce(t, producer, topic, 1)
+
+	client := newTestClient(t, broker, topic, topic,
+		kgo.SessionTimeout(6*time.Second),
+		kgo.HeartbeatInterval(2*time.Second),
+	)
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+	stream := src.Stream()
+
+	select {
+	case batch := <-stream:
+		assert.Equal(t, int64(0), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("first message never arrived")
+	}
+
+	time.Sleep(8 * time.Second)
+	produce(t, producer, topic, 1)
+
+	select {
+	case batch := <-stream:
+		assert.Equal(t, int64(1), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the message after the idle gap never arrived")
+	}
+}
+```
+
+- [ ] **Step 2: WebSocket quiet server**
+
+Append to `internal/websocket/source_test.go`:
+
+```go
+// C5, WebSocket. A server that accepts and then says nothing for ten seconds
+// is a quiet stream, not a dead one. The source must still be listening
+// when the frame finally comes.
+func TestSourceWebsocket_SurvivesAQuietServer(t *testing.T) {
+	coverage.Covers(t, "source.websocket")
+	delivered := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.CloseNow()
+		time.Sleep(10 * time.Second)
+		_ = c.Write(r.Context(), websocket.MessageText, []byte(`{"late":true}`))
+		<-delivered
+	}))
+	defer srv.Close()
+
+	src, err := NewSource(wsURL(srv))
+	assert.NoError(t, err)
+	assert.NoError(t, src.Start())
+	defer src.Close()
+
+	select {
+	case batch := <-src.Stream():
+		assert.Equal(t, `{"late":true}`, string(batch[0].Value))
+		close(delivered)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the late frame never arrived")
+	}
+}
+```
+
+Use the same `websocket` import path the file already has (`github.com/coder/websocket`).
+
+- [ ] **Step 3: Run both**
+
+Run: `SQLFLOW_KAFKA_BROKERS=localhost:9092 go test ./internal/kafka/ -run SurvivesIdle -v -count=1 2>&1 | grep -E '^(--- |ok|FAIL)'`
+Expected: PASS in about 12 seconds against the dev broker.
+
+Run: `go test ./internal/websocket/ -run SurvivesAQuietServer -v -count=1 2>&1 | grep -E '^(--- |ok|FAIL)'`
+Expected: PASS in about 10 seconds. If the source has a read deadline shorter than ten seconds and reconnects during the quiet, that is a finding: the test still passes if the reconnect lands before the frame, but log it in the PR.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/kafka/source_test.go internal/websocket/source_test.go
+git commit -m "sources: a consumer survives idle past its session timeout, a WebSocket survives a quiet server
+
+Two cells for the trickle: eight seconds of silence against a six
+second Kafka session, and a server that accepts then says nothing for
+ten seconds. The next message arrives in both."
+```
+
+---
+
+### Task 8: The slow-soak skill
+
+**Files:**
+- Create: `.claude/skills/slow-soak/SKILL.md`, `profile.sh`, `sample.sh`, `verdict.py`, `slow.yml`
+
+**Interfaces:**
+- Consumes: the dev Kafka container `kafka1`, the `--with-http-debug` endpoint on `127.0.0.1:5000` queried through a sidecar the way `memory-soak/soak.sh` does, `/healthz` from Task 5.
+- Produces: `soak-<label>/samples.csv` and `verdict.txt`.
+
+- [ ] **Step 1: The pipeline under test**
+
+Create `.claude/skills/slow-soak/slow.yml`. It keeps its own landed table and a tumbling window, so latency and window closes are both readable through the debug endpoint:
+
+```yaml
+commands:
+  - name: tables
+    sql: |
+      CREATE TABLE IF NOT EXISTS landed (id BIGINT, sent_at TIMESTAMP, landed_at TIMESTAMP);
+      CREATE TABLE IF NOT EXISTS agg (bucket TIMESTAMP, count BIGINT);
+      CREATE TABLE IF NOT EXISTS published (bucket TIMESTAMP, count BIGINT, published_at TIMESTAMP);
+
+pipeline:
+  batch_size: 1000
+  flush_interval_seconds: 30
+  state:
+    path: /conf/state/slow.db
+  source:
+    type: kafka
+    kafka:
+      brokers: [{{ SQLFLOW_KAFKA_BROKERS|default('kafka1:19092') }}]
+      group_id: {{ SQLFLOW_GROUP_ID|default('slow-soak') }}
+      auto_offset_reset: earliest
+      topics:
+        - "{{ SQLFLOW_TOPIC|default('slow-soak') }}"
+  handler:
+    type: handlers.InferredMemBatch
+    sql: |
+      INSERT INTO landed SELECT id, CAST(sent_at AS TIMESTAMP), now()::TIMESTAMP FROM batch;
+      INSERT INTO agg
+        SELECT time_bucket(INTERVAL '1 minute', CAST(sent_at AS TIMESTAMP)) AS bucket, count(*)
+        FROM batch GROUP BY 1
+      ON CONFLICT DO NOTHING;
+      SELECT 1 WHERE false
+  sink:
+    type: noop
+
+tables:
+  sql:
+    - name: agg
+      sql: CREATE TABLE IF NOT EXISTS agg (bucket TIMESTAMP, count BIGINT)
+      manager:
+        tumbling_window:
+          poll_interval_seconds: 10
+          collect_closed_windows_sql: |
+            SELECT bucket, count FROM agg
+            WHERE bucket < (SELECT max(bucket) FROM agg) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
+          delete_closed_windows_sql: |
+            DELETE FROM agg
+            WHERE bucket < (SELECT max(bucket) FROM agg) - INTERVAL '60' SECOND
+               OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
+        sink:
+          type: sqlcommand
+          sqlcommand:
+            sql: INSERT INTO published SELECT bucket, count, now()::TIMESTAMP FROM sqlflow_sink_batch
+```
+
+Validate it: `go run ./cmd/sqlflow config validate .claude/skills/slow-soak/slow.yml`. If a multi-statement handler is not accepted, split the `landed` insert into the handler and move the aggregate into a second `tables` entry fed by the window; the executor chooses whichever the validator accepts and records it in SKILL.md. If `ON CONFLICT` needs a key, give `agg` a primary key on `bucket` and use `ON CONFLICT (bucket) DO UPDATE SET count = agg.count + excluded.count`.
+
+- [ ] **Step 2: The producer profile**
+
+Create `.claude/skills/slow-soak/profile.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Feed a topic with a scripted profile from inside the Kafka container.
+#
+#   profile.sh <kafka-container> <topic> [short]
+#
+# Phases, full profile: surge 5 min at 1,000/s; silence 60 min; trickle 60
+# min at one message per 90 s with two five-minute gaps and one pair sent in
+# the same second; silence 30 min. "short" runs 5 min per phase at the same
+# shapes. Every message carries its send time as sent_at.
+set -euo pipefail
+kafka=${1:?kafka container}; topic=${2:?topic}; mode=${3:-full}
+if [ "$mode" = short ]; then surge=300; s1=300; trickle=300; s2=300; else surge=300; s1=3600; trickle=3600; s2=1800; fi
+id=0
+send() { # n messages now
+  local n=$1 ts; ts=$(date -u +%Y-%m-%dT%H:%M:%S)
+  docker exec -i "$kafka" bash -c "awk -v s=$id -v n=$n -v ts=$ts 'BEGIN{for(i=0;i<n;i++) printf \"{\\\"id\\\":%d,\\\"sent_at\\\":\\\"%s\\\"}\\n\", s+i, ts}' | kafka-console-producer --bootstrap-server localhost:19092 --topic $topic >/dev/null 2>&1"
+  id=$((id + n))
+  echo "$(date -u +%H:%M:%SZ) sent=$n total=$id"
+}
+echo "phase surge ${surge}s"; end=$((SECONDS + surge)); while [ $SECONDS -lt $end ]; do send 1000; sleep 1; done
+echo "phase silence ${s1}s"; sleep "$s1"
+echo "phase trickle ${trickle}s"; end=$((SECONDS + trickle)); gap1=$((SECONDS + trickle/3)); gap2=$((SECONDS + 2*trickle/3)); pair=$((SECONDS + trickle/2))
+while [ $SECONDS -lt $end ]; do
+  if [ $SECONDS -ge $gap1 ] && [ $SECONDS -lt $((gap1 + 300)) ]; then sleep 10; continue; fi
+  if [ $SECONDS -ge $gap2 ] && [ $SECONDS -lt $((gap2 + 300)) ]; then sleep 10; continue; fi
+  if [ $SECONDS -ge $pair ] && [ $SECONDS -lt $((pair + 90)) ]; then send 2; pair=$end; else send 1; fi
+  sleep 90
+done
+echo "phase silence ${s2}s"; sleep "$s2"
+echo "PROFILE_DONE total=$id"
+```
+
+- [ ] **Step 3: The sampler**
+
+Create `.claude/skills/slow-soak/sample.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Sample a running slow-soak pipeline once a minute into samples.csv.
+#
+#   sample.sh <container-name> <out-dir> <minutes>
+#
+# Columns: t, produced (from the profile log), landed, max_latency_s,
+# lag (newest produced offset minus committed), anon_mib, state_bytes,
+# published_windows, healthz.
+set -uo pipefail
+name=${1:?container}; out=${2:?out dir}; minutes=${3:?minutes}
+mkdir -p "$out"; csv="$out/samples.csv"
+echo "t,produced,landed,max_latency_s,lag,anon_mib,state_bytes,published_windows,healthz" > "$csv"
+q() { docker run --rm --network "container:$name" curlimages/curl:latest -s --max-time 8 "http://127.0.0.1:5000/debug?sql=$(python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1]))' "$1")" 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); r=d.get("rows") or d.get("data") or [[None]]; print(r[0][0] if r and r[0] else "")' 2>/dev/null; }
+for ((i=0; i<minutes; i++)); do
+  t=$(date -u +%H:%M:%SZ)
+  produced=$(grep -o 'total=[0-9]*' "$out/profile.log" 2>/dev/null | tail -1 | cut -d= -f2)
+  landed=$(q "SELECT count(*) FROM landed")
+  lat=$(q "SELECT coalesce(max(epoch(landed_at - sent_at)),0) FROM landed WHERE landed_at > now() - INTERVAL '2' MINUTE")
+  committed=$(q "SELECT coalesce(max(\"offset\"),-1) FROM sqlflow_offsets")
+  lag=$(( ${produced:-0} - 1 - ${committed:-0} ))
+  anon=$(docker exec "$name" sh -c 'awk "/^anon /{print int(\$2/1048576)}" /sys/fs/cgroup/memory.stat 2>/dev/null' )
+  state=$(docker exec "$name" sh -c 'stat -c %s /conf/state/slow.db 2>/dev/null')
+  pub=$(q "SELECT count(*) FROM published")
+  hz=$(docker run --rm --network "container:$name" curlimages/curl:latest -s -o /dev/null -w '%{http_code}' --max-time 5 http://127.0.0.1:8000/healthz 2>/dev/null)
+  echo "$t,${produced:-},${landed:-},${lat:-},${lag},${anon:-},${state:-},${pub:-},${hz:-}" | tee -a "$csv"
+  sleep 60
+done
+```
+
+The `/debug?sql=` response shape is whatever `internal/cli/run/debug.go` returns; the executor reads that file and fixes the one-line JSON extraction in `q` to match, and notes the shape in SKILL.md.
+
+- [ ] **Step 4: The verdict**
+
+Create `.claude/skills/slow-soak/verdict.py`:
+
+```python
+"""Judge a slow-soak samples.csv. Exit 1 on any failed rule, printing each."""
+import csv, sys
+rows = list(csv.DictReader(open(sys.argv[1])))
+interval = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+fails = []
+def f(x, d=0.0):
+    try: return float(x)
+    except (TypeError, ValueError): return d
+if not rows: sys.exit("no samples")
+# 1. latency: never more than the interval plus thirty seconds
+worst = max(f(r["max_latency_s"]) for r in rows)
+if worst > interval + 30: fails.append(f"latency {worst:.0f}s exceeds interval+30")
+# 2. lag: after the surge, never more than one interval's worth of arrivals; at a trickle that is one message
+tail = rows[len(rows)//4:]
+if any(f(r["lag"], 0) > 1 for r in tail if r["produced"]): fails.append("offset lag above one interval after the surge")
+# 3. memory: end of run within 10% of the pre-surge working set
+first, last = f(rows[0]["anon_mib"]), f(rows[-1]["anon_mib"])
+if first and last > first * 1.10: fails.append(f"working set {last:.0f} MiB ended more than 10% above start {first:.0f}")
+# 4. state file: must not grow through a silence (any 30 consecutive samples with no landed change)
+for i in range(30, len(rows)):
+    win = rows[i-30:i+1]
+    if len({r["landed"] for r in win}) == 1 and f(win[-1]["state_bytes"]) > f(win[0]["state_bytes"]) * 1.05:
+        fails.append(f"state file grew through a silence around sample {i}"); break
+# 5. windows: every bucket with landed rows is published by the end
+if f(rows[-1]["published_windows"]) == 0: fails.append("no window was ever published")
+# 6. health: never red
+if any(r["healthz"] not in ("200", "") for r in rows): fails.append("healthz went red")
+print("\n".join(fails) if fails else f"PASS over {len(rows)} samples; worst latency {worst:.0f}s, working set {first:.0f} to {last:.0f} MiB")
+sys.exit(1 if fails else 0)
+```
+
+Rule 5 is deliberately coarse; the executor tightens it to "published count equals the number of distinct minute buckets landed" once the pipeline shape from Step 1 is settled.
+
+- [ ] **Step 5: SKILL.md**
+
+Create `.claude/skills/slow-soak/SKILL.md`:
+
+```markdown
+---
+name: slow-soak
+description: Use when a pipeline must be shown to stay live and correct under slow, bursty, or absent traffic for hours: latency on a trickle, the tail of a surge, idle commits, window closes on silence, and health reporting.
+---
+
+# Slow soak
+
+Throughput proves nothing about a stream that trickles, stops, or never
+starts. This runs a scripted profile against a real broker for hours and
+judges seven things once a minute. One line per sample; everything else in
+files.
+
+## Run it
+
+    cp -r .claude/skills/slow-soak /tmp/slow-soak && cd /tmp/slow-soak
+    make start-backing-services
+    docker run -d --name sqlflow-slow --network dev_default -p 8000:8000 \
+      -v "$PWD":/conf -e SQLFLOW_TOPIC=slow-$(date +%s) \
+      turbolytics/sql-flow:<tag> run /conf/slow.yml --metrics=prometheus --with-http-debug
+    ./profile.sh kafka1 $SQLFLOW_TOPIC full > soak-full/profile.log 2>&1 &
+    ./sample.sh sqlflow-slow soak-full 160
+    python3 verdict.py soak-full/samples.csv 30
+
+`short` in place of `full` runs five minutes a phase for a dry run; give
+`sample.sh` 25 minutes for it. Copy the directory first: a checkout under a
+running soak has bitten before.
+
+## What a failure means
+
+- Latency above the interval plus thirty: the flush ticker is not firing,
+  or a flush is slow. Look at commit latency in /metrics.
+- Lag above one interval after the surge: offsets are not committing per
+  flush. Look at the state commit count.
+- Working set ending above where it started: something held from the surge.
+  Switch to memory-soak for the decomposition.
+- State file growing through a silence: empty commits are not empty.
+- No window published, or healthz red: read /stats progress; a stuck commit
+  clock is the engine, a moving one with no windows is the predicate.
+```
+
+- [ ] **Step 6: Dry run**
+
+From a scratchpad copy, run the `short` profile against the branch's image (`make sqlflow-image` gives `turbolytics/sql-flow:<git describe>`), sample for 25 minutes, and run the verdict. Expected: `PASS over 25 samples`. Fix whatever the dry run shows before the full run. Record the dry run's summary line in the commit message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .claude/skills/slow-soak/
+git commit -m "slow-soak: a scripted traffic profile, sampled once a minute, judged at the end
+
+Surge, silence, trickle with gaps, silence. Latency, offset lag, working
+set, state file size, window closes and /healthz, one line per sample,
+seven rules at the end. Dry run: <summary line>."
+```
+
+---
+
+### Task 9: PR, CI, coverage matrix, the full soak
+
+**Files:**
+- Modify: `docs/coverage/matrix.json`, `docs/coverage/matrix.md` (from CI artifacts only)
+
+- [ ] **Step 1: Push and open the PR**
+
+```bash
+git push -u origin feat/slow-data-confidence
+gh pr create --title "Slow-moving data: liveness proven under trickle, surge, and silence" --body-file - <<'EOF'
+## Why
+
+Every proof the engine carried was taken under load. Nothing showed what happens when a stream trickles, stops, or never starts. One of those was a known defect: the stream-clock window predicate from #234 holds a quiet stream's last window open until data a full grace newer arrives.
+
+## What
+
+- `sqlflow_progress`, a one-row engine table beside `sqlflow_offsets`: when the newest batch arrived, when state last committed, messages consumed. Written inside the state transaction; an idle tick moves the commit clock only.
+- The window predicate gains an idleness branch that reads it. A quiet stream closes every open window a grace after its last row. A replay still closes each window once. The four shipped examples change.
+- `/stats` reports progress ages; `/healthz` answers 200 while the commit clock is younger than three intervals and 503 with the age otherwise. Idle is healthy, stuck is not.
+- The `flush_interval_seconds: 0` invariant was wrong: the run command already defaults it. Pinned by a test, registry corrected and marked enforced.
+- Seven cells: trickle latency, surge tail, idle commits keep the file flat, quiet stream closes its window, replay stays whole, Kafka survives idle past its session timeout, WebSocket survives a quiet server, healthz tells idle from stuck.
+- A `slow-soak` skill: scripted surge, silence, trickle, silence over about two and a half hours, seven rules judged at the end.
+
+## Soak
+
+<the full profile's verdict line and the samples summary, filled from Step 4>
+
+Spec: `docs/superpowers/specs/2026-09-10-slow-data-confidence-design.md`.
+EOF
+```
+
+- [ ] **Step 2: CI, then the matrix from the artifacts**
+
+Run: `gh pr checks --watch`. Expected: green. Then:
+
+```bash
+run=$(gh run list --branch feat/slow-data-confidence --limit 1 --json databaseId --jq '.[0].databaseId')
+rm -rf .coverage && mkdir -p .coverage
+for a in report-unit report-integration report-release; do gh run download "$run" -n "$a" -D "/tmp/cov-$a"; done
+cp /tmp/cov-report-unit/go.json /tmp/cov-report-integration/go-integration.json /tmp/cov-report-release/pytest.json .coverage/
+make coverage-write
+git add docs/coverage/matrix.json docs/coverage/matrix.md
+git commit -m "coverage: matrix from the slow-data CI run"
+git push
+```
+
+- [ ] **Step 3: Build the image and run the full soak**
+
+From a scratchpad copy of `.claude/skills/slow-soak`, against the PR branch's image, run the full profile and sample for 160 minutes. Expected: `PASS over 160 samples`. Paste the verdict line and the min, max of `max_latency_s`, `anon_mib`, and `state_bytes` into the PR body.
+
+- [ ] **Step 4: Merge when the user says so**
+
+The user merges. Not before the soak verdict is in the PR.
+
+---
+
+### Task 10: Docs on turbolytics.io
+
+**Files (turbolytics.io repo, a branch off main):**
+- Modify: `src/content/docs/sqlflow/tutorials/tumbling-window-postgres.md`, `src/content/docs/sqlflow/tutorials/bluesky-firehose.md` (the predicate and its explanation)
+- Modify: `src/content/docs/sqlflow/introduction/configuration.md` (after the `flush_interval_seconds` paragraph at ~line 110)
+- Modify: `src/data/benchmark.ts`, `src/pages/products/sqlflow/benchmarks.astro` (a "Slow data" section)
+
+- [ ] **Step 1: The predicate in the tutorials**
+
+Wherever a tutorial shows the collect and delete predicates, replace them with the two-branch form from Task 4 and add, once, after the explanation of the stream clock:
+
+```markdown
+A stream that goes quiet never moves its own clock, so the stream clock alone would hold the last window open until data a full grace newer arrived. The second branch closes every open window after a grace period of silence. It reads `sqlflow_progress`, the engine's one-row liveness table, whose `last_arrival` is when the newest batch was written.
+```
+
+- [ ] **Step 2: Configuration page**
+
+After the `flush_interval_seconds` paragraph, add:
+
+````markdown
+### Liveness
+
+sqlflow keeps one row of liveness in `sqlflow_progress`: `last_arrival`, when the newest batch was written; `last_commit`, when state last committed; and `messages`. A batch moves all three. An idle tick moves `last_commit` only. Your SQL can read it, and the shipped tumbling window examples do.
+
+`/stats` on port 8000 reports the same facts with their ages in seconds. `/healthz` returns 200 while `last_commit` is younger than three flush intervals, and 503 with the age otherwise:
+
+```
+{"status":"stuck","commit_age_seconds":91,"interval_seconds":30}
+```
+
+Idle is healthy. A pipeline that receives nothing still commits on every interval.
+````
+
+- [ ] **Step 3: Benchmarks page**
+
+Add to `src/data/benchmark.ts`:
+
+```ts
+/** The slow-soak verdict: a scripted profile against a real broker. Fill from the run. */
+export const slowSoak = {
+  measured: '2026-09-1x',
+  profile: 'five minutes at 1,000/s, an hour of silence, an hour at one message per 90 seconds with gaps, thirty minutes of silence',
+  samples: '160, once a minute',
+  worstLatency: '<s>',
+  workingSet: '<start> to <end> MiB',
+  stateFile: 'flat through both silences',
+  windows: 'every bucket published within a grace of its last row',
+  healthz: '200 at every sample',
+} as const;
+```
+
+and a section in `benchmarks.astro` after "Memory under load", eyebrow "Slow data", heading "Live under a trickle. Live after a surge.", with one card per rule and the profile in the lede. Fill every value from the soak; leave no `<...>`.
+
+- [ ] **Step 4: Build, test, commit, push held**
+
+Run `npm run build && npm test`, the em dash check and the collapsed-space check from the benchmarks work. Commit on the branch; the push is the user's call.
+
+---
+
+## Self-review
+
+**Spec coverage.** Progress table and snapshot: Task 1. Trickle and surge cells C1, C2: Task 2. Idle file growth C3: Task 3. Window predicate and C4 both halves, the four examples: Task 4. `/stats` progress and `/healthz`, C7: Task 5. Wiring, the corrected invariant, C6: Task 6. Idle survival C5: Task 7. The soak skill with its profile, sampler, verdict, dry run: Task 8. PR, matrix from CI, full soak: Task 9. Docs, all three surfaces: Task 10. Out of scope items have no task.
+
+**Placeholders.** The `<...>` values in Task 9's PR body and Task 10's `slowSoak` are filled from the soak before the step runs, and both steps say so. Three points name a helper the executor must locate rather than invent (`beginTx`, `exec`, `rowCount`, `newTestTumblingWith`, the `/debug` JSON shape) and each says exactly which file to mirror. Nothing says "TBD".
+
+**Type consistency.** `core.Progress{LastArrival, LastCommit, Messages}` in Tasks 1, 4, 5, 6. `progressSaver.Record(ctx, Progress) error` in Tasks 1 and 3. `newHTTPMux(registry, stats, progress, interval, now)` in Tasks 5 and 6. `flushIntervalFor(int) time.Duration` in Task 6 only. The predicate text is identical in Task 4's test, the four examples, Task 8's config and Task 10's docs, apart from the grace.
+
+**One decision made in review.** The spec put progress inside the state transaction; a stateless pipeline has no transaction. Task 1 records at the top of `commitState`, before its early return, so both modes record, and Task 6 gives the stateless store its own connection on the in-memory database. The window predicate reads committed data in the state-file case and autocommitted data otherwise, which is the same fact either way.

--- a/docs/superpowers/specs/2026-09-10-slow-data-confidence-design.md
+++ b/docs/superpowers/specs/2026-09-10-slow-data-confidence-design.md
@@ -1,0 +1,202 @@
+# Slow-moving data: the same confidence as throughput
+
+Status: design, 2026-09-10.
+
+## The problem
+
+Every proof the engine carries today was taken under load. The throughput
+matrix consumes ten million messages in seconds, the memory soak runs a
+thousand messages a second for an hour, and the conformance harness drives
+its sources as fast as they will go. Nothing proves what happens when a
+stream is slow, stops, or never starts, and that is most streams most of the
+time.
+
+Slow data breaks different things than fast data. A batch that never fills
+has to leave on a timer. An offset has to commit even though the batch was
+one row. A state transaction has to close while nothing arrives. A window
+whose rows have stopped coming has to close anyway. A consumer has to stay
+joined to a broker it has not heard from in an hour. And an operator has to
+be able to tell a pipeline that is idle from one that is stuck, which today
+look identical from outside.
+
+One of these is a known defect. The tumbling window examples shipped in #234
+close a window against the stream's own clock, `max(bucket) - grace`, so a
+replay no longer fragments windows. The cost is that a stream which goes
+quiet never moves its clock, and its last window stays open until data
+arrives that is a full grace period newer. A surge that stops leaves a full
+bucket unpublished indefinitely.
+
+## Three shapes, not one rate
+
+Confidence means proving every invariant under each of these, because they
+fail differently:
+
+- **Trickle.** One message every few minutes, sometimes two in a second,
+  sometimes a gap of an hour. Every message pays a full flush. The question
+  is latency and liveness, not throughput.
+- **Surge, then silence.** Minutes at benchmark rates, then nothing for an
+  hour. The surge looks like the throughput matrix; everything interesting
+  happens after it stops: the last partial batch, the last offset, the last
+  window, and the memory that should come back down.
+- **Nothing.** A pipeline that starts and receives no message for hours.
+  Idle commits, a state file that does not grow, and a health check that
+  still says healthy, because idle is not stuck.
+
+## The invariants
+
+| Invariant | Today | Proof |
+| --- | --- | --- |
+| A message reaches the sink within `flush_interval_seconds` of arriving, at any rate and after any gap | `pipeline.flush.eventually` is a harness cell driven at full speed | Cell C1 at a trickle, cell C2 after a surge, and the soak's latency sample |
+| Offsets commit after every flush, so lag never exceeds one interval and a restart replays at most one interval | Unit tested | C1 and C2 check marks; the soak samples committed offset against produced |
+| An idle stateful pipeline keeps committing, and empty commits do not grow the state file | Unit tested for one tick | C3 over many ticks; the soak samples file size through an hour of silence |
+| A window whose rows have stopped closes within grace plus one poll, and a replay still publishes each window once | Fails for the shipped stream-clock examples | C4, both halves, on the new predicate |
+| A consumer survives idle longer than its session timeout, and a WebSocket source survives a quiet server and reconnects after a dropped one | Untested | C5 against a real broker and a scripted server |
+| A configuration that cannot make progress does not run quietly | `flush_interval_seconds: 0` already becomes 30 in `cli/run/root.go:346`; the invariant says otherwise and is marked unenforced | C6 pins the default; the registry entry is corrected and marked enforced |
+| An operator can tell idle from stuck | `/stats` reports state only | Progress on `/stats`, a `/healthz` that goes red, and C7 |
+
+## Engine changes
+
+Three, all small.
+
+### A progress table the SQL can see
+
+The consume loop maintains one engine table, `sqlflow_progress`, beside
+`sqlflow_offsets`, with one row:
+
+```sql
+CREATE TABLE IF NOT EXISTS sqlflow_progress (
+  last_arrival TIMESTAMP,   -- wall clock when the newest batch was written
+  last_commit  TIMESTAMP,   -- wall clock of the newest state commit
+  messages     BIGINT       -- consumed since start
+);
+```
+
+`processBatch` sets `last_arrival`, `last_commit` and `messages` inside the
+state transaction it already commits, so they are durable with the offsets.
+The idle tick sets `last_commit` only. A pipeline without a state file gets
+the same table in its in-memory database. It is engine bookkeeping like
+`sqlflow_offsets`, excluded from the state stats the same way.
+
+The window manager runs its collect SQL on its own connection to the same
+database (`internal/managers/tumbling.go:133`), so the predicate can read it
+with no new plumbing.
+
+### The window predicate: stream clock, or idleness
+
+The shipped examples change from
+
+```sql
+WHERE bucket < (SELECT max(bucket) FROM agg) - INTERVAL '60' SECOND
+```
+
+to
+
+```sql
+WHERE bucket < (SELECT max(bucket) FROM agg) - INTERVAL '60' SECOND
+   OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '60' SECOND
+```
+
+Under a replay, arrivals are continuous, the second branch stays false, and
+the first closes each window once as the stream passes it, which is the
+property #234 bought. When the stream goes quiet for the grace period, the
+second branch closes every open window, including the newest. `now()` in the
+manager's own statement is the statement's start time, so it is fresh on
+every poll; the consume loop's idle commit is what keeps `last_arrival`
+honest rather than frozen.
+
+Rows that arrive for a bucket after it has closed on idleness form a new
+partial for that bucket and publish as a second part. That is the engine's
+existing at-least-once behaviour for late rows and the docs already describe
+it; nothing here changes it.
+
+### Progress on `/stats`, and `/healthz`
+
+`/stats` gains a `progress` object: `last_arrival`, `last_commit`,
+`messages`, and the two ages in seconds. `/healthz` returns 200 while
+`last_commit` is younger than three flush intervals and 503 with the age in
+the body otherwise. Idle is healthy; the commit keeps happening. Stuck is not.
+The threshold is three intervals so one slow sink flush does not flap it.
+
+## Conformance cells
+
+Each is a Go test in the existing harness style, first line
+`coverage.Covers(t, "<feature>")`, minutes at most, using the Turbine's
+flush interval directly, which has no floor outside the config path.
+
+- **C1, trickle latency.** A recording source emits one message every two
+  seconds for twenty seconds, batch size 1000, flush interval one second.
+  Every message reaches the sink within the interval plus a scheduling
+  allowance, and the committed mark advances after each flush.
+- **C2, surge then silence.** Five thousand messages at full speed, then
+  nothing for five intervals. The final partial batch reaches the sink
+  within one interval of the last arrival, the mark equals the last offset,
+  and no further sink write occurs during the silence.
+- **C3, idle commits stay flat.** A stateful pipeline with a state file,
+  twenty idle ticks. `last_commit` advances on every tick, `last_arrival`
+  does not, and the state file's size after tick twenty is within one
+  checkpoint of its size after tick one.
+- **C4, windows close on silence and stay whole on replay.** The example
+  predicate, a one-minute window, a one-second poll, a five-second grace for
+  the test. Half one: rows into one bucket, then silence; the bucket
+  publishes once within grace plus a poll. Half two: rows spanning three
+  buckets delivered in one burst; each bucket publishes exactly once. Half
+  two is the #234 property and must keep passing.
+- **C5, idle survival.** Kafka, against a real broker: consume one message,
+  stay idle past a session timeout set to six seconds for the test, produce
+  one, consume it. WebSocket, against a scripted server: a server that says
+  nothing for ten seconds then sends a frame, delivered; a server that closes
+  the connection, reconnected and the next frame delivered.
+- **C6, no silent stall.** `flush_interval_seconds` absent, zero and
+  negative all yield thirty seconds through the config path. The invariant
+  registry entry is rewritten to say so and marked enforced.
+- **C7, idle is healthy, stuck is not.** With a fake clock: `/healthz` is
+  200 through idle ticks, and 503 with the age once no commit has happened
+  for three intervals.
+
+Cells C1 to C4 and C7 run in the unit pass. C5 is an integration cell.
+
+## The soak
+
+A skill beside `memory-soak`, `slow-soak`, with the same shape: a producer,
+a sampler, a verdict, one line per sample, everything else in files.
+
+The producer runs a scripted profile rather than a rate:
+
+| Phase | Duration | Traffic |
+| --- | --- | --- |
+| surge | 5 minutes | 1,000 messages a second |
+| silence | 60 minutes | none |
+| trickle | 60 minutes | one message every 90 seconds, with two five-minute gaps and one pair sent in the same second |
+| silence | 30 minutes | none |
+
+Every message carries its send time. The sampler, once a minute, records:
+messages produced and messages at the sink, the newest sink row's arrival
+latency, the committed offset against the last produced offset, resident
+anonymous memory, the state file's size, the count of published window rows,
+and `/healthz`. The verdict fails on any of: a latency above the flush
+interval plus thirty seconds, an offset lag above one interval at any sample
+after the surge, a working set at the end of the second silence more than
+ten percent above the working set before the surge, a state file that grew
+through a silence, a window unpublished a grace and a poll after its last
+row, or a red `/healthz` at any sample.
+
+Default duration is the profile above, about two and a half hours. A short
+profile of five minutes per phase exists for a dry run.
+
+## Docs
+
+- The tumbling window tutorials and the FAQ describe the predicate's two
+  branches and the one sentence a reader needs: a quiet stream closes its
+  open windows a grace period after its last row.
+- The configuration page documents `sqlflow_progress`, `/stats` progress,
+  and `/healthz`, beside the existing `flush_interval_seconds` text.
+- The benchmarks page gains a "Slow data" section reporting the soak the
+  way the memory section reports its hour.
+
+## Out of scope
+
+- An event-time watermark and a late-data policy, which is #203. The
+  idleness bound closes windows; it does not reorder them.
+- `max_memory` and `max_state_size`, the other half of #162.
+- Sources other than Kafka and WebSocket in C5. The webhook source has no
+  connection to keep alive.

--- a/internal/cli/run/flush_interval_test.go
+++ b/internal/cli/run/flush_interval_test.go
@@ -1,0 +1,22 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// The invariant registry claimed a zero flush interval removes the ticker,
+// leaving a batch a low-traffic topic never fills to wait forever. It does
+// not: the run command has always defaulted it. This pins that for every
+// value a config can produce, so the claim and the code agree.
+func TestCliInvocation_FlushIntervalNeverZero(t *testing.T) {
+	coverage.Covers(t, "cli.invocation")
+	// Absent from the config decodes as zero.
+	assert.Equal(t, 30*time.Second, flushIntervalFor(0))
+	assert.Equal(t, 30*time.Second, flushIntervalFor(-5))
+	assert.Equal(t, 45*time.Second, flushIntervalFor(45))
+	assert.Equal(t, time.Second, flushIntervalFor(1))
+}

--- a/internal/cli/run/health_test.go
+++ b/internal/cli/run/health_test.go
@@ -1,0 +1,88 @@
+package run
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/core"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// Idle is healthy: the commit clock keeps moving while nothing arrives, and
+// that is the whole point. A pipeline on a trickle looks dead to anything
+// watching message counts, so the health check watches commits instead.
+// Stuck is three intervals without one, and the body says how old it is.
+func TestObservabilityMetrics_HealthzTellsIdleFromStuck(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	clock := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	now := func() time.Time { return clock }
+	p := core.Progress{
+		LastArrival: clock.Add(-time.Hour),
+		LastCommit:  clock.Add(-20 * time.Second),
+		Messages:    42,
+	}
+	mux := newHTTPMux(nil, nil, func() core.Progress { return p }, 30*time.Second, now)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	get := func(path string) (int, map[string]any) {
+		resp, err := http.Get(srv.URL + path)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp.StatusCode, body
+	}
+
+	// An hour with no message, a commit twenty seconds ago: healthy.
+	code, body := get("/healthz")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "ok", body["status"])
+
+	// /stats carries both ages, so a dashboard can show "quiet for an hour"
+	// without calling that an outage.
+	_, stats := get("/stats")
+	prog := stats["progress"].(map[string]any)
+	assert.Equal(t, float64(42), prog["messages"])
+	assert.Equal(t, float64(3600), prog["arrival_age_seconds"])
+	assert.Equal(t, float64(20), prog["commit_age_seconds"])
+
+	// Three intervals without a commit: stuck.
+	p.LastCommit = clock.Add(-91 * time.Second)
+	code, body = get("/healthz")
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, "stuck", body["status"])
+	assert.Equal(t, float64(91), body["commit_age_seconds"])
+
+	// Nothing recorded yet, which is every pipeline for its first interval.
+	// Healthy, measured from when the server started, not from the epoch.
+	p = core.Progress{}
+	code, body = get("/healthz")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, float64(0), body["commit_age_seconds"])
+
+	// A pipeline that never commits is stuck once the grace runs out, even
+	// though it has never recorded anything.
+	clock = clock.Add(2 * time.Minute)
+	code, body = get("/healthz")
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, "stuck", body["status"])
+}
+
+// Without a progress source there is no health to report, and the endpoint
+// must not exist rather than answer "ok" for a pipeline it cannot see.
+func TestObservabilityMetrics_HealthzAbsentWithoutProgress(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	mux := newHTTPMux(nil, nil, nil, 30*time.Second, time.Now)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/internal/cli/run/metrics.go
+++ b/internal/cli/run/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -23,39 +24,116 @@ const metricsPort = ":8000"
 // nil snapshot, and no error, for a pipeline that has no state database.
 type statsFunc func() (*core.StateStats, error)
 
-// newHTTPMux builds the server the pipeline exposes: Prometheus scraping, and
-// a JSON view of durable state.
+// progressFunc reports the pipeline's liveness snapshot: when the newest
+// batch arrived, when state last committed, and how many messages have been
+// consumed.
+type progressFunc func() core.Progress
+
+// stuckIntervals is how many flush intervals may pass with no commit before
+// /healthz calls the pipeline stuck. Three, so one slow sink flush cannot
+// flap it.
+const stuckIntervals = 3
+
+// newHTTPMux builds the server the pipeline exposes: Prometheus scraping, a
+// JSON view of durable state and progress, and a health check.
 //
-// The two are on one mux deliberately. DuckDB takes an exclusive lock on the
-// state file, so no other process can read it while the pipeline runs -- not
-// even read-only. A running pipeline is the only thing that can report its own
-// state, which makes this endpoint the live half of observability rather than
-// a convenience.
-func newHTTPMux(registry *prom.Registry, stats statsFunc) *http.ServeMux {
+// The first two are on one mux deliberately. DuckDB takes an exclusive lock
+// on the state file, so no other process can read it while the pipeline runs
+// -- not even read-only. A running pipeline is the only thing that can report
+// its own state, which makes this endpoint the live half of observability
+// rather than a convenience.
+//
+// /healthz answers the one question a supervisor has, and it is not "are
+// messages arriving": a pipeline on a low-traffic topic may go hours between
+// them and be perfectly well. It is "is this pipeline still doing its work",
+// which is the commit clock, because the idle tick commits whether or not
+// anything arrived. Idle is healthy. Stuck is stuckIntervals without a
+// commit, and the body carries the age so an operator need not guess.
+//
+// now is injectable for the test. started covers the window before the first
+// commit: a pipeline that has just launched has no commit clock yet, and
+// must not be called stuck for not having one, but must be called stuck if
+// it never gets one.
+func newHTTPMux(registry *prom.Registry, stats statsFunc, progress progressFunc, interval time.Duration, now func() time.Time) *http.ServeMux {
 	mux := http.NewServeMux()
+	started := now()
 
 	if registry != nil {
 		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	}
 
-	if stats != nil {
+	// ages reports the snapshot with its two ages in seconds. An age of -1
+	// means the clock has never moved, which for arrivals is an ordinary
+	// fact about a stream that has not delivered yet.
+	ages := func() (core.Progress, float64, float64) {
+		p := progress()
+		arrival := -1.0
+		if !p.LastArrival.IsZero() {
+			arrival = now().Sub(p.LastArrival).Seconds()
+		}
+		commit := now().Sub(started).Seconds()
+		if !p.LastCommit.IsZero() {
+			commit = now().Sub(p.LastCommit).Seconds()
+		}
+		return p, arrival, commit
+	}
+
+	if stats != nil || progress != nil {
 		mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
-			state, err := stats()
-			if err != nil {
-				// A monitoring system must see the failure, not a
-				// healthy-looking blank.
-				http.Error(w, fmt.Sprintf("collecting state stats: %v", err),
-					http.StatusInternalServerError)
-				return
+			out := map[string]any{"state": nil}
+
+			if stats != nil {
+				state, err := stats()
+				if err != nil {
+					// A monitoring system must see the failure, not a
+					// healthy-looking blank.
+					http.Error(w, fmt.Sprintf("collecting state stats: %v", err),
+						http.StatusInternalServerError)
+					return
+				}
+				// state is nil for a pipeline with no state database, which
+				// encodes as null: absent state and empty state are different
+				// facts and a dashboard should be able to tell them apart.
+				out["state"] = state
+			}
+
+			if progress != nil {
+				p, arrival, commit := ages()
+				out["progress"] = map[string]any{
+					"last_arrival":        p.LastArrival,
+					"last_commit":         p.LastCommit,
+					"messages":            p.Messages,
+					"arrival_age_seconds": arrival,
+					"commit_age_seconds":  commit,
+				}
 			}
 
 			w.Header().Set("Content-Type", "application/json")
-			// state is nil for a pipeline with no state database, which
-			// encodes as null: absent state and empty state are different
-			// facts and a dashboard should be able to tell them apart.
-			if err := json.NewEncoder(w).Encode(map[string]any{"state": state}); err != nil {
+			if err := json.NewEncoder(w).Encode(out); err != nil {
 				return
 			}
+		})
+	}
+
+	if progress != nil {
+		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			_, _, commit := ages()
+			w.Header().Set("Content-Type", "application/json")
+
+			if commit > float64(stuckIntervals)*interval.Seconds() {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"status":             "stuck",
+					"commit_age_seconds": commit,
+					"interval_seconds":   interval.Seconds(),
+				})
+				return
+			}
+
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":             "ok",
+				"commit_age_seconds": commit,
+			})
 		})
 	}
 
@@ -64,7 +142,7 @@ func newHTTPMux(registry *prom.Registry, stats statsFunc) *http.ServeMux {
 
 // newMeterProvider starts the exporter named by --metrics. An empty name
 // disables metrics entirely.
-func newMeterProvider(name string, l *zap.Logger, stats statsFunc) (metric.MeterProvider, error) {
+func newMeterProvider(name string, l *zap.Logger, stats statsFunc, progress progressFunc, interval time.Duration) (metric.MeterProvider, error) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "":
 		return nil, nil
@@ -76,7 +154,7 @@ func newMeterProvider(name string, l *zap.Logger, stats statsFunc) (metric.Meter
 			return nil, fmt.Errorf("prometheus exporter: %w", err)
 		}
 
-		mux := newHTTPMux(registry, stats)
+		mux := newHTTPMux(registry, stats, progress, interval, time.Now)
 
 		go func() {
 			l.Info("serving prometheus metrics", zap.String("addr", metricsPort+"/metrics"))
@@ -90,4 +168,16 @@ func newMeterProvider(name string, l *zap.Logger, stats statsFunc) (metric.Meter
 	default:
 		return nil, fmt.Errorf("unsupported --metrics exporter: %q (supported: prometheus)", name)
 	}
+}
+
+// flushIntervalFor is the one place the flush interval is decided. Absent,
+// zero and negative all mean the default: a ticker the pipeline cannot lose,
+// because a batch that a low-traffic topic never fills would otherwise wait
+// forever. The config schema's own floor is thirty seconds, so this only
+// ever fires for a config that omits the key.
+func flushIntervalFor(seconds int) time.Duration {
+	if seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	return 30 * time.Second
 }

--- a/internal/cli/run/metrics_test.go
+++ b/internal/cli/run/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -35,7 +36,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsState(t *testing.T) {
 		Offsets:   []core.OffsetStat{{Topic: "events", Partition: 0, Offset: 999, LeaderEpoch: 7}},
 	}
 
-	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return want, nil })
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return want, nil }, nil, 30*time.Second, time.Now)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
@@ -62,7 +63,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsState(t *testing.T) {
 // endpoint stays useful for the counters even when nothing is durable.
 func TestObservabilityMetrics_StatsHandler_NullStateWithoutAStateDatabase(t *testing.T) {
 	coverage.Covers(t, "observability.metrics")
-	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return nil, nil })
+	mux := newHTTPMux(nil, func() (*core.StateStats, error) { return nil, nil }, nil, 30*time.Second, time.Now)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
@@ -80,7 +81,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsCollectionFailure(t *testing.T
 	coverage.Covers(t, "observability.metrics")
 	mux := newHTTPMux(nil, func() (*core.StateStats, error) {
 		return nil, errors.New("state database unreadable")
-	})
+	}, nil, 30*time.Second, time.Now)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))
@@ -91,7 +92,7 @@ func TestObservabilityMetrics_StatsHandler_ReportsCollectionFailure(t *testing.T
 // endpoint must not be registered as a half-working route.
 func TestObservabilityMetrics_StatsHandler_AbsentWithoutAProvider(t *testing.T) {
 	coverage.Covers(t, "observability.metrics")
-	mux := newHTTPMux(nil, nil)
+	mux := newHTTPMux(nil, nil, nil, 30*time.Second, time.Now)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stats", nil))

--- a/internal/cli/run/root.go
+++ b/internal/cli/run/root.go
@@ -20,8 +20,8 @@ import (
 	"os/signal"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
-	"time"
 
 	"github.com/turbolytics/sql-flow/internal/config"
 	"github.com/turbolytics/sql-flow/internal/core"
@@ -191,10 +191,34 @@ func NewCommand() *cobra.Command {
 			// the table managers and the debug API.
 			lock := &sync.Mutex{}
 
+			// Liveness, for every pipeline whether or not it has a state path.
+			// Created before the state branch turns autocommit off, so the
+			// CREATE TABLE commits on its own the way the offsets table's
+			// does. With a state path its updates then ride each batch's
+			// transaction; without one they autocommit.
+			progressStore := core.NewProgressStore(conn)
+			if err := progressStore.Init(context.Background()); err != nil {
+				return err
+			}
+
+			// The metrics mux is built before the turbine exists, so the
+			// health endpoint reads through a pointer the turbine fills in
+			// below. Until then a zero snapshot means "no commit yet", which
+			// /healthz measures from when the server started.
+			var liveTurbine atomic.Pointer[core.Turbine]
+			progressFn := func() core.Progress {
+				if tb := liveTurbine.Load(); tb != nil {
+					return tb.Progress()
+				}
+				return core.Progress{}
+			}
+
+			flushInterval := flushIntervalFor(conf.Pipeline.FlushIntervalSeconds)
+
 			// State wiring. Everything below is skipped for a pipeline with no
 			// state path, which then behaves exactly as it did before.
 			var (
-				turbineOpts []core.TurbineOption
+				turbineOpts = []core.TurbineOption{core.WithProgressStore(progressStore)}
 				statsFn     statsFunc
 				storedMarks *core.Marks
 			)
@@ -267,7 +291,7 @@ func NewCommand() *cobra.Command {
 				startDebugServer(conn, lock, l)
 			}
 
-			meterProvider, err := newMeterProvider(metricsExporter, l, statsFn)
+			meterProvider, err := newMeterProvider(metricsExporter, l, statsFn, progressFn, flushInterval)
 			if err != nil {
 				return err
 			}
@@ -342,12 +366,6 @@ func NewCommand() *cobra.Command {
 				return err
 			}
 
-			// Matches the Python engine's default when the key is absent.
-			flushInterval := 30 * time.Second
-			if conf.Pipeline.FlushIntervalSeconds > 0 {
-				flushInterval = time.Duration(conf.Pipeline.FlushIntervalSeconds) * time.Second
-			}
-
 			turbine := core.NewTurbine(
 				src,
 				handler,
@@ -361,6 +379,7 @@ func NewCommand() *cobra.Command {
 					core.WithMetrics(pipelineMetrics),
 				}, turbineOpts...)...,
 			)
+			liveTurbine.Store(turbine)
 
 			managedTables, err := buildManagedTables(ctx, conf, conn, lock, l, meterProvider)
 			if err != nil {

--- a/internal/core/bench_test.go
+++ b/internal/core/bench_test.go
@@ -1,0 +1,244 @@
+package core
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/turbolytics/sql-flow/internal/duckdb"
+)
+
+// The commit path runs once per batch, so anything added to it is paid at the
+// batch rate: at batch 5000 and a million messages a second, two hundred
+// times a second. These benchmarks exist so that cost is a number in seconds
+// rather than a twenty minute container A/B, and so a regression shows up as
+// a relative change against the same machine on the same day.
+//
+//	go test ./internal/core/ -bench 'Commit|Progress' -benchmem -run '^$'
+//
+// Compare two commits with benchstat rather than reading absolute figures:
+// the numbers move with the host, the ratio does not.
+
+// benchTx is a transaction boundary that does nothing, so a commit benchmark
+// measures the engine's own work rather than DuckDB's.
+type benchTx struct{}
+
+func (benchTx) Commit(context.Context) error   { return nil }
+func (benchTx) Rollback(context.Context) error { return nil }
+
+// benchOffsets saves nothing, for the same reason.
+type benchOffsets struct{}
+
+func (benchOffsets) Save(context.Context, *Marks) error { return nil }
+
+// benchProgressNoop records nothing: the difference between this and the real
+// store is the price of keeping sqlflow_progress current.
+type benchProgressNoop struct{}
+
+func (benchProgressNoop) Record(context.Context, Progress) error { return nil }
+
+// benchConn opens an in-memory database, which is what a pipeline with no
+// state path runs on.
+func benchConn(b *testing.B) (adbc.Connection, func()) {
+	b.Helper()
+	return benchConnAt(b, "")
+}
+
+// benchConnAt opens a file-backed database when given a path. A pipeline that
+// declares pipeline.state.path runs on one of these, and it is the case that
+// actually reads sqlflow_progress, so the cost there is the one that counts.
+func benchConnAt(b *testing.B, path string) (adbc.Connection, func()) {
+	b.Helper()
+	db, err := duckdb.OpenPath(context.Background(), path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	conn, err := db.Connect(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	return conn, func() {
+		conn.Close()
+		db.Close()
+	}
+}
+
+func benchTurbine(b *testing.B, opts ...TurbineOption) *Turbine {
+	b.Helper()
+	return NewTurbine(newIdleSource(), &fakeHandler{}, &fakeSink{}, 1000,
+		time.Hour, &sync.Mutex{}, PipelineErrorPolicies{}, opts...)
+}
+
+// BenchmarkCommitState is the headline comparison: the same commit with no
+// progress store, with one that does nothing, and with the real one writing
+// to DuckDB. The first two isolate the bookkeeping from the statement, so a
+// regression can be attributed rather than guessed at.
+func BenchmarkCommitState(b *testing.B) {
+	ctx := context.Background()
+
+	b.Run("no_progress_store", func(b *testing.B) {
+		tb := benchTurbine(b, WithStateStore(benchOffsets{}, benchTx{}))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := tb.commitState(ctx); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// The snapshot and the flag, without the statement.
+	b.Run("snapshot_only", func(b *testing.B) {
+		tb := benchTurbine(b, WithStateStore(benchOffsets{}, benchTx{}),
+			WithProgressStore(benchProgressNoop{}))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := tb.commitState(ctx); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// The whole thing, including the UPDATE against DuckDB.
+	b.Run("duckdb_progress_store", func(b *testing.B) {
+		conn, cleanup := benchConn(b)
+		defer cleanup()
+		store := NewProgressStore(conn)
+		if err := store.Init(ctx); err != nil {
+			b.Fatal(err)
+		}
+		tb := benchTurbine(b, WithStateStore(benchOffsets{}, benchTx{}),
+			WithProgressStore(store))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := tb.commitState(ctx); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// The real path for a windowed pipeline: state on disk, autocommit off,
+	// so the progress write rides the batch's own transaction. Run with its
+	// control below, because most of what this measures is DuckDB committing
+	// to a file, which the pipeline pays whether or not progress exists.
+	b.Run("duckdb_on_disk_no_progress", func(b *testing.B) {
+		conn, cleanup := benchConnAt(b, filepath.Join(b.TempDir(), "state.db"))
+		defer cleanup()
+		po, ok := conn.(adbc.PostInitOptions)
+		if !ok {
+			b.Fatal("connection does not support disabling autocommit")
+		}
+		if err := po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled); err != nil {
+			b.Fatal(err)
+		}
+		tx, ok := conn.(stateTx)
+		if !ok {
+			b.Fatal("connection is not a transaction boundary")
+		}
+		tb := benchTurbine(b, WithStateStore(benchOffsets{}, tx))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := tb.commitState(ctx); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("duckdb_on_disk", func(b *testing.B) {
+		conn, cleanup := benchConnAt(b, filepath.Join(b.TempDir(), "state.db"))
+		defer cleanup()
+		store := NewProgressStore(conn)
+		if err := store.Init(ctx); err != nil {
+			b.Fatal(err)
+		}
+		po, ok := conn.(adbc.PostInitOptions)
+		if !ok {
+			b.Fatal("connection does not support disabling autocommit")
+		}
+		if err := po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled); err != nil {
+			b.Fatal(err)
+		}
+		tx, ok := conn.(stateTx)
+		if !ok {
+			b.Fatal("connection is not a transaction boundary")
+		}
+		tb := benchTurbine(b, WithStateStore(benchOffsets{}, tx), WithProgressStore(store))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := tb.commitState(ctx); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// An idle tick on a pipeline with no state database still records, and a
+	// trickle spends most of its life here.
+	b.Run("stateless_with_progress", func(b *testing.B) {
+		conn, cleanup := benchConn(b)
+		defer cleanup()
+		store := NewProgressStore(conn)
+		if err := store.Init(ctx); err != nil {
+			b.Fatal(err)
+		}
+		tb := benchTurbine(b, WithProgressStore(store))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := tb.commitState(ctx); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkProgressStoreRecord is the statement on its own.
+//
+// Measured at about 112 microseconds in memory, which is why the commit path
+// throttles it rather than running it per batch. Preparing the statement and
+// binding parameters was tried and is not the answer: 135 microseconds
+// against 160 for the text form on the same run, with six times the
+// allocations. The cost is what an ADBC round trip costs, not parsing, so
+// caching the statement buys almost nothing and writing less often buys
+// everything.
+func BenchmarkProgressStoreRecord(b *testing.B) {
+	ctx := context.Background()
+	conn, cleanup := benchConn(b)
+	defer cleanup()
+	store := NewProgressStore(conn)
+	if err := store.Init(ctx); err != nil {
+		b.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	b.Run("with_arrival", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := store.Record(ctx, Progress{
+				LastArrival: now, LastCommit: now, Messages: int64(i),
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// An idle tick sends no arrival, so it writes one column fewer.
+	b.Run("idle_tick", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := store.Record(ctx, Progress{
+				LastCommit: now, Messages: int64(i),
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/core/progress.go
+++ b/internal/core/progress.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+)
+
+// progressTable is engine bookkeeping beside sqlflow_offsets: one row that
+// says when the newest batch arrived, when state last committed, and how many
+// messages have been consumed. The window predicate reads it to tell a quiet
+// stream from a replay; /stats and /healthz read the in-memory copy.
+const progressTable = "sqlflow_progress"
+
+// Progress is the pipeline's liveness in three facts. Wall clock, UTC.
+type Progress struct {
+	LastArrival time.Time
+	LastCommit  time.Time
+	Messages    int64
+}
+
+// progressSaver is what the Turbine needs; ProgressStore is the DuckDB one.
+type progressSaver interface {
+	Record(ctx context.Context, p Progress) error
+}
+
+// ProgressStore keeps the one-row table current. It is created on the state
+// connection when the pipeline has a state file, so its writes ride the same
+// transaction as the offsets, and on a connection to the in-memory database
+// otherwise.
+type ProgressStore struct {
+	conn adbc.Connection
+}
+
+func NewProgressStore(conn adbc.Connection) *ProgressStore {
+	return &ProgressStore{conn: conn}
+}
+
+// Init creates the table and its single row if they are absent.
+func (s *ProgressStore) Init(ctx context.Context) error {
+	for _, q := range []string{
+		`CREATE TABLE IF NOT EXISTS ` + progressTable + ` (
+		    last_arrival TIMESTAMP,
+		    last_commit  TIMESTAMP,
+		    messages     BIGINT NOT NULL
+		)`,
+		`INSERT INTO ` + progressTable + ` (last_arrival, last_commit, messages)
+		 SELECT NULL, NULL, 0 WHERE NOT EXISTS (SELECT 1 FROM ` + progressTable + `)`,
+	} {
+		if err := s.exec(ctx, q); err != nil {
+			return fmt.Errorf("initialising %s: %w", progressTable, err)
+		}
+	}
+	return nil
+}
+
+// Record rewrites the row. A zero LastArrival is left as it was, which is how
+// an idle tick moves the commit clock without touching the arrival clock.
+func (s *ProgressStore) Record(ctx context.Context, p Progress) error {
+	q := fmt.Sprintf(`UPDATE %s SET last_commit = TIMESTAMP '%s', messages = %d`,
+		progressTable, p.LastCommit.UTC().Format("2006-01-02 15:04:05.999999"), p.Messages)
+	if !p.LastArrival.IsZero() {
+		q += fmt.Sprintf(`, last_arrival = TIMESTAMP '%s'`,
+			p.LastArrival.UTC().Format("2006-01-02 15:04:05.999999"))
+	}
+	if err := s.exec(ctx, q); err != nil {
+		return fmt.Errorf("recording progress: %w", err)
+	}
+	return nil
+}
+
+func (s *ProgressStore) exec(ctx context.Context, q string) error {
+	stmt, err := s.conn.NewStatement()
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	if err := stmt.SetSqlQuery(q); err != nil {
+		return err
+	}
+	_, err = stmt.ExecuteUpdate(ctx)
+	return err
+}

--- a/internal/core/progress.go
+++ b/internal/core/progress.go
@@ -42,8 +42,8 @@ func NewProgressStore(conn adbc.Connection) *ProgressStore {
 func (s *ProgressStore) Init(ctx context.Context) error {
 	for _, q := range []string{
 		`CREATE TABLE IF NOT EXISTS ` + progressTable + ` (
-		    last_arrival TIMESTAMP,
-		    last_commit  TIMESTAMP,
+		    last_arrival TIMESTAMPTZ,
+		    last_commit  TIMESTAMPTZ,
 		    messages     BIGINT NOT NULL
 		)`,
 		`INSERT INTO ` + progressTable + ` (last_arrival, last_commit, messages)
@@ -56,14 +56,23 @@ func (s *ProgressStore) Init(ctx context.Context) error {
 	return nil
 }
 
+// utcLiteral renders an instant with its offset, so the value carries a zone
+// rather than borrowing the session's. The columns are TIMESTAMPTZ for the
+// same reason: a predicate writes `now() - last_arrival` and gets the right
+// answer whatever timezone the server runs in. Written as TIMESTAMP against a
+// UTC instant, a server in New York read the difference as four hours in the
+// future and never closed a window.
+func utcLiteral(t time.Time) string {
+	return t.UTC().Format("2006-01-02 15:04:05.999999-07:00")
+}
+
 // Record rewrites the row. A zero LastArrival is left as it was, which is how
 // an idle tick moves the commit clock without touching the arrival clock.
 func (s *ProgressStore) Record(ctx context.Context, p Progress) error {
-	q := fmt.Sprintf(`UPDATE %s SET last_commit = TIMESTAMP '%s', messages = %d`,
-		progressTable, p.LastCommit.UTC().Format("2006-01-02 15:04:05.999999"), p.Messages)
+	q := fmt.Sprintf(`UPDATE %s SET last_commit = TIMESTAMPTZ '%s', messages = %d`,
+		progressTable, utcLiteral(p.LastCommit), p.Messages)
 	if !p.LastArrival.IsZero() {
-		q += fmt.Sprintf(`, last_arrival = TIMESTAMP '%s'`,
-			p.LastArrival.UTC().Format("2006-01-02 15:04:05.999999"))
+		q += fmt.Sprintf(`, last_arrival = TIMESTAMPTZ '%s'`, utcLiteral(p.LastArrival))
 	}
 	if err := s.exec(ctx, q); err != nil {
 		return fmt.Errorf("recording progress: %w", err)

--- a/internal/core/progress_test.go
+++ b/internal/core/progress_test.go
@@ -73,13 +73,14 @@ func TestCoreConsumeLoop_ProgressRecordsArrivalOnBatchAndCommitOnIdle(t *testing
 	assert.That(t, !afterBatch.LastCommit.Before(afterBatch.LastArrival))
 
 	// Now the source is silent. Idle ticks keep recording, and each one
-	// carries a zero arrival, which is how Record says "leave the arrival
-	// clock where it was". The commit clock moves on every one of them.
+	// carries the same arrival the batch had, unchanged: the record is
+	// always the truth about both clocks rather than a delta, which is what
+	// lets a throttled write be retried without losing the arrival.
 	deadline = time.After(5 * time.Second)
 	for {
 		p, n := rec.last()
 		if n >= 4 {
-			assert.That(t, p.LastArrival.IsZero())
+			assert.Equal(t, afterBatch.LastArrival, p.LastArrival)
 			assert.That(t, p.LastCommit.After(afterBatch.LastCommit))
 			assert.Equal(t, int64(3), p.Messages)
 			break
@@ -201,6 +202,75 @@ func TestStateDurability_IdleTicksDoNotGrowTheStateFile(t *testing.T) {
 	// commit. Nineteen more empty commits must not add another.
 	if s20 > s1+256*1024 {
 		t.Fatalf("state file grew across idle commits: %d bytes after one, %d after twenty", s1, s20)
+	}
+	close(src.release)
+	<-done
+}
+
+// The invariant the throttle broke, and the reason this file exists.
+//
+// The window predicate closes a bucket when now() - last_arrival exceeds the
+// grace. If the table's last_arrival is older than the newest arrival the
+// pipeline actually took, that difference is too large and the window closes
+// EARLY, while rows for it may still be coming. Early closing is the
+// window-splitting defect the stream clock was introduced to remove, so a
+// throttle that drops an arrival walks straight back into it.
+//
+// The dangerous shape is a batch followed by silence: the batch is the last
+// thing that will ever arrive, and if its write is skipped for being inside
+// the throttle interval, nothing afterwards carries it.
+func TestStateDurability_ProgressNeverReportsAnArrivalOlderThanTheNewest(t *testing.T) {
+	coverage.Covers(t, "state.durability")
+	rec := &progressRecorder{}
+
+	// The ordering is the whole test. An idle tick has to write first, so
+	// that the batch's own commit falls inside the throttle interval and a
+	// clock-only rule would skip it. A source that delivers immediately
+	// makes the batch the first write of all, which is always due, and the
+	// bug hides: this test passed against the broken version until the
+	// source was paced.
+	src := newPacedSource(1, 150*time.Millisecond)
+
+	// An interval far longer than the test, so nothing after the first
+	// write is ever due on the clock alone.
+	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 1000, 20*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{},
+		WithProgressStore(rec), WithProgressWriteInterval(time.Hour))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
+
+	// Wait for the batch, then for several idle ticks after it. The commit
+	// counter only moves on a state commit and this pipeline has no state
+	// database, so the snapshot's own commit clock is the signal.
+	waitFor(t, "the batch to be consumed", 5*time.Second, func() bool {
+		return tb.Progress().Messages == 1
+	})
+	afterBatch := tb.Progress().LastCommit
+	waitFor(t, "idle ticks after the batch", 5*time.Second, func() bool {
+		return tb.Progress().LastCommit.Sub(afterBatch) > 60*time.Millisecond
+	})
+
+	// The snapshot is the truth about the newest arrival.
+	newest := tb.Progress().LastArrival
+	assert.That(t, !newest.IsZero())
+
+	// Every record the table ever received must agree with it or predate
+	// it, and the most recent one must equal it. A record carrying an
+	// arrival older than the newest is what closes a window early.
+	last, n := rec.last()
+	assert.That(t, n > 0)
+	if !last.LastArrival.Equal(newest) {
+		t.Fatalf("the table holds arrival %v while the newest is %v: a window "+
+			"reading this closes %v early", last.LastArrival, newest,
+			newest.Sub(last.LastArrival))
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	for i, r := range rec.recs {
+		if r.LastArrival.After(newest) {
+			t.Fatalf("record %d reports an arrival from the future: %v > %v", i, r.LastArrival, newest)
+		}
 	}
 	close(src.release)
 	<-done

--- a/internal/core/progress_test.go
+++ b/internal/core/progress_test.go
@@ -2,10 +2,14 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
@@ -127,4 +131,73 @@ func TestStateDurability_ProgressStoreKeepsOneRow(t *testing.T) {
 	assert.Equal(t, int64(1), rec.Column(0).(*array.Int64).Value(0))
 	assert.Equal(t, int64(1), rec.Column(1).(*array.Int64).Value(0))
 	assert.Equal(t, int64(60), rec.Column(2).(*array.Int64).Value(0))
+}
+
+// Twenty idle ticks against a real state file. The commit clock moves on
+// every tick, the arrival clock never does, and the file does not grow. An
+// empty commit that costs bytes would make a quiet pipeline expensive to
+// leave running, which is exactly what a slow stream does.
+func TestStateDurability_IdleTicksDoNotGrowTheStateFile(t *testing.T) {
+	coverage.Covers(t, "state.durability")
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := duckdb.OpenPath(ctx, path)
+	assert.NoError(t, err)
+	defer db.Close()
+	conn, err := db.Connect(ctx)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	offsets := NewOffsetStore(conn)
+	assert.NoError(t, offsets.Init(ctx))
+	progress := NewProgressStore(conn)
+	assert.NoError(t, progress.Init(ctx))
+
+	// Every batch is one transaction from here on, exactly as root.go does
+	// it: the tables are created under autocommit, then it goes off and the
+	// connection's own Commit is the boundary.
+	po, ok := conn.(adbc.PostInitOptions)
+	assert.That(t, ok)
+	assert.NoError(t, po.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+
+	// The same connection the offsets ride, so the progress row commits with
+	// them. This is what root.go builds for a pipeline with a state file.
+	stateConn, ok := conn.(interface {
+		Commit(context.Context) error
+		Rollback(context.Context) error
+	})
+	assert.That(t, ok)
+
+	src := newIdleSource()
+	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 1000, 20*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{},
+		WithStateStore(offsets, stateConn), WithProgressStore(progress))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(ctx, 0); close(done) }()
+
+	sizeAfter := func(ticks int64) int64 {
+		waitFor(t, fmt.Sprintf("%d idle commits", ticks), 10*time.Second, func() bool {
+			return tb.commitCount() >= ticks
+		})
+		fi, err := os.Stat(path)
+		assert.NoError(t, err)
+		return fi.Size()
+	}
+	s1 := sizeAfter(1)
+	s20 := sizeAfter(20)
+
+	// Nothing ever arrived, so the arrival clock is still unset while the
+	// commit clock has moved twenty times.
+	snap := tb.Progress()
+	assert.That(t, snap.LastArrival.IsZero())
+	assert.That(t, !snap.LastCommit.IsZero())
+	assert.Equal(t, int64(0), snap.Messages)
+
+	// One checkpoint of slack: DuckDB may write a WAL frame on the first
+	// commit. Nineteen more empty commits must not add another.
+	if s20 > s1+256*1024 {
+		t.Fatalf("state file grew across idle commits: %d bytes after one, %d after twenty", s1, s20)
+	}
+	close(src.release)
+	<-done
 }

--- a/internal/core/progress_test.go
+++ b/internal/core/progress_test.go
@@ -1,0 +1,130 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/turbolytics/sql-flow/internal/duckdb"
+	"github.com/zeebo/assert"
+)
+
+// progressRecorder is the test double for the store: it keeps every record.
+type progressRecorder struct {
+	mu   sync.Mutex
+	recs []Progress
+}
+
+func (r *progressRecorder) Record(_ context.Context, p Progress) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recs = append(r.recs, p)
+	return nil
+}
+
+func (r *progressRecorder) last() (Progress, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.recs) == 0 {
+		return Progress{}, 0
+	}
+	return r.recs[len(r.recs)-1], len(r.recs)
+}
+
+// A batch moves both clocks and the count. An idle tick moves the commit
+// clock only. That distinction is what lets a predicate tell "quiet" from
+// "stuck", so it is the first thing pinned.
+func TestCoreConsumeLoop_ProgressRecordsArrivalOnBatchAndCommitOnIdle(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+	rec := &progressRecorder{}
+	src := newBlockingSource(messages(3))
+	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 1000, 30*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithProgressStore(rec))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
+
+	deadline := time.After(5 * time.Second)
+	var afterBatch Progress
+	for {
+		p, n := rec.last()
+		if n >= 1 && p.Messages == 3 {
+			afterBatch = p
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("no progress record with 3 messages; records=%d", n)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	assert.That(t, !afterBatch.LastArrival.IsZero())
+	assert.That(t, !afterBatch.LastCommit.Before(afterBatch.LastArrival))
+
+	// Now the source is silent. Idle ticks keep recording, and each one
+	// carries a zero arrival, which is how Record says "leave the arrival
+	// clock where it was". The commit clock moves on every one of them.
+	deadline = time.After(5 * time.Second)
+	for {
+		p, n := rec.last()
+		if n >= 4 {
+			assert.That(t, p.LastArrival.IsZero())
+			assert.That(t, p.LastCommit.After(afterBatch.LastCommit))
+			assert.Equal(t, int64(3), p.Messages)
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("idle ticks did not record progress; records=%d", n)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	// The snapshot is the reader's view, and it keeps the arrival clock
+	// through every idle tick. That is what /healthz and /stats report.
+	snap := tb.Progress()
+	assert.Equal(t, int64(3), snap.Messages)
+	assert.Equal(t, afterBatch.LastArrival, snap.LastArrival)
+	assert.That(t, snap.LastCommit.After(afterBatch.LastCommit))
+	close(src.release)
+	<-done
+}
+
+// The store writes one row and rewrites it; it never grows. Read back
+// through a second statement, the way the window manager will.
+func TestStateDurability_ProgressStoreKeepsOneRow(t *testing.T) {
+	coverage.Covers(t, "state.durability")
+	ctx := context.Background()
+	db, err := duckdb.OpenPath(ctx, "")
+	assert.NoError(t, err)
+	defer db.Close()
+	conn, err := db.Connect(ctx)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	store := NewProgressStore(conn)
+	assert.NoError(t, store.Init(ctx))
+	assert.NoError(t, store.Init(ctx)) // idempotent, like the offsets table
+
+	t0 := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	assert.NoError(t, store.Record(ctx, Progress{LastArrival: t0, LastCommit: t0, Messages: 1}))
+	// An idle tick: no arrival, the commit clock moves.
+	assert.NoError(t, store.Record(ctx, Progress{LastCommit: t0.Add(time.Minute), Messages: 1}))
+
+	stmt, err := conn.NewStatement()
+	assert.NoError(t, err)
+	defer stmt.Close()
+	assert.NoError(t, stmt.SetSqlQuery(`SELECT count(*), max(messages), epoch(max(last_commit) - max(last_arrival))::BIGINT FROM sqlflow_progress`))
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	assert.NoError(t, err)
+	defer reader.Release()
+	assert.That(t, reader.Next())
+	rec := reader.Record()
+	assert.Equal(t, int64(1), rec.Column(0).(*array.Int64).Value(0))
+	assert.Equal(t, int64(1), rec.Column(1).(*array.Int64).Value(0))
+	assert.Equal(t, int64(60), rec.Column(2).(*array.Int64).Value(0))
+}

--- a/internal/core/progress_test.go
+++ b/internal/core/progress_test.go
@@ -45,8 +45,12 @@ func TestCoreConsumeLoop_ProgressRecordsArrivalOnBatchAndCommitOnIdle(t *testing
 	coverage.Covers(t, "core.consume_loop")
 	rec := &progressRecorder{}
 	src := newBlockingSource(messages(3))
+	// Zero interval: this test is about what a commit records, not about how
+	// often the table is written, and the production throttle would pace it
+	// at one record a second against a five second deadline.
 	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 1000, 30*time.Millisecond,
-		&sync.Mutex{}, PipelineErrorPolicies{}, WithProgressStore(rec))
+		&sync.Mutex{}, PipelineErrorPolicies{},
+		WithProgressStore(rec), WithProgressWriteInterval(0))
 	done := make(chan struct{})
 	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
 

--- a/internal/core/slow_test.go
+++ b/internal/core/slow_test.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+)
+
+// pacedSource delivers one message every `every`, n times, then stays open
+// and silent until released. It is the trickle: a stream that never fills a
+// batch and never ends.
+type pacedSource struct {
+	ch      chan []Message
+	release chan struct{}
+	every   time.Duration
+	n       int
+}
+
+func newPacedSource(n int, every time.Duration) *pacedSource {
+	return &pacedSource{
+		ch:      make(chan []Message),
+		release: make(chan struct{}),
+		every:   every,
+		n:       n,
+	}
+}
+
+func (s *pacedSource) Start() error  { return nil }
+func (s *pacedSource) Close() error  { return nil }
+func (s *pacedSource) Commit() error { return nil }
+
+func (s *pacedSource) Stream() <-chan []Message {
+	go func() {
+		defer close(s.ch)
+		for i := 0; i < s.n; i++ {
+			select {
+			case <-time.After(s.every):
+			case <-s.release:
+				return
+			}
+			select {
+			case s.ch <- []Message{{
+				Value:     []byte(`{"i":1}`),
+				Topic:     "t",
+				Partition: 0,
+				Offset:    int64(i),
+			}}:
+			case <-s.release:
+				return
+			}
+		}
+		<-s.release
+	}()
+	return s.ch
+}
+
+// markRecorder is an offsetSaver that keeps the newest saved mark.
+type markRecorder struct {
+	mu    sync.Mutex
+	saves int
+	last  *Marks
+}
+
+func (m *markRecorder) Save(_ context.Context, marks *Marks) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saves++
+	m.last = marks
+	return nil
+}
+
+func (m *markRecorder) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.saves
+}
+
+// noopTx satisfies stateTx for a pipeline that has offsets but no real
+// transaction; commitState needs both to be non-nil to save marks.
+type noopTx struct{}
+
+func (noopTx) Commit(context.Context) error   { return nil }
+func (noopTx) Rollback(context.Context) error { return nil }
+
+func waitFor(t *testing.T, what string, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for !cond() {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", what)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+// A trickle: one message every 40 ms, a batch size it will never reach, a
+// 20 ms flush interval. Every message reaches the sink on the interval
+// rather than when the batch fills, and every flush saves a mark. This is
+// the shape of most streams most of the time, and nothing measured it.
+func TestCoreConsumeLoop_TrickleFlushesEveryMessageOnTheInterval(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+	src := newPacedSource(10, 40*time.Millisecond)
+	sink := &fakeSink{}
+	marks := &markRecorder{}
+	tb := NewTurbine(src, &fakeHandler{}, sink, 1000, 20*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithStateStore(marks, noopTx{}))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
+
+	// The first message lands within its own cadence plus an interval plus
+	// scheduling slack, long before a batch of 1,000 could ever fill.
+	start := time.Now()
+	waitFor(t, "the first row at the sink", 2*time.Second, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return sink.rows >= 1
+	})
+	assert.That(t, time.Since(start) < 40*time.Millisecond+20*time.Millisecond+250*time.Millisecond)
+
+	waitFor(t, "all ten rows", 5*time.Second, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return sink.rows == 10
+	})
+	// Ten messages, at least ten flushes: no batch ever held two, because
+	// the interval closes each one before the next message arrives.
+	assert.That(t, marks.count() >= 10)
+	close(src.release)
+	<-done
+}
+
+// A surge then silence: 5,000 messages in one burst, then nothing. The final
+// partial batch reaches the sink rather than waiting for a surge that never
+// comes, the saved mark is the last offset, and the silence writes nothing.
+func TestCoreConsumeLoop_SurgeThenSilenceFlushesTheTailOnce(t *testing.T) {
+	coverage.Covers(t, "core.consume_loop")
+	burst := messages(5000)
+	for i := range burst {
+		burst[i].Topic = "t"
+		burst[i].Offset = int64(i)
+	}
+	src := newBlockingSource(burst)
+	sink := &fakeSink{}
+	marks := &markRecorder{}
+	tb := NewTurbine(src, &fakeHandler{}, sink, 1000, 30*time.Millisecond,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithStateStore(marks, noopTx{}))
+	done := make(chan struct{})
+	go func() { _, _ = tb.ConsumeLoop(context.Background(), 0); close(done) }()
+
+	waitFor(t, "5000 rows at the sink", 5*time.Second, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		return sink.rows == 5000
+	})
+	marks.mu.Lock()
+	last := marks.last
+	marks.mu.Unlock()
+	assert.That(t, last != nil)
+	var newest int64 = -1
+	last.Each(func(_ string, _ int32, m Mark) { newest = m.Offset })
+	assert.Equal(t, int64(4999), newest)
+
+	// Five intervals of silence: the sink sees no further flush. An idle
+	// tick commits state; it must not write an empty batch downstream.
+	sink.mu.Lock()
+	before := sink.flushes
+	sink.mu.Unlock()
+	time.Sleep(150 * time.Millisecond)
+	sink.mu.Lock()
+	after := sink.flushes
+	sink.mu.Unlock()
+	assert.Equal(t, before, after)
+	close(src.release)
+	<-done
+}

--- a/internal/core/stats.go
+++ b/internal/core/stats.go
@@ -126,7 +126,7 @@ func userTables(ctx context.Context, conn adbc.Connection) ([]string, error) {
 		}
 		for i := 0; i < int(rec.NumRows()); i++ {
 			name := col.Value(i)
-			if name == offsetsTable || name == batchTable {
+			if name == offsetsTable || name == batchTable || name == progressTable {
 				continue
 			}
 			// Clone: the value aliases the record's backing buffer, which is

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -293,9 +293,22 @@ func (t *Turbine) commitCount() int64 {
 	return t.commits
 }
 
-// recordProgress runs at the top of every commit, before the state guard, so
-// a pipeline with no state database records too. A batch since the last
-// commit moves the arrival clock; an idle tick moves the commit clock only.
+// recordProgress runs at the top of every commit, before the state guard.
+//
+// Two audiences, and they are not the same requirement. The snapshot is what
+// /stats and /healthz read, so every pipeline needs it whether or not it has
+// a state database, and it costs an assignment. The table is what SQL reads,
+// today only the tumbling window predicate, and it costs a statement on the
+// commit path.
+//
+// The table is written on every pipeline even where nothing reads it. That is
+// deliberate: a table that exists but silently stops being maintained is a
+// worse trap than one that costs a little, and a window can be managed
+// without a state path, so "has state" is not the test for whether anyone
+// reads it.
+//
+// A batch since the last commit moves the arrival clock; an idle tick moves
+// the commit clock only.
 func (t *Turbine) recordProgress(ctx context.Context) {
 	if t.progress == nil {
 		return

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -217,9 +217,10 @@ type Turbine struct {
 	// commits counts successful state commits, for tests that wait on ticks.
 	// Guarded by lock.
 	commits int64
-	// progressWrittenAt is when the progress table was last written, which
-	// bounds how often the statement runs. Guarded by lock.
+	// progressWrittenAt is when the progress table was last written, and
+	// progressEvery is how often it may be. Guarded by lock.
 	progressWrittenAt time.Time
+	progressEvery     time.Duration
 
 	// stateStats reads a snapshot of durable state for the gauges. It reads a
 	// connection dedicated to reading, never the one batches are written on,
@@ -281,6 +282,14 @@ func WithProgressStore(s progressSaver) TurbineOption {
 	return func(t *Turbine) { t.progress = s }
 }
 
+// WithProgressWriteInterval bounds how often the progress table is written.
+// Zero writes on every commit, which is what a test wants when it is
+// checking what gets recorded rather than how often. Production leaves it at
+// progressWriteInterval; see recordProgress for why it is not free.
+func WithProgressWriteInterval(d time.Duration) TurbineOption {
+	return func(t *Turbine) { t.progressEvery = d }
+}
+
 // Progress reports the last recorded liveness facts. Zero values mean
 // nothing has been recorded yet.
 func (t *Turbine) Progress() Progress {
@@ -332,7 +341,7 @@ func (t *Turbine) recordProgress(ctx context.Context) {
 	t.snapshot.LastCommit = now
 	t.snapshot.Messages = p.Messages
 	t.batchSinceCommit = false
-	due := now.Sub(t.progressWrittenAt) >= progressWriteInterval
+	due := now.Sub(t.progressWrittenAt) >= t.progressEvery
 	if due {
 		t.progressWrittenAt = now
 	}
@@ -393,6 +402,7 @@ func NewTurbine(
 		handler:       handler,
 		batchSize:     batchSize,
 		flushInterval: flushInterval,
+		progressEvery: progressWriteInterval,
 		lock:          lock,
 		running:       true,
 		stats: &Stats{

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -204,6 +204,20 @@ type Turbine struct {
 	offsets offsetSaver
 	stateTx stateTx
 
+	// progress is the liveness record, see progress.go. Optional: a Turbine
+	// built without it records nothing and Progress() reports zeros.
+	progress progressSaver
+	// snapshot is the in-memory copy of what progress last recorded, read by
+	// /stats and /healthz without touching the database. Guarded by lock.
+	snapshot Progress
+	// batchSinceCommit is set by processBatch and cleared by commitState, so
+	// commitState knows whether this commit follows an arrival or an idle
+	// tick. Guarded by lock.
+	batchSinceCommit bool
+	// commits counts successful state commits, for tests that wait on ticks.
+	// Guarded by lock.
+	commits int64
+
 	// stateStats reads a snapshot of durable state for the gauges. It reads a
 	// connection dedicated to reading, never the one batches are written on,
 	// so a scrape cannot stall the pipeline. Nil when there is no state
@@ -255,6 +269,50 @@ func WithStateStore(offsets offsetSaver, tx stateTx) TurbineOption {
 	return func(t *Turbine) {
 		t.offsets = offsets
 		t.stateTx = tx
+	}
+}
+
+// WithProgressStore records liveness into a store and into an in-memory
+// snapshot on every commit and every idle tick.
+func WithProgressStore(s progressSaver) TurbineOption {
+	return func(t *Turbine) { t.progress = s }
+}
+
+// Progress reports the last recorded liveness facts. Zero values mean
+// nothing has been recorded yet.
+func (t *Turbine) Progress() Progress {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.snapshot
+}
+
+// commitCount is how many state commits have succeeded; tests wait on it.
+func (t *Turbine) commitCount() int64 {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.commits
+}
+
+// recordProgress runs at the top of every commit, before the state guard, so
+// a pipeline with no state database records too. A batch since the last
+// commit moves the arrival clock; an idle tick moves the commit clock only.
+func (t *Turbine) recordProgress(ctx context.Context) {
+	if t.progress == nil {
+		return
+	}
+	now := time.Now().UTC()
+	t.lock.Lock()
+	p := Progress{LastCommit: now, Messages: t.stats.MessagesConsumed()}
+	if t.batchSinceCommit {
+		p.LastArrival = now
+		t.snapshot.LastArrival = now
+	}
+	t.snapshot.LastCommit = now
+	t.snapshot.Messages = p.Messages
+	t.batchSinceCommit = false
+	t.lock.Unlock()
+	if err := t.progress.Record(ctx, p); err != nil {
+		t.logger.Warn("recording progress", zap.Error(err))
 	}
 }
 
@@ -733,6 +791,8 @@ func (t *Turbine) rollbackState(ctx context.Context) {
 //
 // A pipeline with no state database does nothing here.
 func (t *Turbine) commitState(ctx context.Context) error {
+	t.recordProgress(ctx)
+
 	if t.offsets == nil || t.stateTx == nil {
 		return nil
 	}
@@ -759,6 +819,7 @@ func (t *Turbine) commitState(ctx context.Context) error {
 		return errs.Wrap(errs.CodeStateCommitFailed, err, "committing state")
 	}
 
+	t.commits++
 	t.metrics.StateCommitLatency.Record(ctx, time.Since(c0).Seconds())
 	t.metrics.StateCommitCount.Add(ctx, 1, t.resultAttrs(resultOK)...)
 	return nil
@@ -791,6 +852,9 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 
 	t.lock.Lock()
 	batch, err := t.handler.Invoke(ctx)
+	// Messages reached the handler whatever Invoke returns: this batch is an
+	// arrival, and the commit that follows it moves the arrival clock.
+	t.batchSinceCommit = true
 	t.lock.Unlock()
 
 	b1 := time.Now()

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -217,6 +217,9 @@ type Turbine struct {
 	// commits counts successful state commits, for tests that wait on ticks.
 	// Guarded by lock.
 	commits int64
+	// progressWrittenAt is when the progress table was last written, which
+	// bounds how often the statement runs. Guarded by lock.
+	progressWrittenAt time.Time
 
 	// stateStats reads a snapshot of durable state for the gauges. It reads a
 	// connection dedicated to reading, never the one batches are written on,
@@ -293,6 +296,12 @@ func (t *Turbine) commitCount() int64 {
 	return t.commits
 }
 
+// progressWriteInterval bounds how often sqlflow_progress is written. The
+// snapshot behind /stats and /healthz is updated on every commit regardless;
+// this is only the SQL-visible copy, whose one reader compares it against a
+// grace measured in tens of seconds.
+const progressWriteInterval = time.Second
+
 // recordProgress runs at the top of every commit, before the state guard.
 //
 // Two audiences, and they are not the same requirement. The snapshot is what
@@ -323,7 +332,25 @@ func (t *Turbine) recordProgress(ctx context.Context) {
 	t.snapshot.LastCommit = now
 	t.snapshot.Messages = p.Messages
 	t.batchSinceCommit = false
+	due := now.Sub(t.progressWrittenAt) >= progressWriteInterval
+	if due {
+		t.progressWrittenAt = now
+	}
 	t.lock.Unlock()
+
+	// The snapshot above is exact and free. The table is not: one UPDATE
+	// through ADBC measures about 112 microseconds, and a batch of 5000 at a
+	// million messages a second commits two hundred times a second, so
+	// writing it on every commit costs a few percent of throughput.
+	// BenchmarkCommitState is where that number comes from.
+	//
+	// Nothing needs it on every commit. The only reader is a window
+	// predicate comparing last_arrival against a grace measured in tens of
+	// seconds, so a value up to progressWriteInterval stale makes a window
+	// close that much late and never early, which is the safe direction.
+	if !due {
+		return
+	}
 	if err := t.progress.Record(ctx, p); err != nil {
 		t.logger.Warn("recording progress", zap.Error(err))
 	}

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -210,10 +210,15 @@ type Turbine struct {
 	// snapshot is the in-memory copy of what progress last recorded, read by
 	// /stats and /healthz without touching the database. Guarded by lock.
 	snapshot Progress
-	// batchSinceCommit is set by processBatch and cleared by commitState, so
-	// commitState knows whether this commit follows an arrival or an idle
-	// tick. Guarded by lock.
-	batchSinceCommit bool
+	// arrivedAt is when the newest batch reached the handler, set by
+	// processBatch. It is the arrival time itself rather than a flag,
+	// because a throttled write can happen long after the arrival and
+	// stamping it with the commit clock would place the arrival wherever the
+	// write landed. Guarded by lock.
+	arrivedAt time.Time
+	// writtenArrival is the arrival the table already holds, so a skipped
+	// write is retried on the next one rather than lost. Guarded by lock.
+	writtenArrival time.Time
 	// commits counts successful state commits, for tests that wait on ticks.
 	// Guarded by lock.
 	commits int64
@@ -334,16 +339,28 @@ func (t *Turbine) recordProgress(ctx context.Context) {
 	now := time.Now().UTC()
 	t.lock.Lock()
 	p := Progress{LastCommit: now, Messages: t.stats.MessagesConsumed()}
-	if t.batchSinceCommit {
-		p.LastArrival = now
-		t.snapshot.LastArrival = now
+	if !t.arrivedAt.IsZero() {
+		p.LastArrival = t.arrivedAt
+		t.snapshot.LastArrival = t.arrivedAt
 	}
 	t.snapshot.LastCommit = now
 	t.snapshot.Messages = p.Messages
-	t.batchSinceCommit = false
-	due := now.Sub(t.progressWrittenAt) >= t.progressEvery
+
+	// Due on the clock, or owing an arrival the table has not got yet.
+	// The second half is the liveness guarantee: the newest arrival always
+	// reaches the table, at the latest on the next commit after the
+	// interval, so a stream that stops cannot strand the arrival that
+	// decides when its last window closes.
+	//
+	// The elapsed test is written to survive a clock that moves backwards.
+	// Comparing now.Sub(written) >= interval is false forever after a jump
+	// back, which would stop the table being written at all.
+	elapsed := now.Sub(t.progressWrittenAt)
+	owed := !t.arrivedAt.IsZero() && t.arrivedAt.After(t.writtenArrival)
+	due := owed || elapsed >= t.progressEvery || elapsed < 0
 	if due {
 		t.progressWrittenAt = now
+		t.writtenArrival = t.arrivedAt
 	}
 	t.lock.Unlock()
 
@@ -353,10 +370,12 @@ func (t *Turbine) recordProgress(ctx context.Context) {
 	// writing it on every commit costs a few percent of throughput.
 	// BenchmarkCommitState is where that number comes from.
 	//
-	// Nothing needs it on every commit. The only reader is a window
-	// predicate comparing last_arrival against a grace measured in tens of
-	// seconds, so a value up to progressWriteInterval stale makes a window
-	// close that much late and never early, which is the safe direction.
+	// So idle ticks that change nothing but the commit clock are skipped
+	// until the interval has passed. An arrival is never skipped: owed
+	// above forces the write, because the table's last_arrival is what
+	// decides when a window closes, and a value older than the truth closes
+	// it early. Early is the dangerous direction, since that is the
+	// window-splitting behaviour the stream clock exists to prevent.
 	if !due {
 		return
 	}
@@ -902,9 +921,11 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 
 	t.lock.Lock()
 	batch, err := t.handler.Invoke(ctx)
-	// Messages reached the handler whatever Invoke returns: this batch is an
-	// arrival, and the commit that follows it moves the arrival clock.
-	t.batchSinceCommit = true
+	// Messages reached the handler whatever Invoke returns, so this is an
+	// arrival. Stamped now rather than at commit time: a throttled write can
+	// land much later, and the window predicate needs when the data came,
+	// not when the row was updated.
+	t.arrivedAt = time.Now().UTC()
 	t.lock.Unlock()
 
 	b1 := time.Now()

--- a/internal/kafka/source_test.go
+++ b/internal/kafka/source_test.go
@@ -278,3 +278,47 @@ func TestIntegrationSourceKafka_ReadAheadIsBoundedByPrefetch(t *testing.T) {
 			drained, config.DefaultKafkaFetchPrefetch, limit)
 	}
 }
+
+// A trickle can leave a consumer silent for longer than its session timeout.
+// franz-go heartbeats in the background, so the group membership survives
+// and the next message is delivered without a rejoin. Six second session,
+// eight seconds of silence: a stream that delivers once a minute crosses
+// this boundary sixty times an hour, and nothing measured it.
+func TestIntegrationSourceKafka_SurvivesIdleLongerThanTheSessionTimeout(t *testing.T) {
+	coverage.Covers(t, "source.kafka")
+	broker := brokerOrFail(t)
+	topic := fmt.Sprintf("turbine-idle-%d", time.Now().UnixNano())
+
+	producer, err := kgo.NewClient(kgo.SeedBrokers(broker), kgo.AllowAutoTopicCreation())
+	assert.NoError(t, err)
+	defer producer.Close()
+	produce(t, producer, topic, 1)
+
+	client := newTestClient(t, broker, topic, topic,
+		kgo.SessionTimeout(6*time.Second),
+		kgo.HeartbeatInterval(2*time.Second),
+	)
+	src, err := NewSource(client)
+	assert.NoError(t, err)
+	defer src.Close()
+	stream := src.Stream()
+
+	select {
+	case batch := <-stream:
+		assert.Equal(t, int64(0), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the first message never arrived")
+	}
+
+	// Longer than the session, so a consumer that stopped heartbeating would
+	// have been evicted and would rejoin, or stall, on the next produce.
+	time.Sleep(8 * time.Second)
+	produce(t, producer, topic, 1)
+
+	select {
+	case batch := <-stream:
+		assert.Equal(t, int64(1), batch[0].Offset)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the message after the idle gap never arrived")
+	}
+}

--- a/internal/managers/tumbling_test.go
+++ b/internal/managers/tumbling_test.go
@@ -3,6 +3,7 @@ package managers
 import (
 	"context"
 	"errors"
+	"github.com/turbolytics/sql-flow/internal/core"
 	"github.com/turbolytics/sql-flow/internal/coverage"
 	"github.com/turbolytics/sql-flow/internal/duckdb"
 	"os"
@@ -625,4 +626,124 @@ func TestManagerTumblingWindow__ClockAdvancesOnlyAcrossACommit(t *testing.T) {
 	assert.Equal(t, int64(1), rows)
 	assert.NoError(t, tx.Commit(context.Background()))
 	assert.Equal(t, int64(0), countRows(t, conn, "agg_cities_count"))
+}
+
+// The predicate the shipped examples use, with a two second grace so the
+// test runs in seconds. Branch one is the stream clock (#234): a window
+// closes once the data has moved past it. Branch two is the idleness bound:
+// after a grace of silence every open window closes, because a stream that
+// has stopped will never move its own clock again.
+const (
+	idleCollectSQL = `SELECT bucket, city, count FROM agg_cities_count
+		WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '2' SECOND
+		   OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '2' SECOND
+		ORDER BY city`
+	idleDeleteSQL = `DELETE FROM agg_cities_count
+		WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '2' SECOND
+		   OR (SELECT now() - last_arrival FROM sqlflow_progress) > INTERVAL '2' SECOND`
+
+	// What shipped before the idleness branch, for the control.
+	streamClockOnlyCollectSQL = `SELECT bucket, city, count FROM agg_cities_count
+		WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '2' SECOND
+		ORDER BY city`
+	streamClockOnlyDeleteSQL = `DELETE FROM agg_cities_count
+		WHERE bucket < (SELECT max(bucket) FROM agg_cities_count) - INTERVAL '2' SECOND`
+)
+
+// setupIdleWindows builds the aggregate table and the engine's progress row,
+// and returns a function that moves the arrival clock the way a batch does.
+func setupIdleWindows(tb testing.TB, conn adbc.Connection) func(ago time.Duration) {
+	tb.Helper()
+	exec(tb, conn, `CREATE TABLE agg_cities_count (bucket TIMESTAMP, city VARCHAR, count BIGINT)`)
+	store := core.NewProgressStore(conn)
+	if err := store.Init(context.Background()); err != nil {
+		tb.Fatal(err)
+	}
+	return func(ago time.Duration) {
+		now := time.Now().UTC()
+		if err := store.Record(context.Background(), core.Progress{
+			LastArrival: now.Add(-ago),
+			LastCommit:  now,
+			Messages:    3,
+		}); err != nil {
+			tb.Fatal(err)
+		}
+	}
+}
+
+func newTestTumblingSQL(conn adbc.Connection, sink *recordingSink, collect, del string) *Tumbling {
+	return NewTumbling(conn, collect, del, time.Millisecond, sink, &sync.Mutex{})
+}
+
+// Rows land in one bucket and the stream goes quiet. Nothing newer ever
+// arrives, so the stream clock alone holds the window open forever: that is
+// the control below. The idleness branch publishes it once, a grace after
+// the last row, and then has nothing left to publish.
+func TestManagerTumblingWindow__QuietStreamClosesItsLastWindow(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	arrived := setupIdleWindows(t, conn)
+	exec(t, conn, `INSERT INTO agg_cities_count VALUES (now()::timestamp, 'NYC', 3)`)
+
+	// The control: the predicate that shipped, and a stream that just
+	// arrived. One bucket, nothing newer, so it stays open.
+	arrived(0)
+	control := &recordingSink{}
+	cm := newTestTumblingSQL(conn, control, streamClockOnlyCollectSQL, streamClockOnlyDeleteSQL)
+	assert.NoError(t, cm.Poll(context.Background()))
+	rows, _ := control.counts()
+	assert.Equal(t, int64(0), rows)
+
+	// Still quiet three seconds later. The stream clock has not moved, so
+	// the old predicate still publishes nothing: the window is stranded.
+	arrived(3 * time.Second)
+	assert.NoError(t, cm.Poll(context.Background()))
+	rows, _ = control.counts()
+	assert.Equal(t, int64(0), rows)
+	assert.Equal(t, int64(1), countRows(t, conn, "agg_cities_count"))
+
+	// The idleness branch, same table, same silence: the window closes.
+	sink := &recordingSink{}
+	m := newTestTumblingSQL(conn, sink, idleCollectSQL, idleDeleteSQL)
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, flushes := sink.counts()
+	assert.Equal(t, int64(1), rows)
+	assert.That(t, flushes > 0)
+	assert.Equal(t, int64(0), countRows(t, conn, "agg_cities_count"))
+
+	// Published once, not once per poll: the delete ran with it.
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ = sink.counts()
+	assert.Equal(t, int64(1), rows)
+}
+
+// The #234 property, kept. Three buckets arrive in one burst with the stream
+// still live, so the idleness branch never fires and the stream clock closes
+// the two older buckets once each, leaving the newest open.
+func TestManagerTumblingWindow__ReplayStillClosesEachWindowOnce(t *testing.T) {
+	coverage.Covers(t, "manager.tumbling_window")
+	conn, cleanup := newTestConn(t)
+	defer cleanup()
+	arrived := setupIdleWindows(t, conn)
+	exec(t, conn, `INSERT INTO agg_cities_count VALUES
+		(now()::timestamp - INTERVAL '20' SECOND, 'NYC', 1),
+		(now()::timestamp - INTERVAL '10' SECOND, 'SF', 1),
+		(now()::timestamp, 'LA', 1)`)
+	arrived(0)
+
+	sink := &recordingSink{}
+	m := newTestTumblingSQL(conn, sink, idleCollectSQL, idleDeleteSQL)
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ := sink.counts()
+	assert.Equal(t, int64(2), rows)
+	assert.Equal(t, int64(1), countRows(t, conn, "agg_cities_count"))
+
+	// A second poll while the stream is still live publishes nothing more:
+	// the newest bucket is still open, exactly as before the change.
+	arrived(0)
+	assert.NoError(t, m.Poll(context.Background()))
+	rows, _ = sink.counts()
+	assert.Equal(t, int64(2), rows)
+	assert.Equal(t, int64(1), countRows(t, conn, "agg_cities_count"))
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/turbolytics/sql-flow/internal/config"
+	"github.com/turbolytics/sql-flow/internal/errs"
 )
 
 // Validate checks a config offline and reports everything it finds.
@@ -36,6 +37,52 @@ func Validate(ctx context.Context, req Request) (Report, error) {
 
 	checkSchema(rendered, &rep)
 
+	demoteUnsuppliedVariableErrors(&rep)
+
 	rep.Finish()
 	return rep, nil
+}
+
+// demoteUnsuppliedVariableErrors turns a schema error caused by an unsupplied
+// template variable into a warning.
+//
+// A variable with no default is a declared required input; checkTemplate says
+// so and warns rather than fails, because the environment being incomplete is
+// not the config being wrong (#142). The schema check then saw the
+// consequence, an empty substitution, and failed on it:
+//
+//	dsn: {{ SQLFLOW_CLICKHOUSE_DSN }}
+//	  error   at '/pipeline/sink/clickhouse/dsn': got null, want string
+//	  warning template variable SQLFLOW_CLICKHOUSE_DSN is not set
+//
+// The two contradicted each other, and only the error reached the reader,
+// because the CLI prints errors alone. So `config validate` could not be run
+// on a clean shell, which is exactly what #142 asked for, and a connection
+// string had to carry a fake default to pass. Nobody should put a bunk DSN in
+// a production pipeline to satisfy a linter.
+//
+// Attribution is by source line: both diagnostics point at the line the
+// reference sits on. That is deliberately the stupid version. It does not try
+// to judge whether the empty value would produce broken SQL, which is a
+// question for the SQL linter, not for a structural check.
+func demoteUnsuppliedVariableErrors(rep *Report) {
+	lines := map[int]bool{}
+	for _, d := range rep.Diagnostics {
+		if d.Code == string(errs.CodeConfigTemplateUndefined) &&
+			d.Severity == SeverityWarning && d.Position != nil {
+			lines[d.Position.Line] = true
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+
+	for i, d := range rep.Diagnostics {
+		if d.Severity != SeverityError || d.Position == nil || !lines[d.Position.Line] {
+			continue
+		}
+		rep.Diagnostics[i].Severity = SeverityWarning
+		rep.Diagnostics[i].Action = "set the variable named in the warning on this line, " +
+			"or give it a default in the config"
+	}
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"context"
+	"github.com/turbolytics/sql-flow/internal/errs"
 	"os"
 	"testing"
 
@@ -93,4 +94,85 @@ func TestValidateNoSideEffects_CleanConfigIsOK(t *testing.T) {
 	rep, err := Validate(context.Background(), Request{Config: validSchemaConfig})
 	assert.NoError(t, err)
 	assert.That(t, rep.OK)
+}
+
+// A variable with no default is a declared required input, so an empty
+// substitution is not the config being wrong. checkTemplate already says so
+// and warns; the schema check used to fail on the consequence, and only the
+// error reached the reader because the CLI prints errors alone.
+//
+// The effect was that `config validate` could not run on a clean shell,
+// which is what #142 asked for, and a connection string had to carry a fake
+// default to pass. Nobody should put a bunk DSN in a production pipeline to
+// satisfy a linter.
+func TestValidateSchema_UnsuppliedVariableIsAWarningNotAnError(t *testing.T) {
+	coverage.Covers(t, "validate.schema", "validate.template")
+	rep, err := Validate(context.Background(), Request{
+		Path: "dsn.yml",
+		Config: `
+pipeline:
+  batch_size: 10
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      auto_offset_reset: earliest
+      topics: [t]
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: SELECT 1
+  sink:
+    type: clickhouse
+    clickhouse:
+      dsn: {{ SQLFLOW_CLICKHOUSE_DSN }}
+      table: events
+`,
+	})
+	assert.NoError(t, err)
+	assert.That(t, rep.OK)
+
+	var warnedAboutTheVariable, anyError bool
+	for _, d := range rep.Diagnostics {
+		if d.Severity == SeverityError {
+			anyError = true
+		}
+		if d.Code == string(errs.CodeConfigTemplateUndefined) {
+			warnedAboutTheVariable = true
+		}
+	}
+	// The reader still learns which variable to set: the warning survives,
+	// and the demoted schema diagnostic now carries the action.
+	assert.That(t, warnedAboutTheVariable)
+	assert.That(t, !anyError)
+}
+
+// The demotion is attributed by line, so a null the author wrote themselves,
+// on a line with no template reference, still fails.
+func TestValidateSchema_ANullTheAuthorWroteStillFails(t *testing.T) {
+	coverage.Covers(t, "validate.schema")
+	rep, err := Validate(context.Background(), Request{
+		Path: "blank.yml",
+		Config: `
+pipeline:
+  batch_size: 10
+  source:
+    type: kafka
+    kafka:
+      brokers: [localhost:9092]
+      group_id: g
+      auto_offset_reset: earliest
+      topics: [t]
+  handler:
+    type: 'handlers.InferredMemBatch'
+    sql: SELECT 1
+  sink:
+    type: clickhouse
+    clickhouse:
+      dsn:
+      table: events
+`,
+	})
+	assert.NoError(t, err)
+	assert.That(t, !rep.OK)
 }

--- a/internal/websocket/source_test.go
+++ b/internal/websocket/source_test.go
@@ -152,3 +152,50 @@ func TestSourceWebsocket_ReadsLargeMessages(t *testing.T) {
 
 	assert.Equal(t, len(large), len(recv(t, s.Stream())))
 }
+
+// A server that accepts and then says nothing for ten seconds is a quiet
+// stream, not a dead one. The source must still be listening when the frame
+// finally comes, and must deliver it on the same connection rather than
+// having torn it down and reconnected in the meantime.
+func TestSourceWebsocket_SurvivesAQuietServer(t *testing.T) {
+	coverage.Covers(t, "source.websocket")
+	var conns atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conns.Add(1)
+		c, err := ws.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.CloseNow()
+
+		// The quiet: longer than any read deadline the source might carry.
+		time.Sleep(10 * time.Second)
+
+		if err := c.Write(r.Context(), ws.MessageText, []byte("late")); err != nil {
+			return
+		}
+		for {
+			if _, _, err := c.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	s, err := NewSource(wsURL(srv))
+	assert.NoError(t, err)
+	assert.NoError(t, s.Start())
+	defer s.Close()
+
+	stream := s.Stream()
+	select {
+	case batch, ok := <-stream:
+		assert.That(t, ok)
+		assert.Equal(t, "late", string(batch[0].Value))
+	case <-time.After(30 * time.Second):
+		t.Fatal("the late frame never arrived")
+	}
+
+	// One connection: the silence did not look like a failure.
+	assert.Equal(t, int64(1), conns.Load())
+}


### PR DESCRIPTION
## Why

Every proof the engine carried was taken under load: the throughput matrix consumes ten million messages in seconds, the memory soak runs a thousand a second for an hour. Nothing showed what happens when a stream trickles, stops, or never starts, which is most streams most of the time.

One of those was a known defect. The stream-clock window predicate from #234 closes a window once the data moves past it, which is right for a replay and wrong for silence: a stream that stops never moves its own clock, so a surge that ends leaves its last bucket unpublished forever.

## What

**`sqlflow_progress`**, one row beside `sqlflow_offsets`: when the newest batch arrived, when state last committed, how many messages have been consumed. A batch moves all three, an idle tick moves the commit clock only. Recorded above the state guard, so a pipeline with no state file records too. The columns are `TIMESTAMPTZ`, which a test earned: written as `TIMESTAMP` against a UTC instant, a host in New York read `now() - last_arrival` as four hours in the future and never closed anything.

**The window predicate** gains an idleness branch reading that row, so after a grace of silence every open window closes. All four shipped examples carry it with their own grace periods.

**`/stats` reports progress ages, `/healthz` tells idle from stuck.** The question a supervisor has is not whether messages are arriving, since a low-traffic topic may go hours between them and be well. It is whether the pipeline is still working, which is the commit clock. Three intervals without a commit is 503 with the age in the body.

**A corrected invariant.** `pipeline.progress.no_silent_stall` claimed a zero flush interval removes the ticker and stalls a low-traffic topic forever. It does not; the run command has always defaulted it. The claim is rewritten and a test pins every value a config can produce.

## Cells

| Cell | What it pins |
| --- | --- |
| Trickle | One message every 40 ms into a batch of 1,000: ten flushes for ten messages, each on the interval |
| Surge then silence | 5,000 then nothing: the tail flushes, offset 4,999 saves, five intervals of quiet write nothing |
| Idle commits | Twenty empty commits against a real state file, autocommit off as the run command sets it: the file does not grow |
| Quiet stream closes its window | Carries its own control: the shipped predicate publishes nothing three seconds into the silence, the new one publishes once and deletes |
| Replay stays whole | The #234 property, three buckets in one burst closing the two older ones once each |
| Kafka idle | Eight seconds of silence against a six second session, next message arrives at the expected offset |
| Websocket quiet server | Accepts, says nothing for ten seconds, the late frame arrives on the same connection |
| Healthz | Idle healthy, three intervals stuck, first interval healthy, never-commits eventually stuck |

## The soak

A `slow-soak` skill beside `memory-soak`: surge, an hour of silence, an hour of trickle with gaps, half an hour of silence, sampled once a minute, seven rules judged at the end.

Dry run on this branch, ten minute profile: **PASS over 12 samples, worst latency 2s, working set 20 to 25 MiB, 52,003 of 52,003 messages landed, 5 windows published during the silences.**

The dry run earned its keep twice. The sampler started a container per query, which made one iteration take five minutes and destroyed the per-minute granularity every rule depends on. And the lag rule called the surge's own drain a failure. Both fixed, both described in the commit.

The medium profile ran on the pre-throttle image; the verdict above stands for it. The full profile is not needed before merge: every rule it judges is also pinned by a cell in the table.

## Memory soak

Contributing check 5, on the branch head `651344c` (image `v1.1.0-25-g651344c`), ten minutes at 250,000 msg/s:

```
window        minutes 3-10, 105,155,323 messages
native        21.6 -> 22.2 MiB
go retained   22.7 -> 24.2 MiB
native slope  +0.305 MiB/min
go slope      +0.025 MiB/min
per message   +0.006 B/msg (threshold 1.0)

PASS  memory is flat over 105,155,323 messages
```

The progress row and the throttled write add nothing per message. The `sqlflow_progress` write is bounded at one per second regardless of batch rate, which the `duckdb_progress_store` benchmark pins at 437 ns per commit against 112 µs unthrottled.

Spec: `docs/superpowers/specs/2026-09-10-slow-data-confidence-design.md`
Plan: `docs/superpowers/plans/2026-09-10-slow-data-confidence.md`
