### PR TITLE
SECURITY.md: a disclosure policy, before the CRA reporting date

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,124 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately. Do not open a public issue.
+
+Use one of these channels:
+
+1. [GitHub private vulnerability reporting](https://github.com/turbolytics/sql-flow/security/advisories/new)
+   for this repository. Reports stay private until a fix ships, and the
+   advisory publishes from the same place.
+2. Email `danny@turbolytics.io` if you cannot use GitHub.
+
+Include what you can of the following:
+
+- The version, from `sqlflow version`, or the image tag.
+- The pipeline config that reproduces it, with credentials removed.
+- What you expected, what happened, and what an attacker gains.
+
+## What to expect
+
+- Acknowledgement within 3 business days.
+- A severity assessment and a fix plan once we have reproduced the report.
+- Updates as the fix progresses.
+- Coordinated disclosure when the fix ships, or 90 days after the report,
+  whichever comes first. We will ask before extending that window, and we
+  will not extend it without your agreement.
+- Credit in the advisory, unless you ask us not to.
+
+## Supported versions
+
+| Version | Receives security fixes |
+| ------- | ----------------------- |
+| 1.2.x   | Yes                     |
+| < 1.2   | No. Upgrade to 1.2.x.   |
+
+Fixes ship as a patch release on the current minor. We do not maintain
+long-term support branches for older minors.
+
+## How a fix ships
+
+A fix is a new tag in this repository and a matching image on Docker Hub,
+`turbolytics/sql-flow:<tag>`. The advisory names the fixed version.
+
+Build from source at the tag if you run a binary. See the README for the
+build steps.
+
+## DuckDB and other dependencies
+
+sqlflow loads `libduckdb` at runtime through the ADBC driver manager. The
+supported DuckDB version is pinned in the `DUCKDB_VERSION` file.
+
+When DuckDB publishes a vulnerability that affects sqlflow:
+
+- We bump `DUCKDB_VERSION`, verify, and release. The Docker image bakes in
+  the matching `libduckdb`, so pulling the new tag is the whole fix.
+- If you run a binary against your own `libduckdb`, you can install the
+  fixed DuckDB before we release. The advisory names the DuckDB version that
+  is safe.
+
+Report DuckDB vulnerabilities to the [DuckDB project](https://github.com/duckdb/duckdb/security).
+Tell us too, so we can release.
+
+Vulnerabilities in Go module dependencies ship as a sqlflow release.
+
+## What counts as a vulnerability
+
+sqlflow runs the SQL in a pipeline config with DuckDB's full capability, in
+process. It can read local files, attach databases, load extensions, and
+reach the network. That is the product.
+
+**The pipeline config is trusted input.** Anyone who can write it can do
+anything the sqlflow process can do. A report that a config can read a file
+or reach a host is not a vulnerability. Running configs from untrusted
+authors is not a supported deployment.
+
+**Data from sources is untrusted input.** Kafka messages, webhook request
+bodies, and websocket frames come from outside. A message that lets its
+sender do any of the following is a vulnerability:
+
+- Crash or hang the process.
+- Consume memory or disk without bound.
+- Execute SQL, reach a file, or reach a host the config did not name.
+- Read another pipeline's data.
+
+**Config files hold credentials.** Broker passwords, database DSNs, and
+cloud keys live in the config or in `SQLFLOW_`-prefixed environment
+variables. Protect them as you would any secret. A vulnerability that
+exposes them through a log line, an endpoint, or an error message is in
+scope.
+
+Out of scope:
+
+- Anything that requires an attacker who already controls the host or the
+  config.
+- Throughput or latency under load. Backpressure from a slow sink is by
+  design.
+- Vulnerabilities in DuckDB, Kafka, or another dependency, in isolation.
+  Report those upstream. If sqlflow's use of the dependency makes it worse,
+  that is in scope.
+
+## Network surfaces
+
+sqlflow opens no ports by default. Each of these is a flag, and none of them
+authenticates:
+
+| Flag                | Address          | Serves                                          |
+| ------------------- | ---------------- | ----------------------------------------------- |
+| `--metrics`         | `:8000`          | `/metrics`, `/stats`, `/healthz`, `/turbostats` |
+| `--pprof`           | `:6060`          | Go profiling, including heap contents            |
+| `--with-http-debug` | `127.0.0.1:5000` | `GET /debug?sql=...` against the live database   |
+
+`--metrics` and `--pprof` listen on every interface. Put them behind your
+network policy. `--with-http-debug` runs any SQL it is sent, which is why it
+binds loopback only. Do not forward it.
+
+A webhook source listens where its config says. The request body is
+untrusted input, as above.
+
+## Advisories
+
+Published advisories appear under
+[Security Advisories](https://github.com/turbolytics/sql-flow/security/advisories)
+for this repository, with a CVE where one applies.


### PR DESCRIPTION
## What this changes

There was no `SECURITY.md`. A researcher who found a vulnerability had one
channel — a public issue — which publishes the finding before the fix.
Release Engineering v1 names this its first item and says it is an hour of
work; the EU Cyber Resilience Act's reporting obligations begin 11 September
2026, today.

The file states: the channel (GitHub private vulnerability reporting, now
enabled on the repo, with email as the fallback), a 3-business-day
acknowledgement and 90-day coordinated-disclosure commitment, the supported
line (1.2.x, no LTS), how a fix ships (a tag plus a Docker Hub image), the
DuckDB-CVE path (bump `DUCKDB_VERSION`, release; binary users can patch
`libduckdb` ahead of us), and the trust boundary.

**The trust boundary is the decision in this file.** A pipeline config runs
its SQL with DuckDB's full capability in process, so the config is trusted
input and "a config can read a file" is not a report. Data from a source —
Kafka messages, webhook bodies, websocket frames — is untrusted, so a message
that crashes the process, grows memory without bound, or reaches a file the
config did not name *is* one. Without that line every report is an argument.

**What breaks if this is wrong:** a vulnerability lands in a public issue, or
a reporter reads "3 business days" and nobody answers.

## Verification

Documentation only. No Go, Python, config, or artifact changed, so:

- [ ] `go test -short -race ./...` — not applicable, no code change
- [ ] `uv run --locked pytest tests/tooling -q` — not applicable
- [ ] `make coverage-page && git status --short docs/coverage` — not applicable, no feature or test change
- [ ] `uv run --locked pytest tests/release -q` — not applicable
- [ ] `make soak` — not applicable

The claims in the file were checked against the code rather than the README:

- `--metrics` binds `:8000` (`internal/cli/run/metrics.go:23`), `--pprof` binds
  `:6060` (`root.go:122`), `--with-http-debug` binds `127.0.0.1:5000`
  (`debug.go:15`) and is off by default (`root.go:494`). None authenticates.
- DuckDB pin is `v1.5.2` in `DUCKDB_VERSION`; the binary `dlopen`s it.
- There are no 1.x GitHub Releases (`gh release view v1.2.0` → not found; the
  Releases page shows `v0.6.0` as Latest) and no release workflow, so the file
  points at tags and `turbolytics/sql-flow:<tag>` rather than at Releases.
- GitHub private vulnerability reporting was disabled; it is enabled as of
  this PR so the link in the file resolves.

## Notes for the reviewer

**Left out on purpose:**

- Any CRA category claim. The milestone says that is a lawyer's question. The
  file does the steward obligations without naming the category.
- A safe-harbor clause for good-faith research. Common, and a legal
  commitment — belongs with whoever signs off on those.
- A retroactive advisory for the retry defect in 1.0.4 (#228). The milestone
  raises the question; this PR does not answer it.

**Adjacent, not fixed here:** the README's "Release binaries are published for
linux and macOS" has nowhere to point. That is Release Engineering scope
items 2 and 10.

**Contact address** is `danny@turbolytics.io` per the author. A role address
(`security@`) survives a staffing change and is what vendor questionnaires
expect; easy to swap later.

Part of Release Engineering v1 (milestone 16), scope item 1.
