### PR TITLE
Record phase durations, not only phase errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,30 @@ asserts this table against the running exporter.
 |---|---|---|---|
 | `batch_processing_latency` | `batch_processing_latency_seconds` | histogram | — |
 | `error_count` | `error_count_total` | counter | `class`, `domain`, `code`, `phase` |
+| `phase_duration` | `phase_duration_seconds` | histogram | `phase` |
+
+`phase_duration` decomposes batch time. It carries the same six phases
+`error_count` does — `handler.write`, `handler.invoke`, `sink.write`,
+`sink.flush`, `state.commit`, `handler.init` — so one query says where the time
+went:
+
+```promql
+sum(rate(phase_duration_seconds_sum[5m])) by (phase)
+```
+
+Read it with `error_count` to tell slow from broken. `phase_duration` records
+whether or not the phase succeeded, which no other latency here does:
+`sink_flush_latency` and `state_commit_latency` record after their error
+returns, so a sink that takes thirty seconds to fail leaves them flat.
+
+`handler.write` is measured around the whole message loop rather than each
+write, so it also carries the loop's own bookkeeping. Timing each write cost
+4.1x on that path; see `BenchmarkConsumeLoopWritePath`.
+
+Every latency histogram shares one set of bucket boundaries, from 100
+microseconds to 60 seconds. The OTel SDK's defaults are millisecond-shaped and
+these instruments record seconds, so before this every `histogram_quantile`
+over them returned a number under five seconds and meant nothing.
 
 **Source:**
 

--- a/internal/cli/run/metrics_test.go
+++ b/internal/cli/run/metrics_test.go
@@ -128,6 +128,7 @@ func exportedNames(t *testing.T) []string {
 	m.SinkFlushNumRows.Record(ctx, 1)
 	m.SinkFlushCount.Add(ctx, 1)
 	m.BatchProcessingLatency.Record(ctx, 1)
+	m.PhaseDuration.Record(ctx, 1)
 	m.ConsumerLag.Record(ctx, 1)
 	m.StateCommitLatency.Record(ctx, 1)
 	m.StateCommitCount.Add(ctx, 1)
@@ -196,6 +197,7 @@ func TestExportedSeriesNames(t *testing.T) {
 		"error_count_total",
 		"handler_rows_read_total",
 		"message_count_messages_total",
+		"phase_duration_seconds",
 		"pipeline_commits_total",
 		"pipeline_errors_total",
 		"pipeline_flushes_total",
@@ -217,6 +219,83 @@ func TestExportedSeriesNames(t *testing.T) {
 		"webhook_requests_total",
 	}
 	assert.DeepEqual(t, want, exportedNames(t))
+}
+
+// wantLatencyBuckets is the boundary set every latency histogram declares, in
+// seconds.
+//
+// Written out here rather than imported from core on purpose: a test that read
+// the production constant would agree with whatever that constant became, and
+// the defect this guards against is a silent change of boundaries.
+var wantLatencyBuckets = []float64{
+	0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+	1, 2.5, 5, 10, 30, 60,
+}
+
+// exportedBuckets returns the bucket upper bounds each histogram exports.
+func exportedBuckets(t *testing.T) map[string][]float64 {
+	t.Helper()
+
+	reg := prom.NewRegistry()
+	exp, err := prometheus.New(prometheus.WithRegisterer(reg))
+	assert.NoError(t, err)
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exp))
+
+	m, err := core.NewMetrics(mp)
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	m.SourceReadLatency.Record(ctx, 1)
+	m.SinkFlushLatency.Record(ctx, 1)
+	m.BatchProcessingLatency.Record(ctx, 1)
+	m.StateCommitLatency.Record(ctx, 1)
+	m.PhaseDuration.Record(ctx, 1)
+
+	families, err := reg.Gather()
+	assert.NoError(t, err)
+
+	got := map[string][]float64{}
+	for _, f := range families {
+		for _, mm := range f.GetMetric() {
+			h := mm.GetHistogram()
+			if h == nil {
+				continue
+			}
+			var bounds []float64
+			for _, b := range h.GetBucket() {
+				bounds = append(bounds, b.GetUpperBound())
+			}
+			got[f.GetName()] = bounds
+		}
+	}
+	return got
+}
+
+// TestLatencyHistogramBucketsAreSecondsShaped pins the boundaries of every
+// latency histogram.
+//
+// The OTel SDK's default explicit boundaries are millisecond-shaped -- 0, 5,
+// 10, 25 ... 10000 -- and every histogram here records seconds. Under the
+// defaults a 200 microsecond flush and a 4 second flush land in the same
+// bucket, so histogram_quantile over any of these returned a number between 0
+// and 5 and meant nothing. Only _sum and _count worked.
+//
+// What breaks if this is wrong: an operator reads a p99 that is not a p99.
+func TestLatencyHistogramBucketsAreSecondsShaped(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	got := exportedBuckets(t)
+
+	for _, name := range []string{
+		"batch_processing_latency_seconds",
+		"phase_duration_seconds",
+		"sink_flush_latency_seconds",
+		"source_read_latency_seconds",
+		"state_commit_latency_seconds",
+	} {
+		bounds, ok := got[name]
+		assert.That(t, ok)
+		assert.DeepEqual(t, wantLatencyBuckets, bounds)
+	}
 }
 
 // TestStateCommitLatencyUnitIsNameNeutral guards the unit alignment.

--- a/internal/core/bench_writepath_test.go
+++ b/internal/core/bench_writepath_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// benchSource delivers n messages in batches, generated as the loop consumes
+// them rather than buffered up front, so a run at b.N in the millions measures
+// the loop and not the fixture.
+type benchSource struct {
+	n    int
+	size int
+	ch   chan []Message
+}
+
+func (s *benchSource) Start() error { return nil }
+
+func (s *benchSource) Stream() <-chan []Message {
+	s.ch = make(chan []Message, 1)
+	go func() {
+		defer close(s.ch)
+		for sent := 0; sent < s.n; {
+			k := s.size
+			if rem := s.n - sent; rem < k {
+				k = rem
+			}
+			batch := make([]Message, k)
+			for i := range batch {
+				batch[i] = Message{Value: []byte(`{"a": 1}`)}
+			}
+			s.ch <- batch
+			sent += k
+		}
+	}()
+	return s.ch
+}
+
+func (s *benchSource) Commit() error { return nil }
+func (s *benchSource) Close() error  { return nil }
+
+// BenchmarkConsumeLoopWritePath measures the consume loop per message, which
+// is where phase timing has to be cheap.
+//
+// Timing each writeMessage call took this loop from 22 ns/op to 91 -- 4.1x --
+// so handler.write is measured by bracketing the loop instead. The two batch
+// sizes separate the two costs: batch 100000 leaves the loop almost alone with
+// its per-message work, and batch 500 pays a full processBatch every 500
+// messages, where the other five phases are timed.
+//
+//	go test ./internal/core/ -bench WritePath -benchmem -run '^$'
+//
+// fakeHandler.Write increments a counter and returns, so the loop's own
+// overhead is the whole measurement. A real handler parses JSON and appends to
+// an Arrow builder, which dwarfs it. These figures are the worst case, not the
+// expected one.
+//
+// Compare two commits with benchstat and interleaved runs rather than reading
+// absolute figures: on a laptop the arm that runs second is the warmer one.
+func BenchmarkConsumeLoopWritePath(b *testing.B) {
+	run := func(b *testing.B, batchSize int, opts ...TurbineOption) {
+		src := &benchSource{n: b.N, size: 1000}
+		tb := NewTurbine(src, &fakeHandler{}, &fakeSink{}, batchSize, time.Hour,
+			&sync.Mutex{}, PipelineErrorPolicies{}, opts...)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		if _, err := tb.ConsumeLoop(context.Background(), 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	metered := func(b *testing.B) TurbineOption {
+		b.Helper()
+		m, err := NewMetrics(sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(sdkmetric.NewManualReader())))
+		if err != nil {
+			b.Fatal(err)
+		}
+		return WithMetrics(m)
+	}
+
+	// The default instruments record nothing, which is what a pipeline runs
+	// with when --metrics is off. What remains is the clock reads themselves.
+	b.Run("metrics_off/batch_100000", func(b *testing.B) { run(b, 100000) })
+	b.Run("metrics_off/batch_500", func(b *testing.B) { run(b, 500) })
+
+	// With a real reader attached, the histogram records are paid too.
+	b.Run("metrics_on/batch_100000", func(b *testing.B) { run(b, 100000, metered(b)) })
+	b.Run("metrics_on/batch_500", func(b *testing.B) { run(b, 500, metered(b)) })
+}

--- a/internal/core/metrics.go
+++ b/internal/core/metrics.go
@@ -19,11 +19,15 @@ type Metrics struct {
 	SinkFlushCount         metric.Int64Counter
 	BatchProcessingLatency metric.Float64Histogram
 	StateCommitLatency     metric.Float64Histogram
-	StateCommitCount       metric.Int64Counter
-	StateSizeBytes         metric.Int64Gauge
-	StateTableRows         metric.Int64Gauge
-	ReferenceTableRows     metric.Int64Gauge
-	ConsumerLag            metric.Int64Gauge
+	// PhaseDuration is how long each stage of a batch took, labelled with the
+	// same phase the error taxonomy uses. It is the only instrument that
+	// decomposes batch time, and the only latency that counts failures.
+	PhaseDuration      metric.Float64Histogram
+	StateCommitCount   metric.Int64Counter
+	StateSizeBytes     metric.Int64Gauge
+	StateTableRows     metric.Int64Gauge
+	ReferenceTableRows metric.Int64Gauge
+	ConsumerLag        metric.Int64Gauge
 
 	// Flat twins of the instruments above that carry attributes.
 	//
@@ -45,6 +49,29 @@ type Metrics struct {
 	// cannot: a websocket or webhook source has no offsets at all, and a
 	// per-partition lag is not one number.
 	PipelineLastMessage metric.Int64Gauge
+}
+
+// latencyBuckets is the boundary set every latency histogram declares.
+//
+// The OTel SDK's default explicit boundaries are millisecond-shaped -- 0, 5,
+// 10, 25 ... 10000 -- and every histogram here records seconds. Under the
+// defaults a 200 microsecond flush and a 4 second flush shared the le=5
+// bucket, so histogram_quantile over any latency series returned a number
+// between 0 and 5 that described nothing. Only _sum and _count carried
+// information.
+//
+// Declared as an instrument option rather than an SDK view, so every provider
+// inherits it -- including the ones tests build, which a view configured at
+// the exporter would miss.
+//
+// The floor is 100 microseconds because an in-memory sink flush and a
+// stateless commit really are that fast, and a soak run would otherwise pile
+// into the first bucket -- the same defect one decimal place further down. The
+// ceiling is 60 seconds because past a minute the question is no longer how
+// slow a phase is but whether it is stuck, which error_count answers.
+var latencyBuckets = []float64{
+	0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+	1, 2.5, 5, 10, 30, 60,
 }
 
 // NewMetrics builds the instruments from a meter provider. Passing a noop
@@ -96,6 +123,7 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		"source_read_latency",
 		metric.WithDescription("Latency of reading a message from the source"),
 		metric.WithUnit("seconds"),
+		metric.WithExplicitBucketBoundaries(latencyBuckets...),
 	); err != nil {
 		return nil, fmt.Errorf("source_read_latency: %w", err)
 	}
@@ -104,6 +132,7 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		"sink_flush_latency",
 		metric.WithDescription("Latency of flushing data to the sink"),
 		metric.WithUnit("seconds"),
+		metric.WithExplicitBucketBoundaries(latencyBuckets...),
 	); err != nil {
 		return nil, fmt.Errorf("sink_flush_latency: %w", err)
 	}
@@ -135,8 +164,31 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		"batch_processing_latency",
 		metric.WithDescription("Latency of processing a batch of data, from first message to flush"),
 		metric.WithUnit("seconds"),
+		metric.WithExplicitBucketBoundaries(latencyBuckets...),
 	); err != nil {
 		return nil, fmt.Errorf("batch_processing_latency: %w", err)
+	}
+
+	// The duration twin of error_count, carrying the same phase label.
+	//
+	// Three existing latencies overlap it and none answers the question. Two
+	// of them -- sink_flush_latency and state_commit_latency -- record after
+	// every error return, so a phase that fails contributes nothing however
+	// long it took. sink_flush_latency also spans WriteTable and Flush as one
+	// blob, which is a sink write and a sink flush added together. And
+	// handler.invoke, the SQL, had no metric at all: it appeared only in a
+	// debug log line nobody scrapes.
+	//
+	// Named phase_duration with unit "seconds" so the exporter yields
+	// phase_duration_seconds, the same way sink_flush_latency yields
+	// sink_flush_latency_seconds. Measured in TestExportedSeriesNames.
+	if m.PhaseDuration, err = meter.Float64Histogram(
+		"phase_duration",
+		metric.WithDescription("How long each stage of a batch took, whether or not it succeeded"),
+		metric.WithUnit("seconds"),
+		metric.WithExplicitBucketBoundaries(latencyBuckets...),
+	); err != nil {
+		return nil, fmt.Errorf("phase_duration: %w", err)
 	}
 
 	if m.ConsumerLag, err = meter.Int64Gauge(
@@ -151,6 +203,7 @@ func NewMetrics(mp metric.MeterProvider) (*Metrics, error) {
 		"state_commit_latency",
 		metric.WithDescription("Latency of committing state and offsets together"),
 		metric.WithUnit("seconds"),
+		metric.WithExplicitBucketBoundaries(latencyBuckets...),
 	); err != nil {
 		return nil, fmt.Errorf("state_commit_latency: %w", err)
 	}

--- a/internal/core/phase_test.go
+++ b/internal/core/phase_test.go
@@ -1,0 +1,157 @@
+package core
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/turbolytics/sql-flow/internal/coverage"
+	"github.com/zeebo/assert"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// phase_duration answers where batch time goes. error_count already labels
+// every failure with a phase; until now the same phases carried no duration,
+// so an operator could see which stage was failing and not which was slow.
+
+// phaseCounts returns how many observations phase_duration recorded under
+// each phase.
+func phaseCounts(t *testing.T, r *sdkmetric.ManualReader) map[string]uint64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, r.Collect(context.Background(), &rm))
+
+	counts := map[string]uint64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "phase_duration" {
+				continue
+			}
+			data, ok := m.Data.(metricdata.Histogram[float64])
+			if !ok {
+				continue
+			}
+			for _, dp := range data.DataPoints {
+				v, ok := dp.Attributes.Value("phase")
+				if !ok {
+					continue
+				}
+				counts[v.AsString()] += dp.Count
+			}
+		}
+	}
+	return counts
+}
+
+// phasesSeen returns the phases phase_duration recorded, sorted.
+func phasesSeen(t *testing.T, r *sdkmetric.ManualReader) []string {
+	t.Helper()
+	var out []string
+	for phase := range phaseCounts(t, r) {
+		out = append(out, phase)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// histogramCount returns the total observations one dimensionless histogram
+// recorded.
+func histogramCount(t *testing.T, r *sdkmetric.ManualReader, name string) uint64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, r.Collect(context.Background(), &rm))
+
+	var total uint64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			if data, ok := m.Data.(metricdata.Histogram[float64]); ok {
+				for _, dp := range data.DataPoints {
+					total += dp.Count
+				}
+			}
+		}
+	}
+	return total
+}
+
+// recordPhase looks its attributes up by phase name. A phase with no cached
+// entry records a point with no phase label, which merges into a series that
+// is true of nothing -- silently, with every test above still passing, because
+// the observation is made either way.
+//
+// What breaks if this is wrong: a new phase lands in the taxonomy, goes into
+// an unlabelled series, and an operator reads a batch-time decomposition whose
+// parts no longer add up.
+func TestObservabilityMetrics_EveryPhaseHasCachedAttributes(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	tb := newTestTurbine(&fakeSource{}, &fakeHandler{}, &fakeSink{}, 1)
+
+	for _, phase := range []string{
+		phaseHandlerWrite, phaseHandlerInvoke, phaseHandlerInit,
+		phaseSinkWrite, phaseSinkFlush, phaseStateCommit,
+	} {
+		if _, ok := tb.phaseAttrs[phase]; !ok {
+			t.Errorf("phase %q has no cached attribute set", phase)
+		}
+	}
+}
+
+// A batch that runs every phase times every phase. The assertion is the whole
+// set rather than a spot check: a phase added to the taxonomy and not to the
+// timing is the exact asymmetry this instrument exists to remove.
+func TestObservabilityMetrics_ABatchTimesEveryPhaseItRan(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	src := &fakeSource{batches: [][]Message{messages(10)}}
+	tb, reader := meteredTurbine(t, src, &fakeSink{}, 10)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	want := []string{
+		phaseHandlerInit, phaseHandlerInvoke, phaseHandlerWrite,
+		phaseSinkFlush, phaseSinkWrite, phaseStateCommit,
+	}
+	sort.Strings(want)
+	assert.DeepEqual(t, want, phasesSeen(t, reader))
+}
+
+// A phase that fails still spent the time. sink_flush_latency records after
+// both error returns in processBatch, so a sink that takes thirty seconds to
+// fail leaves it flat -- the operator sees a rising error_count and cannot
+// tell a fast failure from a slow one. phase_duration counts both.
+//
+// What breaks if this is wrong: a slow-failing sink is indistinguishable from
+// a fast-failing one, and the scale-out guardrail reads a batch-time
+// decomposition that omits the phase burning the time.
+func TestObservabilityMetrics_AFailedPhaseStillRecordsItsDuration(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	src := &fakeSource{batches: [][]Message{messages(10)}}
+	tb, reader := meteredTurbine(t, src, &flushFailingSink{}, 10)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.Error(t, err)
+
+	assert.Equal(t, uint64(1), phaseCounts(t, reader)[phaseSinkFlush])
+	// The contrast that makes the new instrument worth having.
+	assert.Equal(t, uint64(0), histogramCount(t, reader, "sink_flush_latency"))
+}
+
+// handler.write is the one phase on the per-message path, which runs at
+// benchmarked rates near 900k msgs/sec. It is timed per source batch: the
+// observation is the time that batch's messages took to reach the handler, so
+// the hot path pays two clock reads per message and none per observation.
+func TestObservabilityMetrics_HandlerWriteIsTimedPerSourceBatch(t *testing.T) {
+	coverage.Covers(t, "observability.metrics")
+	src := &fakeSource{batches: [][]Message{messages(10), messages(10)}}
+	tb, reader := meteredTurbine(t, src, &fakeSink{}, 10)
+
+	_, err := tb.ConsumeLoop(context.Background(), 0)
+	assert.NoError(t, err)
+
+	// Two source batches, twenty messages, two observations.
+	assert.Equal(t, uint64(2), phaseCounts(t, reader)[phaseHandlerWrite])
+}

--- a/internal/core/turbine.go
+++ b/internal/core/turbine.go
@@ -178,6 +178,23 @@ const (
 	phaseStateCommit   = "state.commit"
 )
 
+// phases is every phase above, in the order a batch runs them, so the
+// attribute cache is built once at startup rather than grown on the batch
+// path.
+//
+// A phase named in the block above and missing here records a point with no
+// phase label, which merges into a series that is true of nothing rather than
+// failing. TestObservabilityMetrics_EveryPhaseHasCachedAttributes is what
+// catches that.
+var phases = []string{
+	phaseHandlerWrite,
+	phaseHandlerInvoke,
+	phaseSinkWrite,
+	phaseSinkFlush,
+	phaseStateCommit,
+	phaseHandlerInit,
+}
+
 // offsetSaver writes positions into the pipeline's state database. It is an
 // interface so the ordering tests need no DuckDB; OffsetStore implements it.
 type offsetSaver interface {
@@ -261,6 +278,10 @@ type Turbine struct {
 	// measuring every attempt regardless of outcome.
 	resultOKAttrs    []metric.AddOption
 	resultErrorAttrs []metric.AddOption
+
+	// One cached option slice per phase, for the same reason. Every phase is
+	// known at startup, so this is a fixed six entries and never grows.
+	phaseAttrs map[string][]metric.RecordOption
 
 	logger  *zap.Logger
 	metrics *Metrics
@@ -448,6 +469,13 @@ func NewTurbine(
 		metric.WithAttributes(attribute.String("result", resultError)),
 	}
 
+	t.phaseAttrs = make(map[string][]metric.RecordOption, len(phases))
+	for _, phase := range phases {
+		t.phaseAttrs[phase] = []metric.RecordOption{
+			metric.WithAttributes(attribute.String("phase", phase)),
+		}
+	}
+
 	// Instruments that record nothing until a provider is supplied, so the
 	// pipeline never has to nil-check them.
 	t.metrics, _ = NewMetrics(nil)
@@ -612,6 +640,24 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 		// anything" cannot tell the two apart.
 		t.metrics.PipelineLastMessage.Record(ctx, time.Now().Unix())
 
+		// handler.write is timed by bracketing the whole loop and subtracting
+		// the batches that ran inside it, rather than by timing each
+		// writeMessage call.
+		//
+		// Two clock reads per message took this loop from 22 ns/op to 91,
+		// benchmarked in BenchmarkConsumeLoopWritePath -- 4.1x, the same shape
+		// as the regression that put a cached attribute set in front of
+		// consumer_lag. Nothing on the per-message path survives that price.
+		//
+		// The cost of measuring it out here is that mark, the consumed
+		// counters and the pending-lag map write are charged to handler.write
+		// along with the write itself. That is around 22 ns a message against
+		// a real handler that parses JSON and appends to an Arrow builder in
+		// microseconds, so the attribution error is under a percent of the
+		// phase it lands in.
+		loopStart := time.Now()
+		var batchTook time.Duration
+
 		for _, raw := range msgBatch {
 			if err := t.writeMessage(raw); err != nil {
 				t.recordError(ctx, err, phaseHandlerWrite, "error writing message")
@@ -656,12 +702,24 @@ func (t *Turbine) ConsumeLoop(ctx context.Context, maxMsgs int) (stats *Stats, e
 				default:
 				}
 
+				p0 := time.Now()
 				if err := t.processBatch(ctx, numBatchMessages); err != nil {
 					return nil, err
 				}
+				batchTook += time.Since(p0)
 				numBatchMessages = 0
 			}
 		}
+		// One observation per source batch. Guarded because an empty batch
+		// wrote nothing, and recording a zero would drag the histogram toward
+		// the floor with time no message spent.
+		//
+		// Before recordLag, so the per-partition gauge records that fetch owes
+		// are not charged to handler.write.
+		if len(msgBatch) > 0 {
+			t.recordPhase(ctx, phaseHandlerWrite, time.Since(loopStart)-batchTook)
+		}
+
 		t.recordLag(ctx)
 	}
 
@@ -705,6 +763,17 @@ func (t *Turbine) resultAttrs(result string) []metric.AddOption {
 		return t.resultOKAttrs
 	}
 	return t.resultErrorAttrs
+}
+
+// recordPhase times one stage of a batch.
+//
+// Called on the success and the failure path both, which is the difference
+// between this and sink_flush_latency or state_commit_latency: those record
+// after every error return, so a phase that takes thirty seconds to fail
+// leaves them flat. Time spent failing is still time the batch spent, and a
+// decomposition that drops it points the operator at the wrong phase.
+func (t *Turbine) recordPhase(ctx context.Context, phase string, took time.Duration) {
+	t.metrics.PhaseDuration.Record(ctx, took.Seconds(), t.phaseAttrs[phase]...)
 }
 
 // recordError counts and logs one failure.
@@ -958,6 +1027,7 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	t.lock.Unlock()
 
 	b1 := time.Now()
+	t.recordPhase(ctx, phaseHandlerInvoke, b1.Sub(b0))
 
 	// Recorded before the error branch below. A failed Invoke reports zero,
 	// which is the honest number, and skipping the record entirely would
@@ -991,7 +1061,13 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	}
 
 	if batch != nil {
-		if err := t.sink.WriteTable(ctx, batch); err != nil {
+		w0 := time.Now()
+		err = t.sink.WriteTable(ctx, batch)
+		// Before the branch, so a write that fails slowly is still counted as
+		// time the batch spent.
+		t.recordPhase(ctx, phaseSinkWrite, time.Since(w0))
+
+		if err != nil {
 			t.recordError(ctx, err, phaseSinkWrite, "error writing batch to sink")
 			t.metrics.SinkFlushCount.Add(ctx, 1, t.resultAttrs(resultError)...)
 			// Same reasoning as the flush path below: this batch's handler
@@ -1003,7 +1079,11 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 		}
 	}
 
-	if err := t.flush(ctx, batch); err != nil {
+	f0 := time.Now()
+	err = t.flush(ctx, batch)
+	t.recordPhase(ctx, phaseSinkFlush, time.Since(f0))
+
+	if err != nil {
 		t.recordError(ctx, err, phaseSinkFlush, "error flushing sink")
 		t.metrics.SinkFlushCount.Add(ctx, 1, t.resultAttrs(resultError)...)
 		// A failed flush keeps its rows buffered, and sink_rows_written does
@@ -1037,7 +1117,16 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 	// duplicate -- recoverable -- while state and offsets stay consistent.
 	// Committing first would move the offsets past rows the sink never
 	// received, which loses them silently.
-	if err := t.commitState(ctx); err != nil {
+	c0 := time.Now()
+	err = t.commitState(ctx)
+	// Timed at the call site rather than inside commitState, so the phase is
+	// reported by a pipeline with no state database too. state_commit_latency
+	// is deliberately absent there -- an absent series and an empty state are
+	// different facts -- but the commit phase still runs, still writes
+	// progress, and still belongs in the batch-time decomposition.
+	t.recordPhase(ctx, phaseStateCommit, time.Since(c0))
+
+	if err != nil {
 		t.recordError(ctx, err, phaseStateCommit, "error committing state")
 		t.metrics.StateCommitCount.Add(ctx, 1, t.resultAttrs(resultError)...)
 		if batch != nil {
@@ -1074,7 +1163,11 @@ func (t *Turbine) processBatch(ctx context.Context, numBatchMessages int) error 
 		batch.Release()
 	}
 
-	if err := t.handler.Init(ctx); err != nil {
+	i0 := time.Now()
+	err = t.handler.Init(ctx)
+	t.recordPhase(ctx, phaseHandlerInit, time.Since(i0))
+
+	if err != nil {
 		t.recordError(ctx, err, phaseHandlerInit, "error reinitializing handler")
 		return err
 	}


### PR DESCRIPTION
## What this changes

`error_count` labels every failure with a phase. The same phases carried no
duration, so nothing answered where batch time goes. `handler.invoke` — the SQL,
the thing most likely to be slow in a SQL engine — had no metric at all beyond a
debug log line nobody scrapes.

Adds `phase_duration_seconds{phase}` over all six taxonomy phases, recorded on
the success path and the failure path both. That second part is the point:
`sink_flush_latency` and `state_commit_latency` record *after* their error
returns, so a sink that takes thirty seconds to fail leaves them flat and an
operator cannot tell slow from broken.

```promql
sum(rate(phase_duration_seconds_sum[5m])) by (phase)
```

**Every latency histogram also gains explicit bucket boundaries.** The SDK
defaults are millisecond-shaped (`0, 5, 10, 25 … 10000`) and these instruments
record seconds. Measured against the Prometheus exporter, six samples from 0.2ms
to 4.9s all landed in `le=5`:

```
count=6 sum=6.6222
  le=0     cumulative=0
  le=5     cumulative=6
  le=10    cumulative=6   ... (flat to le=10000)
```

`histogram_quantile` over any latency series in this repo returned a number
under five seconds and described nothing. Only `_sum` and `_count` carried
information.

**What breaks if this is wrong:** an autoscaler reads a batch-time decomposition
whose parts do not add up, and scales out a sink-bound pipeline.

### Performance

`handler.write` is the one phase on the per-message path. Timing each
`writeMessage` call took the loop from **22 ns/op to 91 — 4.1x**, the same shape
as the `consumer_lag` regression #260 just fixed. So it is timed by bracketing
the loop and subtracting the `processBatch` time that ran inside it.

Interleaved benchstat against `main`, ten samples per arm:

```
ConsumeLoopWritePath/metrics_off/batch_100000    25.46n → 26.50n    ~      (p=0.325)
ConsumeLoopWritePath/metrics_off/batch_500       27.95n → 28.82n    +3.09% (p=0.004)
ConsumeLoopWritePath/metrics_on/batch_100000     22.77n → 23.23n    +2.00% (p=0.030)
ConsumeLoopWritePath/metrics_on/batch_500        29.86n → 32.57n    +9.11% (p=0.002)
allocs/op                                         1.000 →  1.000    ~ (all equal)
```

The +9.11% is **2.71 ns per message** and no extra allocations. That absolute
figure is unchanged from before #260 landed; the percentage grew only because
#260 made the loop it is measured against faster. `fakeHandler.Write` increments
a counter, so these are the worst case — a real handler parses JSON into an
Arrow builder in microseconds.

## Verification

- [x] `go test -short -race ./...` — exit 0, 20 packages ok
- [x] `uv run --locked pytest tests/tooling -q` — 205 passed
- [x] `make coverage-page && git status --short docs/coverage` is clean — no diff
- [ ] `uv run --locked pytest tests/release -q` — **not applicable**: no change
      to the CLI surface, a flag, the Dockerfile, or anything stamped at build
      time
- [x] `make soak` — PASS over 105,231,407 messages

### Soak verdict

```
window        minutes 3-10, 105,231,407 messages
native        21.6 -> 20.2 MiB
go retained   24.8 -> 24.8 MiB
native slope  +0.062 MiB/min
go slope      +0.039 MiB/min
per message   -0.014 B/msg (threshold 1.0)

PASS  memory is flat over 105,231,407 messages
```

Run against `turbolytics/sql-flow:v1.2.0-1-ga22d8c5`, the image built from this
commit, with the `noop` sink config the gate ships.

## Notes for the reviewer

**Decisions I made rather than derived:**

- **Six phases, not the five in #176.** `handler.init` is already in the
  taxonomy and already labels `error_count`. Covering a different set than the
  counter would reintroduce the asymmetry this issue is about.
- **No `result` attribute.** `error_count{phase}` already answers the outcome
  question; doubling a six-value label to answer it twice is not worth the
  series.
- **`state_commit` is timed at the call site, not inside `commitState`**, so a
  pipeline with no state database still reports the phase. `state_commit_latency`
  is deliberately absent there — an absent series and an empty state are
  different facts — but the commit phase still runs and still belongs in the
  decomposition.
- **`handler.write` carries the loop's own bookkeeping** (`mark`, the consumed
  counters, the pending-lag map write) along with the write itself, ~22 ns a
  message. Against a real handler that is under a percent of the phase.

**Found but not fixed — worth its own issue.** `error_count{phase="sink.flush"}`
is double-counted: `flush()` records the error and then `processBatch` records
the same error again. One failed flush increments the counter twice and logs
twice. Left alone here because fixing it changes an existing metric's values.

Closes #176
