### PR TITLE
core: record consumer lag once per fetch, restoring v1.1.0 throughput

### DIFF
--- a/internal/core/lag_test.go
+++ b/internal/core/lag_test.go
@@ -1,0 +1,124 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/embedded"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// recordingGauge keeps every value and partition handed to it, which the
+// SDK's aggregation would collapse into one last value per partition and so
+// could not show how many times Record was called.
+type recordingGauge struct {
+	embedded.Int64Gauge
+	mu    sync.Mutex
+	calls []lagCall
+}
+
+type lagCall struct {
+	partition int
+	value     int64
+}
+
+func (g *recordingGauge) Enabled(context.Context) bool { return true }
+
+func (g *recordingGauge) Record(_ context.Context, v int64, opts ...metric.RecordOption) {
+	set := metric.NewRecordConfig(opts).Attributes()
+	part, _ := set.Value(attribute.Key("partition"))
+	g.mu.Lock()
+	g.calls = append(g.calls, lagCall{partition: int(part.AsInt64()), value: v})
+	g.mu.Unlock()
+}
+
+// The consumer lag gauge is a last value, so one record per partition per
+// fetch says everything a record per message would, and the difference is
+// paid ten million times on the 10M benchmark: v1.1.0 ran it at 1.16M msg/s
+// against a noop provider, main at 0.95M once the provider became the SDK
+// so TurboStats could read it. The record has to carry the newest offset the
+// fetch delivered, not the first.
+func TestObservabilityMetrics_ConsumerLagRecordsOncePerFetchAndPartition(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	m, err := NewMetrics(nil)
+	assert.NoError(t, err)
+	gauge := &recordingGauge{}
+	m.ConsumerLag = gauge
+
+	// One fetch: a thousand messages from partition 0 ending at offset 999
+	// under a watermark of 1200, then ten from partition 1 that reach the
+	// watermark exactly.
+	fetch := kafkaMessages("events", 0, 0, 1000)
+	for i := range fetch {
+		fetch[i].HighWatermark = 1200
+	}
+	tail := kafkaMessages("events", 1, 500, 10)
+	for i := range tail {
+		tail[i].HighWatermark = 510
+	}
+	fetch = append(fetch, tail...)
+
+	src := &fakeSource{batches: [][]Message{fetch}}
+	tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, 100, time.Second,
+		&sync.Mutex{}, PipelineErrorPolicies{}, WithMetrics(m))
+	_, err = tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	gauge.mu.Lock()
+	defer gauge.mu.Unlock()
+	assert.Equal(t, 2, len(gauge.calls))
+	byPartition := map[int]int64{}
+	for _, c := range gauge.calls {
+		byPartition[c.partition] = c.value
+	}
+	// 1200 - 999 - 1: the last processed offset, not the first.
+	assert.Equal(t, int64(200), byPartition[0])
+	// 510 - 509 - 1: caught up.
+	assert.Equal(t, int64(0), byPartition[1])
+}
+
+// BenchmarkGaugeRecord is what one Record costs on the provider a pipeline
+// actually runs with. The noop case is what v1.1.0 paid per message; the sdk
+// case is what main paid once the provider stopped being a noop. Multiply by
+// messages per second to see the throughput it costs when recorded per
+// message, which is why mark no longer does.
+//
+//	go test ./internal/core/ -bench GaugeRecord -benchmem -run '^$'
+func BenchmarkGaugeRecord(b *testing.B) {
+	ctx := context.Background()
+	attrs := []metric.RecordOption{metric.WithAttributes(
+		attribute.String("topic", "events"),
+		attribute.Int("partition", 0),
+	)}
+
+	b.Run("noop", func(b *testing.B) {
+		m, err := NewMetrics(nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			m.ConsumerLag.Record(ctx, int64(i), attrs...)
+		}
+	})
+
+	b.Run("sdk", func(b *testing.B) {
+		mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewManualReader()))
+		m, err := NewMetrics(mp)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			m.ConsumerLag.Record(ctx, int64(i), attrs...)
+		}
+	})
+}

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -226,6 +226,13 @@ type Turbine struct {
 	// passing options one by one reallocates the slice on every call.
 	lagAttrCache map[lagKey][]metric.RecordOption
 
+	// lagPending holds the newest lag seen per topic and partition since the
+	// last recordLag. A gauge is a last value, so recording it on every
+	// message spends a real instrument call to say what the final message of
+	// the fetch says anyway: 18% of throughput on the 10M benchmark once the
+	// default provider stopped being a noop. Same goroutine rule as the cache.
+	lagPending map[lagKey]int64
+
 	// Built once at startup for the same reason as lagAttrCache. Typed as
 	// AddOption because only counters carry result; the histograms keep
 	// measuring every attempt regardless of outcome.
@@ -528,6 +535,7 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 				numBatchMessages = 0
 			}
 		}
+		t.recordLag(ctx)
 	}
 
 	// Whatever is buffered when the loop ends — because --max-msgs was
@@ -669,8 +677,21 @@ func (t *Turbine) mark(m Message) {
 	// -1 because a mark names the last *processed* offset: having processed
 	// offset 9 with a watermark of 10 is lag zero.
 	if m.HighWatermark > 0 {
-		t.metrics.ConsumerLag.Record(context.Background(), m.HighWatermark-m.Offset-1,
-			t.lagAttrs(m.Topic, m.Partition)...)
+		if t.lagPending == nil {
+			t.lagPending = make(map[lagKey]int64)
+		}
+		t.lagPending[lagKey{topic: m.Topic, partition: m.Partition}] = m.HighWatermark - m.Offset - 1
+	}
+}
+
+// recordLag publishes the lag of every partition marked since the last call,
+// once each. The consume loop calls it after each fetch, so the gauge is as
+// fresh as the newest message and costs one record per partition per fetch
+// rather than one per message.
+func (t *Turbine) recordLag(ctx context.Context) {
+	for key, lag := range t.lagPending {
+		t.metrics.ConsumerLag.Record(ctx, lag, t.lagAttrs(key.topic, key.partition)...)
+		delete(t.lagPending, key)
 	}
 }
 


### PR DESCRIPTION
## Why

#258 made the OpenTelemetry SDK the default meter provider so TurboStats can read the instruments. Before it, a pipeline started without `--metrics` got a nil provider and every instrument was a noop. That was the right change, and it exposed one instrument recorded on the wrong cadence: `mark` recorded the consumer lag gauge once per message.

One gauge record costs 2 ns on the noop provider and 118 ns on the SDK (`BenchmarkGaugeRecord`, added here). At 1.16M messages a second the consume loop has about 860 ns per message, so 118 ns of it is 14%. Measured in the container, 10M messages, batch 5,000, StructuredBatch, same machine, two rounds each:

| Build | Throughput | Peak RSS | Working set |
| --- | --- | --- | --- |
| v1.1.0 | 1,161,115/s, 1,166,273/s | 299 to 305 MiB | 210 to 215 MiB |
| main (27d6476) | 947,481/s, 991,645/s | 302 to 304 MiB | 211 to 213 MiB |
| this fix | 1,176,767/s, 1,181,995/s | 298 to 301 MiB | 210 to 211 MiB |

Memory was never affected.

## What

A gauge is a last value. `mark` now keeps the newest lag per topic and partition in a map, and the consume loop records each entry once after every fetch. The gauge carries the same number it did before, the last processed offset against the watermark, and a fetch of a thousand messages costs one record instead of a thousand.

`TestObservabilityMetrics_ConsumerLagRecordsOncePerFetchAndPartition` pins both halves: two partitions in one fetch produce exactly two records, and each carries the lag of that partition's newest message, not its first.

## Checks

- `go test -short -race ./internal/core/ ./internal/cli/run/` pass
- `uv run --locked pytest tests/tooling` 205 passed
- `make coverage-page` clean: the test joins `observability.metrics`, no registry change
- `make soak`, required because this touches the consume loop, on image `v1.1.0-7-gede06df`:

```
window        minutes 3-10, 105,281,755 messages
native        23.3 -> 21.7 MiB
go retained   24.0 -> 22.8 MiB
native slope  -0.008 MiB/min
go slope      -0.112 MiB/min
per message   -0.016 B/msg (threshold 1.0)

PASS  memory is flat over 105,281,755 messages
```

- Release suite not run: no CLI surface, flag, or Dockerfile change.
