### PR TITLE
published: the TigerData config follows the site tutorial

### DIFF
--- a/dev/config/examples/published/README.md
+++ b/dev/config/examples/published/README.md
@@ -14,7 +14,7 @@ generated JSON schema.
 | `clickhouse.taxi.yml` | ClickHouse docs, the NYC taxi walkthrough |
 | `clickhouse.bluesky.yml` | ClickHouse docs, the WebSocket example |
 | `motherduck.bluesky.websocket.yml` | MotherDuck cookbook, `sqlflow-streaming-websocket` |
-| `tigerdata.enrich.yml` | TigerData docs, `integrate/data-ingestion-streaming/sqlflow` |
+| `tigerdata.enrich.yml` | turbolytics.io, `docs/sqlflow/tutorials/tigerdata-enrich` |
 
 When a page changes, change the file here first and copy it out. When the
 engine changes, CI tells you which published page needs an edit before a

--- a/dev/config/examples/published/tigerdata.enrich.yml
+++ b/dev/config/examples/published/tigerdata.enrich.yml
@@ -1,4 +1,4 @@
-# Published in the TigerData docs: integrate/data-ingestion-streaming/sqlflow.
+# Published at turbolytics.io/docs/sqlflow/tutorials/tigerdata-enrich.
 # A stream of device readings from Kafka, enriched per batch by joining a
 # reference table that lives in the service, landed in a hypertable.
 commands:
@@ -44,7 +44,7 @@ pipeline:
         ON batch.device_id = devices.device_id
 
   # Delivery is at-least-once: a crash between this insert and the offset
-  # commit replays the batch on restart. The unique index on (time,
+  # commit replays the batch on restart. The primary key on (time,
   # device_id) plus ON CONFLICT DO NOTHING makes the replay a no-op.
   sink:
     type: sqlcommand


### PR DESCRIPTION
The TigerData docs submission was withdrawn. The config is now copied by the site tutorial at turbolytics.io/docs/sqlflow/tutorials/tigerdata-enrich, so the header and the README row point there.

Two corrections that the tutorial surfaced:

- The sink comment said unique index, but the DDL the page ships uses a primary key: DuckDB's postgres extension only sees primary keys on an attached table, and refuses ON CONFLICT against a unique index.
- The schema variable defaulted to `public` while the tutorial creates its tables in `telemetry`, so a copy-paste without the variable looked for the wrong tables. The default is now `telemetry`. Re-run end to end on v1.2.0 with the tutorial's exact commands and no schema variable: three rows landed, three after the replay.

Comments, one default, and a README row; no engine change. The tutorial is live against this branch's copy of the file, so merging keeps the repo and the page in step.